### PR TITLE
Fix price variable type

### DIFF
--- a/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -168,25 +168,15 @@ public class MiscListener implements Listener {
 
                 if (plugin.useVault()) {
                     try {
-                        int multiplyValue = UtilMethods.getMultiplyValue(event.getLine(2));
+                        double multiplyValue = UtilMethods.getMultiplyValue(event.getLine(2));
                         String line3 = UtilMethods.cleanNumberText(event.getLine(2));
 
                         String[] multiplePrices = line3.split(" ");
                         if (multiplePrices.length > 1) {
-                            if (multiplePrices[0].contains("."))
-                                price = Double.parseDouble(multiplePrices[0]);
-                            else
-                                price = Integer.parseInt(multiplePrices[0]);
-
-                            if (multiplePrices[1].contains("."))
-                                priceCombo = Double.parseDouble(multiplePrices[1]);
-                            else
-                                priceCombo = Integer.parseInt(multiplePrices[1]);
+                            price = Double.parseDouble(multiplePrices[0]);
+                            priceCombo = Double.parseDouble(multiplePrices[1]);
                         } else {
-                            if (line3.contains("."))
-                                price = Double.parseDouble(line3);
-                            else
-                                price = Integer.parseInt(line3);
+                            price = Double.parseDouble(line3);
                         }
 
                         price *= multiplyValue;

--- a/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -309,8 +309,8 @@ public class UtilMethods {
 
     //this takes a dirty (pre-cleaned) string and finds how much to multiply the final by
     //this utility allows the input of numbers like 1.2k (1200)
-    public static int getMultiplyValue(String text){
-        int multiplyBy = 1;
+    public static double getMultiplyValue(String text){
+        double multiplyBy = 1;
         for(int i=0; i<text.length(); i++) {
             switch (text.charAt(i)) {
                 case 'k':


### PR DESCRIPTION
This pull request fixes two bugs I've encountered.

The first one is that using prefixes G or above on shop price signs (e.g. 1T) do not always work as intended due to the multiply value in UtilMethods being stored and returned as an int.  The result of the method gets multiplied into a double so there are no negative consequences for changing the return type.

The second bug is that if you put a big number (like 10^12) in the price line on a shop, the plugin will politely ask you to put a real number there.  This has been fixed by always parsing the price as a double, instead of being parsed as an int if it doesn't contain a dot.  This change shouldn't have any negative effects either because the price is always stored in a double anyway.

I've tested these fixes and they both work.

Thanks!