### PR TITLE
Fix economy implementation, display config, and display viewing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.snowgears.shop</groupId>
     <artifactId>Shop</artifactId>
-    <version>1.8.2.4</version>
+    <version>1.8.2.5</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.4-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/snowgears/shop/Shop.java
+++ b/src/main/java/com/snowgears/shop/Shop.java
@@ -270,8 +270,6 @@ public class Shop extends JavaPlugin {
             if (!setupEconomy()) {
                 log.severe("[Shop] Vault implementation not detected at startup! Currency may not work properly!");
                 log.info("[Shop] If you do not wish to use Vault with Shop, make sure to set 'useVault' in the config file to false.");
-                // getServer().getPluginManager().disablePlugin(plugin);
-                return;
             } else {
                 log.info("[Shop] Vault dependency found. Using the Vault economy (" + vaultCurrencySymbol + ") for currency on the server.");
             }
@@ -532,6 +530,11 @@ public class Shop extends JavaPlugin {
     }
 
     public Economy getEconomy() {
+
+        if (econ == null) {
+            setupEconomy();
+        }
+
         return econ;
     }
 

--- a/src/main/java/com/snowgears/shop/Shop.java
+++ b/src/main/java/com/snowgears/shop/Shop.java
@@ -268,9 +268,9 @@ public class Shop extends JavaPlugin {
 
         if (useVault) {
             if (!setupEconomy()) {
-                log.severe("[Shop] PLUGIN DISABLED DUE TO NO VAULT DEPENDENCY FOUND ON SERVER!");
+                log.severe("[Shop] Vault implementation not detected at startup! Currency may not work properly!");
                 log.info("[Shop] If you do not wish to use Vault with Shop, make sure to set 'useVault' in the config file to false.");
-                getServer().getPluginManager().disablePlugin(plugin);
+                // getServer().getPluginManager().disablePlugin(plugin);
                 return;
             } else {
                 log.info("[Shop] Vault dependency found. Using the Vault economy (" + vaultCurrencySymbol + ") for currency on the server.");

--- a/src/main/java/com/snowgears/shop/Shop.java
+++ b/src/main/java/com/snowgears/shop/Shop.java
@@ -155,6 +155,11 @@ public class Shop extends JavaPlugin {
 
         try {
             displayNameTagsLifespan = config.getInt("displayNameTagsLifespan");
+            // Catch missing or negative config entry and default to 10
+            if (displayNameTagsLifespan <= 0) {
+                displayNameTagsLifespan = 10;
+            }
+        // This exception will only occur if text is entered in the config
         } catch (Exception e){ displayNameTagsLifespan = 10; }
 
         try {

--- a/src/main/java/com/snowgears/shop/display/Display.java
+++ b/src/main/java/com/snowgears/shop/display/Display.java
@@ -247,30 +247,35 @@ public class Display {
             new BukkitRunnable() {
                 @Override
                 public void run() {
-                    Iterator<Entity> entityIterator = entities.iterator();
-                    while (entityIterator.hasNext()) {
-                        Entity entity = entityIterator.next();
-                        if (entity != null && entity.getType() == EntityType.ARMOR_STAND) {
-                            PersistentDataContainer persistentData = entity.getPersistentDataContainer();
-                            if (persistentData != null) {
-                                try {
-                                    int dataDisplay = persistentData.get(new NamespacedKey(Shop.getPlugin(), "display_nametag"), PersistentDataType.INTEGER);
-                                    if (dataDisplay == 1) {
-                                        entityIterator.remove();
-                                        entity.remove();
-                                    }
-                                } catch (NullPointerException e) {
-                                }
-                            }
-                        }
-                    }
-                    nameTagsVisible = false;
+                    removeTagEntities();
                 }
             }.runTaskLater(Shop.getPlugin(), (Shop.getPlugin().getDisplayTagLifespan() * 20));
         } catch (NullPointerException e){
             e.printStackTrace();
         }
     }
+
+    public void removeTagEntities() {
+        Iterator<Entity> entityIterator = entities.iterator();
+        while (entityIterator.hasNext()) {
+            Entity entity = entityIterator.next();
+            if (entity != null && entity.getType() == EntityType.ARMOR_STAND) {
+                PersistentDataContainer persistentData = entity.getPersistentDataContainer();
+                if (persistentData != null) {
+                    try {
+                        int dataDisplay = persistentData.get(new NamespacedKey(Shop.getPlugin(), "display_nametag"), PersistentDataType.INTEGER);
+                        if (dataDisplay == 1) {
+                            entityIterator.remove();
+                            entity.remove();
+                        }
+                    } catch (NullPointerException e) {
+                    }
+                }
+            }
+        }
+        nameTagsVisible = false;
+    }
+
 
     private void createTagEntity(String text, Location location){
         ArmorStand as = (ArmorStand) location.getWorld().spawnEntity(location, EntityType.ARMOR_STAND); //Spawn the ArmorStand

--- a/src/main/java/com/snowgears/shop/util/InventoryUtils.java
+++ b/src/main/java/com/snowgears/shop/util/InventoryUtils.java
@@ -149,6 +149,13 @@ public class InventoryUtils {
                 return itemStack1.isSimilar(itemStack2);
             }
         }
+        //fix NBT attributes for cached older items to be compatible with Spigot serializer updates
+        if (i1Meta != null && i2Meta != null && i1Meta.hasAttributeModifiers() && i2Meta.hasAttributeModifiers()) {
+            i1Meta.setAttributeModifiers(i1Meta.getAttributeModifiers());
+            i2Meta.setAttributeModifiers(i2Meta.getAttributeModifiers());
+            i1.setItemMeta(i1Meta);
+            i2.setItemMeta(i2Meta);
+        }
 
         return i1.isSimilar(i2);
     }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: Shop
 author: Tanner Embry (SnowGears)
 description: Easily create shops to buy or sell items!
-version: 1.8.2.4
+version: 1.8.2.5
 api-version: 1.16
 main: com.snowgears.shop.Shop
 softdepend: [Vault, WorldGuard]


### PR DESCRIPTION
This pull request achieves three bugfixes:

- The plugin will no longer fail to load if an economy provider is not present at startup; economy providers will load successfully after startup.
- The plugin will no longer fail to implement a default value of 10 seconds for a missing display duration config entry; the 10 seconds are now implemented properly if the entry is missing, zero, or below zero.
- Displays that are no longer being viewed by a player will be removed on the 15-tick scheduler rather than at the end of their durations, so that players will not create unreadable overlap by viewing multiple shops immediately next to each other.

Each of these fixes have been tested.