### PR TITLE
v1.10.1

### DIFF
--- a/.cursor/rules/clean-code.mdc
+++ b/.cursor/rules/clean-code.mdc
@@ -1,0 +1,55 @@
+---
+description: Guidelines for writing clean, maintainable, and human-readable code. Apply these rules when writing or reviewing code to ensure consistency and quality.
+globs: 
+---
+# Clean Code Guidelines
+
+## Constants Over Magic Numbers
+- Replace hard-coded values with named constants
+- Use descriptive constant names that explain the value's purpose
+- Keep constants at the top of the file or in a dedicated constants file
+
+## Meaningful Names
+- Variables, functions, and classes should reveal their purpose
+- Names should explain why something exists and how it's used
+- Avoid abbreviations unless they're universally understood
+
+## Smart Comments
+- Don't comment on what the code does - make the code self-documenting
+- Use comments to explain why something is done a certain way
+- Document APIs, complex algorithms, and non-obvious side effects
+
+## Single Responsibility
+- Each function should do exactly one thing
+- Functions should be small and focused
+- If a function needs a comment to explain what it does, it should be split
+
+## DRY (Don't Repeat Yourself)
+- Extract repeated code into reusable functions
+- Share common logic through proper abstraction
+- Maintain single sources of truth
+
+## Clean Structure
+- Keep related code together
+- Organize code in a logical hierarchy
+- Use consistent file and folder naming conventions
+
+## Encapsulation
+- Hide implementation details
+- Expose clear interfaces
+- Move nested conditionals into well-named functions
+
+## Code Quality Maintenance
+- Refactor continuously
+- Fix technical debt early
+- Leave code cleaner than you found it
+
+## Testing
+- Write tests before fixing bugs
+- Keep tests readable and maintainable
+- Test edge cases and error conditions
+
+## Version Control
+- Write clear commit messages
+- Make small, focused commits
+- Use meaningful branch names 

--- a/.cursor/rules/codequality.mdc
+++ b/.cursor/rules/codequality.mdc
@@ -1,0 +1,47 @@
+---
+description: Code Quality Guidelines
+globs: 
+---
+# Code Quality Guidelines
+
+## Verify Information
+Always verify information before presenting it. Do not make assumptions or speculate without clear evidence.
+
+## File-by-File Changes
+Make changes file by file and give me a chance to spot mistakes.
+
+## No Apologies
+Never use apologies.
+
+## No Understanding Feedback
+Avoid giving feedback about understanding in comments or documentation.
+
+## No Whitespace Suggestions
+Don't suggest whitespace changes.
+
+## No Summaries
+Don't summarize changes made.
+
+## No Inventions
+Don't invent changes other than what's explicitly requested.
+
+## No Unnecessary Confirmations
+Don't ask for confirmation of information already provided in the context.
+
+## Preserve Existing Code
+Don't remove unrelated code or functionalities. Pay attention to preserving existing structures.
+
+## Single Chunk Edits
+Provide all edits in a single chunk instead of multiple-step instructions or explanations for the same file.
+
+## No Implementation Checks
+Don't ask the user to verify implementations that are visible in the provided context.
+
+## No Unnecessary Updates
+Don't suggest updates or changes to files when there are no actual modifications needed.
+
+## Provide Real File Links
+Always provide links to the real files, not x.md.
+
+## No Current Implementation
+Don't show or discuss the current implementation unless specifically requested.

--- a/.cursor/rules/java.mdc
+++ b/.cursor/rules/java.mdc
@@ -1,0 +1,188 @@
+---
+description: Java Development Guidelines
+globs: *.java
+---
+# AI Developer Profile
+ai_persona:
+  role: Senior Java Developer
+  principles:
+    - SOLID
+    - DRY
+    - KISS
+    - YAGNI
+    - OWASP
+    - DOP
+    - FP
+    - DDD
+
+# Technical Stack
+tech_stack:
+  framework: bukkit/spigot
+  build_tool: Maven
+  java_version: 23
+  dependencies:
+    - Eclipse Collections
+    - Commons Lang3
+    - Guava
+    - VAVR
+    - Junit5
+    - JQwik
+    - JMH
+  language: English
+  code_comments: English
+
+# Development Guidelines
+effective_java_notes:
+  chapter_2:
+    title: "Creating and Destroying Objects"
+    items:
+      - "Consider static factory methods instead of constructors"
+      - "Consider a builder when faced with many constructor parameters"
+      - "Enforce the singleton property with a private constructor or an enum type"
+      - "Enforce noninstantiability with a private constructor"
+      - "Prefer dependency injection to hardwiring resources"
+      - "Avoid creating unnecessary objects"
+      - "Eliminate obsolete object references"
+      - "Avoid finalizers and cleaners"
+      - "Prefer try-with-resources to try-finally"
+
+  chapter_3:
+    title: "Methods Common to All Objects"
+    items:
+      - "Obey the general contract when overriding equals"
+      - "Always override hashCode when you override equals"
+      - "Always override toString"
+      - "Override clone judiciously"
+      - "Consider implementing Comparable"
+
+  chapter_4:
+    title: "Classes and Interfaces"
+    items:
+      - "Minimize the accessibility of classes and members"
+      - "In public classes, use accessor methods, not public fields"
+      - "Minimize mutability"
+      - "Favor composition over inheritance"
+      - "Design and document for inheritance or else prohibit it"
+      - "Prefer interfaces to abstract classes"
+      - "Design interfaces for posterity"
+      - "Use interfaces only to define types"
+      - "Prefer class hierarchies to tagged classes"
+      - "Favor static member classes over nonstatic"
+      - "Limit source files to a single top-level class"
+
+  chapter_5:
+    title: "Generics"
+    items:
+      - "Don't use raw types"
+      - "Eliminate unchecked warnings"
+      - "Prefer lists to arrays"
+      - "Favor generic types"
+      - "Favor generic methods"
+      - "Use bounded wildcards to increase API flexibility"
+      - "Combine generics and varargs judiciously"
+      - "Consider typesafe heterogeneous containers"
+
+  chapter_6:
+    title: "Enums and Annotations"
+    items:
+      - "Use enums instead of int constants"
+      - "Use instance fields instead of ordinals"
+      - "Use EnumSet instead of bit fields"
+      - "Use EnumMap instead of ordinal indexing"
+      - "Emulate extensible enums with interfaces"
+      - "Prefer annotations to naming patterns"
+      - "Consistently use the Override annotation"
+      - "Use marker interfaces to define types"
+
+  chapter_7:
+    title: "Lambdas and Streams"
+    items:
+      - "Prefer lambdas to anonymous classes"
+      - "Prefer method references to lambdas"
+      - "Favor the use of standard functional interfaces"
+      - "Use streams judiciously"
+      - "Prefer side-effect-free functions in streams"
+      - "Prefer Collection to Stream as a return type"
+      - "Use caution when making streams parallel"
+
+  chapter_8:
+    title: "Methods"
+    items:
+      - "Check parameters for validity"
+      - "Make defensive copies when needed"
+      - "Design method signatures carefully"
+      - "Use overloading judiciously"
+      - "Use varargs judiciously"
+      - "Return empty collections or arrays, not nulls"
+      - "Return optionals judiciously"
+      - "Write doc comments for all exposed API elements"
+
+  chapter_9:
+    title: "General Programming"
+    items:
+      - "Minimize the scope of local variables"
+      - "Prefer for-each loops to traditional for loops"
+      - "Know and use the libraries"
+      - "Avoid float and double if exact answers are required"
+      - "Prefer primitive types to boxed primitives"
+      - "Avoid strings where other types are more appropriate"
+      - "Beware the performance of string concatenation"
+      - "Refer to objects by their interfaces"
+      - "Prefer interfaces to reflection"
+      - "Use native methods judiciously"
+      - "Optimize judiciously"
+      - "Adhere to generally accepted naming conventions"
+
+  chapter_10:
+    title: "Exceptions"
+    items:
+      - "Use exceptions only for exceptional conditions"
+      - "Use checked exceptions for recoverable conditions and runtime exceptions for programming errors"
+      - "Avoid unnecessary use of checked exceptions"
+      - "Favor the use of standard exceptions"
+      - "Throw exceptions appropriate to the abstraction"
+      - "Document all exceptions thrown by each method"
+      - "Include failure-capture information in detail messages"
+      - "Strive for failure atomicity"
+      - "Don't ignore exceptions"
+
+  chapter_11:
+    title: "Concurrency"
+    items:
+      - "Synchronize access to shared mutable data"
+      - "Avoid excessive synchronization"
+      - "Prefer executors, tasks, and streams to threads"
+      - "Prefer concurrency utilities to wait and notify"
+      - "Document thread safety"
+      - "Use lazy initialization judiciously"
+      - "Don't depend on the thread scheduler"
+
+  chapter_12:
+    title: "Serialization"
+    items:
+      - "Prefer alternatives to Java serialization"
+      - "Implement Serializable with great caution"
+      - "Consider using a custom serialized form"
+      - "Write readObject methods defensively"
+      - "For instance control, prefer enum types to readResolve"
+      - "Consider serialization proxies instead of serialized instances"
+
+# Best Practices
+concurrency_guidelines:
+  - "Try to not maintain state in the class"
+
+functional_programming_guidelines:
+  - "Try to use immutable objects"
+  - "Try to not mutate the state of the objects"
+
+data_oriented_programming_pillars:
+  - "Separate code from data"
+  - "Represent data with generic data structures"
+  - "Data should be immutable"
+  - "Use pure functions to manipulate data"
+  - "Keep data flat and denormalized"
+  - "Keep data generic until it needs to be specific"
+  - "Data integrity is maintained through validation functions"
+  - "Data access should be flexible and generic"
+  - "Data transformation should be explicit and traceable"
+  - "Data flow should be unidirectional"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,6 @@ jobs:
       with:
         name: shop-plugin
         path: target/Shop-*.jar
-        exclude: target/original-Shop-*.jar
         
     - name: Find JAR filename
       id: find-jar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing to Shop
+
+Thank you for your interest in contributing to Shop, the intuitive shop plugin for Minecraft! This guide will help you set up your development environment and understand our contribution process.
+
+## Getting Started
+
+### Prerequisites
+
+Before you begin, ensure you have the following requirements installed:
+
+- **Docker**: Install Docker from the [official website](https://www.docker.com/get-started)
+- **JDK 21**: Ensure you have JDK 21 installed. You can download it from the [Oracle website](https://www.oracle.com/java/technologies/downloads/#java21)
+- **Maven**: Verify Maven is installed. You can download it from the [Maven website](https://maven.apache.org/download.cgi)
+
+### Setting Up Your Development Environment
+
+1. **Fork the repository** on GitHub.
+2. **Clone your fork** to your local machine:
+   ```
+   git clone https://github.com/snowgears/Shop.git
+   cd Shop
+   ```
+
+## Building the Project
+
+### Building the Local Maven Repository
+
+Before compiling the plugin, you need to set up the local Maven repository with the supported versions of Spigot:
+
+1. Navigate to the root directory of the repository.
+2. Run the script to build the local Maven repository:
+   ```shell
+   # Pull the latest image from Docker Hub and extract the Maven repo from it
+   ./buildMavenRepo.sh
+   
+   # Alternatively, you can build the image locally on your machine, it just might take an hour or two
+   # Useful if you add a new version to the Dockerfile
+   ./buildMavenRepo.sh local
+   ```
+
+This script will compile all supported versions of Spigot and copy the Maven repository into the Shop folder for later use.
+
+### Compiling the Plugin
+
+After setting up the local Maven repository, you can compile the Shop plugin:
+
+1. Navigate to the root directory of the repository.
+2. Run the script to compile the plugin:
+   ```shell
+   ./compile.sh
+   ```
+
+The compiled plugin will be stored in the `target` directory with the filename `shop-{version}.jar`.
+
+If you need to update the version:
+1. Update the version in `/pom.xml`
+2. Run `./compile.sh`
+3. The plugin will be built to `/target/shop-{version}.jar`
+
+## Versioning Guidelines
+
+This project follows [semantic versioning](https://semver.org/) with the format: `breaking.feature.bugfix`
+
+- `breaking`: Changes that are not backwards compatible, or complete overhaul of plugin
+- `feature`: Addition of new/reworked features, or significantly refactored code
+- `bugfix`: Bug was fixed
+
+Examples:
+- `v1.x.x` → `v2.x.x`: Backwards incompatible changes
+- `v1.1.x` → `v1.2.x`: New Minecraft update or backwards compatible feature added
+- `v1.1.0` → `v1.1.1`: Bug was fixed
+
+## Contribution Process
+
+1. **Create a new branch** for your feature or bugfix:
+   ```
+   git checkout -b feature/your-feature-name
+   ```
+   or
+   ```
+   git checkout -b fix/your-bugfix-name
+   ```
+
+2. **Make your changes**, following the code style of the project.
+
+3. **Test your changes** thoroughly.
+
+4. **Commit your changes** with a clear and descriptive commit message:
+   ```
+   git commit -m "Add feature: your feature description"
+   ```
+   or
+   ```
+   git commit -m "Fix: your bugfix description"
+   ```
+
+5. **Push your branch** to your fork:
+   ```
+   git push origin feature/your-feature-name
+   ```
+
+6. **Create a pull request** against the main repository's master branch.
+
+## Pull Request Guidelines
+
+- Provide a clear description of what your changes accomplish
+- Reference any related issues in your pull request description
+- Ensure all tests pass
+- Update documentation if necessary
+
+Thank you for contributing to Shop! 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build and Package](https://github.com/snowgears/Shop/actions/workflows/build.yml/badge.svg)](https://github.com/snowgears/Shop/actions/workflows/build.yml)
+![GitHub Release](https://img.shields.io/github/v/release/snowgears/Shop) [![Build and Package](https://github.com/snowgears/Shop/actions/workflows/build.yml/badge.svg)](https://github.com/snowgears/Shop/actions/workflows/build.yml) ![bStats Servers](https://img.shields.io/bstats/servers/25211) ![bStats Players](https://img.shields.io/bstats/players/25211) 
+
 [![520ef725efdc8caad836d0370a17d58ce8ee99b2](https://github.com/user-attachments/assets/075aaff3-2328-4672-89af-32bc86ec3fcd)](https://www.spigotmc.org/resources/shop-the-intuitive-shop-plugin.9628/)
 
 ## Description
@@ -8,10 +9,36 @@ By focusing on ease of use, players of any skill level can create in-game shops 
 
 [![Server Metrics](https://bstats.org/signatures/bukkit/shop-the-intuitive-shop-plugin.svg)](https://bstats.org/plugin/bukkit/shop-the-intuitive-shop-plugin/25211)
 
-## Build Locally
-* Update version in `/pom.xml`
-* `./compile.sh`
-* Plugin is built to `/target/shop-{version}.jar`
+## Features
+- **Versatile Shop Types:** Create shops to sell, buy, barter, or gamble items
+- **Multiple Currency Options:** Change currency to a custom item, virtual currency (Vault), or experience points
+- **Multiple Shop Creation Methods:** Fill out a sign or hit a chest with an item
+- **No Commands Required:** Create shops without needing complex commands
+- **Item Support:** Easily handles items with custom display names, descriptions, and enchantments
+- **Admin Shops:** Create shops that don't need to be stocked
+- **Display Options:** Change between different types of displays (item floating, glass case, large item, item frame)
+- **Holographic Displays:** Optional and fully configurable displays above shops
+- **Find Shops:** Easily find shops selling specific items and teleport to them (optional)
+- **Integration Support:** Works with WorldGuard, Towny, AdvancedRegionMarket, DynMap, BlueMap, and more
+- **Container Support:** Works with chests, double chests, barrels, shulker boxes, even ender chests
+
+## Shop Types
+- **Sell Shops:** Sell items to other players
+- **Buy Shops:** Buy items from other players
+- **Barter Shops:** Trade items with other players
+- **Combo Shops:** Combined buy and sell functionality in one shop
+- **Gamble Shops:** Let players gamble for random items
+
+## Usage
+Simply place a sign on a container (chest, barrel, etc.) and format it according to the shop type you want to create. Right-click the sign with the item you want to trade, and the shop will be created.
+
+Players can then interact with the shop by right-clicking the sign.
+
+## Developer Resources
+Check out the [Developer Documentation](https://www.spigotmc.org/wiki/shop-developer-wiki/) for API usage and integration information.
+
+## Contributing
+Interested in contributing to Shop? Check out our [CONTRIBUTING.md](CONTRIBUTING.md) guide for instructions on building the project locally and contributing to the codebase.
 
 ## Versioning
 This project follows [semantic versioning](https://semver.org/)
@@ -26,41 +53,7 @@ Examples:
 - `v1.1.x` -> `v1.2.x`: New Minecraft update or backwards compatible feature added to Shop
 - `v1.1.0` -> `v1.1.1`: Bug was fixed
 
-## Compiling Prerequisites
-Before you begin, ensure you have met the following requirements:
+## Support
+Join our [Discord server](https://discord.gg/GpSwEWS) for support, discussions, and updates.
 
-- Docker: Install Docker from the official website.
-- JDK 21: Ensure you have JDK 21 installed. You can download it from the Oracle website.
-- Maven: Verify Maven is installed. You can download it from the Maven website.
-
-### Building the Local Maven Repository
-Before compiling the plugin, you need to set up the local Maven repository with the supported versions of Spigot.
-
-- Open a terminal.
-- Navigate to the root directory of the repository.
-- Run the script to build the local Maven repository:
-```shell
-# Pull the latest image from Docker Hub and extract the Maven repo from it
-./buildMavenRepo.sh
-# Alternatively, you can build the image locally on your machine, it just might take an hour or two
-# useful if you add a new version to the Dockerfile
-./buildMavenRepo.sh local
-```
-
-This script will compile all supported versions of Spigot and copy the Maven repository into the Shop folder for later use.
-
-## Compiling the Plugin
-After setting up the local Maven repository, you can compile the Shop plugin.
-
-- Open a terminal.
-- Navigate to the root directory of the repository.
-- Run the script to compile the plugin:
-```shell
-./compile.sh
-```
-
-The compiled plugin will be stored in the target directory with the filename Shop-version.jar.
-
-## Usage
-After compiling, you can find the plugin jar file in the target directory. Copy this jar file into the plugins folder of your Spigot server to use the Shop plugin.
-
+For bug reports and feature requests, please use our [GitHub Issues](https://github.com/snowgears/shopbugs/issues) tracker.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -193,6 +193,13 @@
             <version>24.0.1</version>
             <scope>provided</scope>
         </dependency>
+        <!-- FoliaLib dependency -->
+        <dependency>
+            <groupId>com.github.technicallycoded</groupId>
+            <artifactId>FoliaLib</artifactId>
+            <version>0.4.4</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <!--  this shade plugin is to shade in hikari so that database connections can be used -->
@@ -208,7 +215,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.4.1</version>
                 <configuration>
                 </configuration>
                 <executions>
@@ -230,6 +237,11 @@
                                 <relocation>
                                     <pattern>de.tr7zw.changeme.nbtapi</pattern>
                                     <shadedPattern>com.snowgears.shop.artifact.nbtapi</shadedPattern>
+                                </relocation>
+                                <!-- FoliaLib relocation -->
+                                <relocation>
+                                    <pattern>com.tcoded.folialib</pattern>
+                                    <shadedPattern>com.snowgears.shop.artifact.folialib</shadedPattern>
                                 </relocation>
                             </relocations>
                         </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.2.220</version>
+            <version>2.1.214</version> <!-- Updating to 2.2.220 broke things, leave it here for now -->
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,7 +55,23 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
     </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.intellectualsites.bom</groupId> <!-- PlotSquared -->
+                <artifactId>bom-newest</artifactId>
+                <version>1.52</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -158,6 +174,11 @@
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
             <version>2.14.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.intellectualsites.plotsquared</groupId>
+            <artifactId>plotsquared-core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.spigotmc</groupId>

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -158,17 +158,17 @@ public class Shop extends JavaPlugin {
         // Check if WorldGuard exists
         // Note: If WorldGuard exists we will check to verify a user can build in the region
         if (getServer().getPluginManager().getPlugin("WorldGuard") != null) {
-            this.getLogger().debug("WorldGuard detected, Shop will respect `passthrough`, `build`, and `chest-access` region flags during shop creation!");
+            this.getLogger().notice("WorldGuard detected, Shop will respect `passthrough`, `build`, and `chest-access` region flags during shop creation!");
             // Store for later
             this.worldGuardExists = true;
             // Check if we want to require `allow-shop: true` to exist on regions
             if(hookWorldGuard){
-                this.getLogger().debug("Registering WorldGuard `allow-shop` flag...");
+                this.getLogger().notice("Registering WorldGuard `allow-shop` flag...");
                 // Register flag for WorldGuard if we are hooking into the flag system
                 WorldGuardHook.registerAllowShopFlag();
-                this.getLogger().debug("WorldGuard `allow-shop` flag restriction enabled, Shops can only be created in regions with the `allow-shop` flag set!");
+                this.getLogger().notice("WorldGuard `allow-shop` flag restriction enabled, Shops can only be created in regions with the `allow-shop` flag set!");
             } else {
-                this.getLogger().debug("WorldGuard `allow-shop` flag restriction is disabled, if you want to only allow shops in regions with the `allow-shop` flag, please set `hookWorldGuard` to `true` in `config.yml`");
+                this.getLogger().notice("WorldGuard `allow-shop` flag restriction is disabled, if you want to only allow shops in regions with the `allow-shop` flag, please set `hookWorldGuard` to `true` in `config.yml`");
             }
         } else {
             this.worldGuardExists = false;

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -125,6 +125,8 @@ public class Shop extends JavaPlugin {
     private double displayMovementThreshold;
     private double maxShopDisplayDistance;
     private int shopSearchRadius;
+    private int displayBatchSize;
+    private int displayBatchDelay;
 
     private YamlConfiguration config;
 
@@ -491,6 +493,8 @@ public class Shop extends JavaPlugin {
         displayMovementThreshold = config.getDouble("displayMovementThreshold");
         maxShopDisplayDistance = config.getDouble("maxShopDisplayDistance");
         shopSearchRadius = config.getInt("shopSearchRadius");
+        displayBatchSize = config.getInt("displayBatchSize", 10);
+        displayBatchDelay = config.getInt("displayBatchDelay", 2);
 
         // Check if we should load VAULT economy
         if (currencyType == CurrencyType.VAULT) {
@@ -767,6 +771,8 @@ public class Shop extends JavaPlugin {
         metrics.addCustomChart(new SimplePie("display_movement_threshold", () -> String.valueOf(displayMovementThreshold)));
         metrics.addCustomChart(new SimplePie("display_max_shop_distance", () -> String.valueOf(maxShopDisplayDistance)));
         metrics.addCustomChart(new SimplePie("display_shop_search_radius", () -> String.valueOf(shopSearchRadius)));
+        metrics.addCustomChart(new SimplePie("display_batch_size", () -> String.valueOf(displayBatchSize)));
+        metrics.addCustomChart(new SimplePie("display_batch_delay", () -> String.valueOf(displayBatchDelay)));
 
         debug_allowUseOwnShop = config.getBoolean("debug.allowUseOwnShop");
         debug_transactionDebugLogs = config.getBoolean("debug.transactionDebugLogs");
@@ -1202,5 +1208,25 @@ public class Shop extends JavaPlugin {
      */
     public int getShopSearchRadius() {
         return shopSearchRadius;
+    }
+
+    /**
+     * Gets the number of shop displays to process in a single batch when sending to a player.
+     * This controls how many displays are sent at once to create a smoother appearance.
+     * 
+     * @return The batch size for shop display processing
+     */
+    public int getDisplayBatchSize() {
+        return displayBatchSize;
+    }
+
+    /**
+     * Gets the delay between batches of shop displays in server ticks (20 ticks = 1 second).
+     * Higher values create a smoother appearance but take longer to show all displays.
+     * 
+     * @return The delay in ticks between display batches
+     */
+    public int getDisplayBatchDelay() {
+        return displayBatchDelay;
     }
 }

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -56,6 +56,7 @@ public class Shop extends JavaPlugin {
     private boolean dynmapEnabled;
     private BentoBoxHookListener bentoBoxHookListener;
     private ARMHookListener armHookListener;
+    private PlotSquaredHookListener plotSquaredHookListener;
 
     private ShopHandler shopHandler;
     private CommandHandler commandHandler;
@@ -556,6 +557,12 @@ public class Shop extends JavaPlugin {
             armHookListener = new ARMHookListener(this);
             getServer().getPluginManager().registerEvents(armHookListener, this);
             this.getLogger().notice("AdvancedRegionMarket is installed, creating AdvancedRegionMarket listener");
+        }
+
+        if(getServer().getPluginManager().getPlugin("PlotSquared") != null){
+            plotSquaredHookListener = new PlotSquaredHookListener(this);
+            getServer().getPluginManager().registerEvents(plotSquaredHookListener, this);
+            this.getLogger().notice("PlotSquared is installed, creating PlotSquared listener");
         }
 
         int bstatsPluginId = 25211;

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -495,11 +495,13 @@ public class Shop extends JavaPlugin {
                 this.getLogger().severe("Unable to connect to Vault! Is the plugin installed?");
                 this.getLogger().severe("Plugin Disabled: Invalid configuration value `economy.type` config.yml. If you do not wish to use Vault with Shop, make sure to set `economy.type` in the config file to `ITEM`.");
                 getServer().getPluginManager().disablePlugin(plugin);
+                return;
             }
         } else {
             if (itemCurrency == null) {
                 this.getLogger().severe("Plugin Disabled: Invalid value for `itemCurrencyID` in `config.yml`");
                 getServer().getPluginManager().disablePlugin(plugin);
+                return;
             }
             this.getLogger().info("Shops will use " + itemNameUtil.getName(itemCurrency).toPlainText() + "(s) as the currency on the server.");
         }
@@ -778,7 +780,7 @@ public class Shop extends JavaPlugin {
         }
         
         //save any remaining shops (usually not required but just in case)
-        shopHandler.saveAllShops();
+        if (shopHandler != null) shopHandler.saveAllShops();
 
         this.getLogger().info("Disabled Shop " + this.getDescription().getVersion());
     }

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -492,7 +492,7 @@ public class Shop extends JavaPlugin {
             if (setupEconomy()) {
                 this.getLogger().info("Shops will use the Vault economy (" + currencyName + ") as currency on the server.");
             } else {
-                this.getLogger().severe("Unable to connect to Vault! Is the plugin installed?");
+                this.getLogger().severe("Unable to connect to Vault Economy! Are both Vault AND an Economy plugin installed?");
                 this.getLogger().severe("Plugin Disabled: Invalid configuration value `economy.type` config.yml. If you do not wish to use Vault with Shop, make sure to set `economy.type` in the config file to `ITEM`.");
                 getServer().getPluginManager().disablePlugin(plugin);
                 return;

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -118,6 +118,12 @@ public class Shop extends JavaPlugin {
     private NamespacedKey signLocationNameSpacedKey;
     private NamespacedKey playerUUIDNameSpacedKey;
     private LogHandler logHandler;
+    
+    // Shop display optimization settings
+    private double displayProcessInterval;
+    private double displayMovementThreshold;
+    private double maxShopDisplayDistance;
+    private int shopSearchRadius;
 
     private YamlConfiguration config;
 
@@ -458,6 +464,12 @@ public class Shop extends JavaPlugin {
         clickTypeActionMap.put(ShopClickType.valueOf(config.getString("actionMappings.transactWithShopFullStack")), ShopAction.TRANSACT_FULLSTACK);
         clickTypeActionMap.put(ShopClickType.valueOf(config.getString("actionMappings.viewShopDetails")), ShopAction.VIEW_DETAILS);
         clickTypeActionMap.put(ShopClickType.valueOf(config.getString("actionMappings.cycleShopDisplay")), ShopAction.CYCLE_DISPLAY);
+        
+        // Load shop display optimization settings
+        displayProcessInterval = config.getDouble("displayProcessInterval");
+        displayMovementThreshold = config.getDouble("displayMovementThreshold");
+        maxShopDisplayDistance = config.getDouble("maxShopDisplayDistance");
+        shopSearchRadius = config.getInt("shopSearchRadius");
 
         // Check if we should load VAULT economy
         if (currencyType == CurrencyType.VAULT) {
@@ -1130,5 +1142,33 @@ public class Shop extends JavaPlugin {
     // Getter for FoliaLib
     public FoliaLib getFoliaLib() {
         return foliaLib;
+    }
+
+    public double getDisplayProcessInterval() {
+        return displayProcessInterval;
+    }
+    
+    public double getDisplayMovementThreshold() {
+        return displayMovementThreshold;
+    }
+
+    /**
+     * Gets the maximum distance at which shop displays will be shown to players.
+     * Higher values will show shops from further away but may cause client lag.
+     * 
+     * @return The maximum display distance in blocks
+     */
+    public double getMaxShopDisplayDistance() {
+        return maxShopDisplayDistance;
+    }
+
+    /**
+     * Gets the radius (in chunks) around a player to search for shops.
+     * Each increment searches exponentially more chunks (1=3x3 area, 2=5x5 area, 3=7x7 area).
+     * 
+     * @return The shop search radius in chunks
+     */
+    public int getShopSearchRadius() {
+        return shopSearchRadius;
     }
 }

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -633,7 +633,7 @@ public class Shop extends JavaPlugin {
         }));
         metrics.addCustomChart(new AdvancedPie("shop_containers", () -> shopHandler.getShopContainerCounts()));
         metrics.addCustomChart(new SimplePie("economy_type", () -> { return currencyType.toString(); }));
-        
+        metrics.addCustomChart(new SimplePie("fractional_currency", () -> { return String.valueOf(allowFractionalCurrency); }));
         // Add metrics for more configuration options
         metrics.addCustomChart(new SimplePie("use_permissions", () -> String.valueOf(usePerms)));
         metrics.addCustomChart(new SimplePie("allow_partial_sales", () -> String.valueOf(allowPartialSales)));
@@ -762,6 +762,11 @@ public class Shop extends JavaPlugin {
             }
             return "NOT_SET";
         }));
+
+        metrics.addCustomChart(new SimplePie("display_processing_interval", () -> String.valueOf(displayProcessInterval)));
+        metrics.addCustomChart(new SimplePie("display_movement_threshold", () -> String.valueOf(displayMovementThreshold)));
+        metrics.addCustomChart(new SimplePie("display_max_shop_distance", () -> String.valueOf(maxShopDisplayDistance)));
+        metrics.addCustomChart(new SimplePie("display_shop_search_radius", () -> String.valueOf(shopSearchRadius)));
 
         debug_allowUseOwnShop = config.getBoolean("debug.allowUseOwnShop");
         debug_transactionDebugLogs = config.getBoolean("debug.transactionDebugLogs");

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -129,6 +129,8 @@ public class Shop extends JavaPlugin {
         return plugin;
     }
 
+    public static boolean loggedDisplayDisabledWarning = false;
+
     // Return the custom ShopLogger so that we can log at higher levels.
     @Override
     public ShopLogger getLogger() { return logger; }

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -426,8 +426,24 @@ public class Shop extends JavaPlugin {
             gambleDisplayFile.getParentFile().mkdirs();
             UtilMethods.copy(getResource("GAMBLE_DISPLAY.yml"), gambleDisplayFile);
         }
-        YamlConfiguration gambleItemConfig = YamlConfiguration.loadConfiguration(gambleDisplayFile);
-        gambleDisplayItem = gambleItemConfig.getItemStack("GAMBLE_DISPLAY");
+        try {
+            YamlConfiguration gambleItemConfig = YamlConfiguration.loadConfiguration(gambleDisplayFile);
+            gambleDisplayItem = gambleItemConfig.getItemStack("GAMBLE_DISPLAY");
+        } catch (IllegalArgumentException e) {
+            this.getLogger().severe("Error loading gamble display item from file: " + gambleDisplayFile.getAbsolutePath());
+            gambleDisplayItem = new ItemStack(Material.DIAMOND);
+        } catch (Exception e) {
+            this.getLogger().warning("Error loading gamble display item from file: " + gambleDisplayFile.getAbsolutePath());
+            gambleDisplayItem = new ItemStack(Material.DIAMOND);
+        } catch (Error e) {
+            this.getLogger().warning("Error loading gamble display item from file: " + gambleDisplayFile.getAbsolutePath());
+            gambleDisplayItem = new ItemStack(Material.DIAMOND);
+        }
+
+        if (gambleDisplayItem == null) {
+            this.getLogger().severe("Error loading gamble display item from file: " + gambleDisplayFile.getAbsolutePath());
+            gambleDisplayItem = new ItemStack(Material.DIAMOND);
+        }
 
         currencyName = config.getString("currency.name");
         currencyFormat = config.getString("currency.format");

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -101,6 +101,7 @@ public class Shop extends JavaPlugin {
     private CurrencyType currencyType;
     private String currencyName = "";
     private String currencyFormat = "";
+    private boolean allowFractionalCurrency = false;
     private Economy econ = null;
     private List<Material> enabledContainers;
     private boolean inverseComboShops;
@@ -375,6 +376,10 @@ public class Shop extends JavaPlugin {
             currencyType = CurrencyType.valueOf(config.getString("currency.type"));
         } catch(Exception e){
             currencyType = CurrencyType.ITEM;
+        }
+
+        if (currencyType == CurrencyType.VAULT) {
+            allowFractionalCurrency = config.getBoolean("allowFractionalCurrency");
         }
 
         offlinePurchaseNotificationsEnabled = config.getBoolean("offlinePurchaseNotifications.enabled");
@@ -1074,6 +1079,10 @@ public class Shop extends JavaPlugin {
         }
 
         return econ;
+    }
+
+    public boolean getAllowFractionalCurrency() { 
+        return allowFractionalCurrency;
     }
 
     public List<Material> getEnabledContainers(){

--- a/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
+++ b/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
@@ -41,6 +41,8 @@ public abstract class AbstractDisplay {
         chunkZ = UtilMethods.floor(shopSignLocation.getBlockZ()) >> 4;
     }
 
+    public boolean isEnabled() { return true; }
+
     public boolean isInChunk(Chunk chunk){
         return chunk.getX() == chunkX && chunk.getZ() == chunkZ && chunk.getWorld().toString().equals(shopSignLocation.getWorld().toString());
     }

--- a/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
+++ b/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
@@ -431,7 +431,7 @@ public abstract class AbstractDisplay {
         AbstractShop shop = this.getShop();
 
         Vector offset = new Vector(0,0,0);
-        double space = 1;
+        double space = 0.48;
 
         // @TODO: Verify that we are modifying the coordinates correctly!
         switch (shop.getFacing()) {

--- a/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
+++ b/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
@@ -206,6 +206,9 @@ public abstract class AbstractDisplay {
                 }
             }
 
+            // Create a list to store tag data
+            List<Map.Entry<String, Location>> tagData = new ArrayList<>();
+
             double verticalAddition = 0;
             //iterate through list backwards to build from bottom -> up
             for (int i = displayTags.size() - 1; i >= 0; i--) {
@@ -222,9 +225,21 @@ public abstract class AbstractDisplay {
                 }
 
                 asTagLocation = asTagLocation.add(0, verticalAddition, 0);
+                
+                // Store the tag data instead of creating it immediately
+                tagData.add(new AbstractMap.SimpleEntry<>(tagLine, asTagLocation));
+                
+                verticalAddition += 0.3;
+            }
+            
+            // Now create the tags in reverse order (top to bottom)
+            for (int i = tagData.size() - 1; i >= 0; i--) {
+                Map.Entry<String, Location> entry = tagData.get(i);
+                String tagLine = entry.getKey();
+                Location asTagLocation = entry.getValue();
+                
                 Shop.getPlugin().getLogger().spam("[Display] Adding tag line: " + tagLine, true);
                 createTagEntity(player, tagLine, asTagLocation);
-                verticalAddition += 0.3;
             }
 
             Shop.getPlugin().getShopHandler().addActiveShopDisplayTag(player, this.shopSignLocation);
@@ -266,6 +281,7 @@ public abstract class AbstractDisplay {
     }
 
     public void createTagEntity(Player player, String text, Location location){
+        Shop.getPlugin().getLogger().debug("Spawning hologram for player " + player.getName() + " at " + location.getBlockX() + "/" + location.getBlockY() + "/" + location.getBlockZ() + ": " + text, true);
         ArmorStandData caseStandData = new ArmorStandData();
         caseStandData.setSmall(false);
         caseStandData.setLocation(location);

--- a/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
+++ b/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
@@ -204,6 +204,13 @@ public abstract class AbstractDisplay {
                 if (displayBlock.getType() == Material.BARREL || displayBlock.getRelative(BlockFace.DOWN).getType() == Material.BARREL) {
                     lowerTagLocation = lowerTagLocation.add(0, .25, 0);
                 }
+                // If there is a block above our display, offset the tag location
+                // so that it doesn't become hidden inside the block. (most noticible with chests)
+                if (getShop().getChestLocation().clone().add(0,2,0).getBlock().getType() != Material.AIR) {
+                    // Adds 0.35 on top of the 0.2 added above (total of 0.55)
+                    // 0.3 to get to edge of block, 0.05 to give a lil more wiggle room when the player isnt looking directly at the display
+                    lowerTagLocation = UtilMethods.pushLocationInDirection(lowerTagLocation, this.getShop().getFacing(), 0.35);
+                }
             }
 
             // Create a list to store tag data

--- a/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
+++ b/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
@@ -564,21 +564,18 @@ public abstract class AbstractDisplay {
 
     protected void removeDisplayTagsDelayedTask(Player player) {
         //remove all armor stand name tag entities after x seconds
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                if(!displayTagsVisible(player)){
-                    removeDisplayEntities(player, true);
-                    return;
-                }
-                if (playerIsLookingTowardShop(player)) {
-                    removeDisplayTagsDelayedTask(player);
-                }
-                else {
-                    removeDisplayEntities(player, true);
-                }
+        Shop.getPlugin().getFoliaLib().getScheduler().runLater(() -> {
+            if(!displayTagsVisible(player)){
+                removeDisplayEntities(player, true);
+                return;
             }
-        }.runTaskLater(Shop.getPlugin(), 20);
+            if (playerIsLookingTowardShop(player)) {
+                removeDisplayTagsDelayedTask(player);
+            }
+            else {
+                removeDisplayEntities(player, true);
+            }
+        }, 20);
     }
 
     protected boolean displayTagsVisible(Player player){

--- a/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
+++ b/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
@@ -564,7 +564,7 @@ public abstract class AbstractDisplay {
 
     protected void removeDisplayTagsDelayedTask(Player player) {
         //remove all armor stand name tag entities after x seconds
-        Shop.getPlugin().getFoliaLib().getScheduler().runLater(() -> {
+        Shop.getPlugin().getFoliaLib().getScheduler().runAtEntityLater(player, () -> {
             if(!displayTagsVisible(player)){
                 removeDisplayEntities(player, true);
                 return;

--- a/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
+++ b/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
@@ -235,6 +235,34 @@ public abstract class AbstractDisplay {
         }
     }
 
+    public void updateDisplayTags(){
+        // Update any players display tags who currently have them open
+        if (displayTagEntityIDs == null || displayTagEntityIDs.isEmpty()) {
+            return;
+        }
+        
+        // Get a copy of the keys to avoid concurrent modification issues
+        Set<UUID> playerUUIDs = new HashSet<>(displayTagEntityIDs.keySet());
+        
+        for (UUID playerUUID : playerUUIDs) {
+            Player player = Shop.getPlugin().getServer().getPlayer(playerUUID);
+            
+            // Skip if player is offline or in a different world
+            if (player == null || !player.isOnline() || !isSameWorld(player)) {
+                continue;
+            }
+            
+            // Check if player has display tags visible
+            if (displayTagsVisible(player)) {
+                // Remove the current display tags
+                removeDisplayEntities(player, true);
+                
+                // Show updated display tags
+                showDisplayTags(player);
+            }
+        }
+    }
+
     public void createTagEntity(Player player, String text, Location location){
         ArmorStandData caseStandData = new ArmorStandData();
         caseStandData.setSmall(false);

--- a/core/src/main/java/com/snowgears/shop/display/Display.java
+++ b/core/src/main/java/com/snowgears/shop/display/Display.java
@@ -166,7 +166,7 @@ public class Display extends AbstractDisplay {
     private void sendPacket(Player player, Packet packet){
         if (player != null) {
             if(isSameWorld(player)) {
-                ServerPlayerConnection connection = nmsHelper.getPlayerConnection(player);
+                ServerPlayerConnection connection = (ServerPlayerConnection) Shop.getPlugin().getShopHandler().getCachedPlayerConnection(player);
                 if (connection != null) {
                     connection.send(packet); //sendPacket()
                     //System.out.println("Sending player a packet: "+packet.getClass().toString());
@@ -175,7 +175,7 @@ public class Display extends AbstractDisplay {
         }
         else {
             for (Player onlinePlayer : this.shopSignLocation.getWorld().getPlayers()) {
-                ServerPlayerConnection connection = nmsHelper.getPlayerConnection(onlinePlayer);
+                ServerPlayerConnection connection = (ServerPlayerConnection) Shop.getPlugin().getShopHandler().getCachedPlayerConnection(onlinePlayer);
                 if(connection != null) {
                     connection.send(packet); //sendPacket
                 }

--- a/core/src/main/java/com/snowgears/shop/display/DisplayDisabled.java
+++ b/core/src/main/java/com/snowgears/shop/display/DisplayDisabled.java
@@ -1,0 +1,95 @@
+package com.snowgears.shop.display;
+
+import com.snowgears.shop.Shop;
+import com.snowgears.shop.util.ArmorStandData;
+import net.minecraft.core.Direction;
+import net.minecraft.network.protocol.Packet;
+import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+public class DisplayDisabled extends AbstractDisplay {
+
+    public DisplayDisabled(Location shopSignLocation) {
+        super(shopSignLocation);
+        if (!Shop.loggedDisplayDisabledWarning) {
+            Shop.getPlugin().getLogger().warning("[DisplayDisabled] Display is disabled! No display features will be used.");
+            Shop.getPlugin().getLogger().warning("[DisplayDisabled] This could mean there was an error with the server running an unsupported version or unsupported server software.");
+            Shop.getPlugin().getLogger().warning("[DisplayDisabled] Shop will attempt to function without display features, but some features may not work as expected.");
+            Shop.loggedDisplayDisabledWarning = true;
+        }
+    }
+
+    @Override
+    public boolean isEnabled() { return false; }
+
+    @Override
+    protected void spawnItemPacket(Player player, ItemStack is, Location location) {
+        Shop.getPlugin().getLogger().debug("Display is disabled, item packet not sent");
+    }
+
+    @Override
+    protected void spawnArmorStandPacket(Player player, ArmorStandData armorStandData, String text) {
+        Shop.getPlugin().getLogger().debug("Display is disabled, armor stand packet not sent");
+    }
+
+    @Override
+    protected void spawnItemFramePacket(Player player, ItemStack is, Location location, BlockFace facing, boolean isGlowing){
+        Shop.getPlugin().getLogger().debug("Display is disabled, item frame packet not sent");
+    }
+
+    private void sendPacket(Player player, Packet packet){
+        Shop.getPlugin().getLogger().debug("Display is disabled, packet not sent");
+    }
+
+    @Override
+    public void removeDisplayEntities(Player player, boolean onlyDisplayTags) {
+        Shop.getPlugin().getLogger().debug("Display is disabled, removeDisplayEntities not called");
+    }
+
+    private Direction getMojangDirection(BlockFace facing){
+        switch (facing){
+            case NORTH:
+                return Direction.NORTH;
+            case SOUTH:
+                return Direction.SOUTH;
+            case WEST:
+                return Direction.WEST;
+            case EAST:
+                return Direction.EAST;
+            case DOWN:
+                return Direction.DOWN;
+            default:
+                return Direction.UP;
+        }
+    }
+
+    private net.minecraft.world.entity.EquipmentSlot getMojangEquipmentSlot(EquipmentSlot equipmentSlot){
+        switch(equipmentSlot){
+            case HAND:
+                return net.minecraft.world.entity.EquipmentSlot.MAINHAND;
+            case OFF_HAND:
+                return net.minecraft.world.entity.EquipmentSlot.OFFHAND;
+            case FEET:
+                return net.minecraft.world.entity.EquipmentSlot.FEET;
+            case LEGS:
+                return net.minecraft.world.entity.EquipmentSlot.LEGS;
+            case CHEST:
+                return net.minecraft.world.entity.EquipmentSlot.CHEST;
+            default:
+                return net.minecraft.world.entity.EquipmentSlot.HEAD;
+        }
+    }
+
+    @Override
+    public String getItemNameNMS(ItemStack item) {
+        Shop.getPlugin().getLogger().debug("Display is disabled, getItemNameNMS not called, returning empty string");
+        if (item.getItemMeta().hasDisplayName()) {
+            return item.getItemMeta().getDisplayName();
+        } else {
+            return item.getItemMeta().getItemName();
+        }
+    }
+}

--- a/core/src/main/java/com/snowgears/shop/handler/LogHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/LogHandler.java
@@ -187,7 +187,7 @@ public class LogHandler {
         plugin.getLogger().helpful(
             "Shop " + shop.getType().name().toUpperCase() + " from/to " + player.getName() + ": "
                 + ChatColor.stripColor(new ItemNameUtil().getName(shop.getItemStack()).toPlainText()) + "(x" + amount + ")" + " for " + plugin.getPriceString(price, true)
-                + " | Shop owned by " + plugin.getServer().getOfflinePlayer(shop.getOwnerUUID()).getName() + " at (x: " + shop.getChestLocation().getBlockX() + " y: " + shop.getChestLocation().getBlockY() + " z: " + shop.getChestLocation().getBlockZ() + ")"
+                + " | Shop owned by " + shop.getOwnerName() + " at (x: " + shop.getChestLocation().getBlockX() + " y: " + shop.getChestLocation().getBlockY() + " z: " + shop.getChestLocation().getBlockZ() + ")"
         );
 
         try {

--- a/core/src/main/java/com/snowgears/shop/handler/LogHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/LogHandler.java
@@ -12,7 +12,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-
+import org.bukkit.ChatColor;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -142,16 +142,16 @@ public class LogHandler {
             plugin.getLogger().notice(
                     player.getName() + " created a " + shop.getType().name().toUpperCase() + " shop at ("
                             + "x: " + shop.getChestLocation().getBlockX() + " y: " + shop.getChestLocation().getBlockY() + " z: " + shop.getChestLocation().getBlockZ()
-                            + ") item: " + new ItemNameUtil().getName(shop.getItemStack()).toPlainText()
-                            + (shop.getSecondaryItemStack() != null ? " barterItem: " + new ItemNameUtil().getName(shop.getSecondaryItemStack()).toPlainText() : "")
+                            + ") item: " + ChatColor.stripColor(new ItemNameUtil().getName(shop.getItemStack()).toPlainText())
+                            + (shop.getSecondaryItemStack() != null ? " barterItem: " + ChatColor.stripColor(new ItemNameUtil().getName(shop.getSecondaryItemStack()).toPlainText()) : "")
             );
         }
         if (actionType == ShopActionType.DESTROY) {
             plugin.getLogger().notice(
                     player.getName() + " destroyed a " + shop.getType().name().toUpperCase() + " shop at ("
                             + "x: " + shop.getChestLocation().getBlockX() + " y: " + shop.getChestLocation().getBlockY() + " z: " + shop.getChestLocation().getBlockZ()
-                            + ") item: " + new ItemNameUtil().getName(shop.getItemStack()).toPlainText()
-                            + (shop.getSecondaryItemStack() != null ? " barterItem: " + new ItemNameUtil().getName(shop.getSecondaryItemStack()).toPlainText() : "")
+                            + ") item: " + ChatColor.stripColor(new ItemNameUtil().getName(shop.getItemStack()).toPlainText())
+                            + (shop.getSecondaryItemStack() != null ? " barterItem: " + ChatColor.stripColor(new ItemNameUtil().getName(shop.getSecondaryItemStack()).toPlainText()) : "")
             );
         }
 
@@ -189,7 +189,7 @@ public class LogHandler {
     public void logTransaction(Player player, AbstractShop shop, ShopType transactionType, double price, int amount){
         plugin.getLogger().helpful(
             "Shop " + shop.getType().name().toUpperCase() + " from/to " + player.getName() + ": "
-                + new ItemNameUtil().getName(shop.getItemStack()).toPlainText() + "(x" + amount + ")" + " for " + plugin.getPriceString(price, true)
+                + ChatColor.stripColor(new ItemNameUtil().getName(shop.getItemStack()).toPlainText()) + "(x" + amount + ")" + " for " + plugin.getPriceString(price, true)
                 + " | Shop owned by " + plugin.getServer().getOfflinePlayer(shop.getOwnerUUID()).getName() + " at (x: " + shop.getChestLocation().getBlockX() + " y: " + shop.getChestLocation().getBlockY() + " z: " + shop.getChestLocation().getBlockZ() + ")"
         );
 

--- a/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
@@ -8,6 +8,7 @@ import com.snowgears.shop.shop.ComboShop;
 import com.snowgears.shop.shop.ShopType;
 import com.snowgears.shop.util.DisplayUtil;
 import com.snowgears.shop.util.ItemListType;
+import com.snowgears.shop.util.ShopLogger;
 import com.snowgears.shop.util.UtilMethods;
 import org.bukkit.*;
 import org.bukkit.block.Block;
@@ -1151,7 +1152,12 @@ public class ShopHandler {
                     shopNumber++;
                 }
             }
-            plugin.getLogger().spam("    built config to save... \n" + config.saveToString());
+            
+            // Only generate the stringified config for logging if spam logging is enabled
+            if (plugin.getLogger().isLevelEnabled(ShopLogger.SPAM)) {
+                plugin.getLogger().spam("    built config to save... \n" + config.saveToString());
+            }
+            
             config.save(currentFile);
             plugin.getLogger().helpful("Saved " + shopNumber + " Shops for Player " + playerName + " to file: " + currentFile);
             return shopNumber;

--- a/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
@@ -605,10 +605,11 @@ public class ShopHandler {
                 // Record that we're processing displays for this player
                 lastProcessedLocations.put(player.getUniqueId(), playerLocation.clone());
                 
+                // TODO: Look at maybe adding this back in, but it creates such a huge delay at the moment!
                 // A small random offset added to each shop to stagger packet sending
                 // This helps prevent overwhelming the client with too many entity packets at once
-                int spawnDelay = 0;
-                int jitterInterval = 2; // Add 2 ticks between each shop (100ms)
+                // int spawnDelay = 0;
+                // int jitterInterval = 2; // Add 2 ticks between each shop (100ms)
                 
                 // Process each nearby shop location
                 for (Location shopLocation : nearbyShopLocations) {
@@ -616,7 +617,7 @@ public class ShopHandler {
                     if (shop == null) continue;
                     
                     // Use final variables for the lambda
-                    final int delay = spawnDelay;
+                    final int delay = 1;
                     final AbstractShop finalShop = shop;
 
                     // Use distance check to determine if display should be shown
@@ -649,7 +650,7 @@ public class ShopHandler {
                     }
                     
                     // Increase the delay for the next shop
-                    spawnDelay += jitterInterval;
+                    // spawnDelay += jitterInterval;
                 }
                 
                 // Also check if we need to remove any displays that are no longer in range

--- a/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
@@ -703,7 +703,9 @@ public class ShopHandler {
             sortedLocations.sort(Comparator.comparing(Map.Entry::getValue));
             
             // Process in distance order with small delays between batches to reduce visual clutter
-            int batchSize = 10; // Process 10 displays at a time
+            // Use configurable batch size from config
+            int batchSize = plugin.getDisplayBatchSize();
+            int batchDelay = plugin.getDisplayBatchDelay();
             int totalBatches = (sortedLocations.size() + batchSize - 1) / batchSize;
             
             plugin.getLogger().debug("Creating " + sortedLocations.size() + " displays in " + totalBatches + " batches for " + player.getName());
@@ -711,7 +713,7 @@ public class ShopHandler {
             for (int batch = 0; batch < totalBatches; batch++) {
                 final int currentBatch = batch;
                 
-                // Add a small delay between batches
+                // Add a configurable delay between batches
                 plugin.getFoliaLib().getScheduler().runAtEntityLater(player, () -> {
                     if (!player.isOnline()) return;
                     
@@ -727,7 +729,7 @@ public class ShopHandler {
                             addActiveShopDisplay(player, locationToShow);
                         }
                     }
-                }, batch * 2); // 2 tick delay between batches
+                }, batch * batchDelay); // Configurable delay between batches
             }
         }, 2); // 2 tick delay after removals
     }

--- a/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
@@ -457,11 +457,11 @@ public class ShopHandler {
                     double distance = player.getLocation().distance(shop.getSignLocation());
                     if (distance < 2) {
                         // Very close to shop, always show
-                        shop.getDisplay().spawn(player);
+                        if (!hasActiveDisplay(player, shop.getSignLocation())) shop.getDisplay().spawn(player);
                         addActiveShopDisplay(player, shop.getSignLocation());
                     } else if (distance < 10) {
                         // Within reasonable distance
-                        shop.getDisplay().spawn(player);
+                        if (!hasActiveDisplay(player, shop.getSignLocation())) shop.getDisplay().spawn(player);
                         addActiveShopDisplay(player, shop.getSignLocation());
                     } else {
                         // Too far, remove display
@@ -481,6 +481,11 @@ public class ShopHandler {
     public void clearShopDisplaysNearPlayer(Player player){
         if(playersWithActiveShopDisplays.containsKey(player.getUniqueId()))
             playersWithActiveShopDisplays.remove(player.getUniqueId());
+    }
+
+    public boolean hasActiveDisplay(Player player, Location shopSignLocation) { 
+        HashSet<Location> shops = playersWithActiveShopDisplays.get(player.getUniqueId());
+        return shops != null && shops.contains(shopSignLocation);
     }
 
     public void addActiveShopDisplay(Player player, Location shopSignLocation){

--- a/core/src/main/java/com/snowgears/shop/handler/TransactionHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/TransactionHandler.java
@@ -1,4 +1,3 @@
-
 package com.snowgears.shop.handler;
 
 import com.snowgears.shop.Shop;
@@ -100,7 +99,10 @@ public class TransactionHandler {
 
         // Set the desired purchase amount if we are a full stack order
         if (fullStackOrder) {
-            transaction.negotiatePurchase(64);
+            // Use either 64 (Minecraft's standard "full stack") or the shop's amount, whichever is larger
+            // This ensures players get 64 items when buying from shops with smaller default amounts
+            // But still get the full amount from shops configured to sell larger quantities
+            transaction.negotiatePurchase(Math.max(shop.getAmount(), 64));
         } else {
             transaction.negotiatePurchase();
         }

--- a/core/src/main/java/com/snowgears/shop/handler/TransactionHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/TransactionHandler.java
@@ -208,7 +208,7 @@ public class TransactionHandler {
         else{
             shopMessageCooldown.put(shop.getSignLocation(), shop.getOwnerUUID());
 
-            new BukkitRunnable() {
+            plugin.getFoliaLib().getScheduler().runLater(new BukkitRunnable() {
                 @Override
                 public void run() {
                     if(shop != null){
@@ -218,7 +218,7 @@ public class TransactionHandler {
                     }
                     //TODO if shop is null, should you clear the entire cooldown list so that that location isn't messed up?
                 }
-            }.runTaskLater(this.plugin, 2400); //make cooldown 2 minutes
+            }, 2400); //make cooldown 2 minutes
         }
         return true;
     }

--- a/core/src/main/java/com/snowgears/shop/hook/DynmapHookListener.java
+++ b/core/src/main/java/com/snowgears/shop/hook/DynmapHookListener.java
@@ -10,7 +10,6 @@ import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.dynmap.DynmapAPI;
 import org.dynmap.markers.GenericMarker;
 import org.dynmap.markers.Marker;
@@ -42,12 +41,7 @@ public class DynmapHookListener implements Listener {
                 shopMarkerSet = api.getMarkerAPI().createMarkerSet("shop", markerName, null, false);
             }
 
-            new BukkitRunnable() {
-                @Override
-                public void run() {
-                    updateMarkers();
-                }
-            }.runTaskTimer(plugin, 1, 20 * 120 * 60);
+            plugin.getFoliaLib().getScheduler().runTimer(() -> updateMarkers(), 1, 20 * 120 * 60);
         } catch(NullPointerException e){
             enabled = false;
             plugin.getLogger().warning("Dynmap marker api was null. Disabling DynMap integration.");
@@ -58,14 +52,14 @@ public class DynmapHookListener implements Listener {
     public void onShopRemoved(PlayerDestroyShopEvent event) {
         if(!enabled)
             return;
-        plugin.getServer().getScheduler().runTask(plugin, this::updateMarkers);
+        plugin.getFoliaLib().getScheduler().runNextTick(task -> updateMarkers());
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onShopCreated(PlayerInitializeShopEvent event) {
         if(!enabled)
             return;
-        plugin.getServer().getScheduler().runTask(plugin, this::updateMarkers);
+        plugin.getFoliaLib().getScheduler().runNextTick(task -> updateMarkers());
     }
 
     private void updateMarkers() {

--- a/core/src/main/java/com/snowgears/shop/hook/PlotSquaredHookListener.java
+++ b/core/src/main/java/com/snowgears/shop/hook/PlotSquaredHookListener.java
@@ -1,0 +1,70 @@
+package com.snowgears.shop.hook;
+
+import com.snowgears.shop.Shop;
+import com.snowgears.shop.shop.AbstractShop;
+import org.bukkit.event.Listener;
+
+import com.plotsquared.core.PlotAPI;
+import com.plotsquared.core.events.post.PostPlotDeleteEvent;
+import com.plotsquared.core.events.post.PostPlotClearEvent;
+import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.location.Location;
+
+import java.util.HashSet;
+import java.util.UUID;
+import com.google.common.eventbus.Subscribe;
+
+public class PlotSquaredHookListener implements Listener {
+
+    private Shop plugin;
+    private PlotAPI plotAPI;
+
+    public PlotSquaredHookListener(Shop instance) {
+        plugin = instance;
+        plotAPI = new PlotAPI();
+        plotAPI.registerListener(this);
+    }
+
+    @Subscribe
+    public void onPlotDelete(PostPlotDeleteEvent e) {
+        deleteAllShopsInPlot(e.getPlot());
+    }
+    
+    @Subscribe
+    public void onPlotClear(PostPlotClearEvent e) {
+        deleteAllShopsInPlot(e.getPlot());
+    }
+
+    private void deleteAllShopsInPlot(Plot plot){
+        HashSet<UUID> shopOwnersToSave = new HashSet<>();
+        int shopsDeleted = 0;
+        for(UUID shopOwnerUUID : plugin.getShopHandler().getShopOwnerUUIDs()){
+            for(AbstractShop shop : plugin.getShopHandler().getShops(shopOwnerUUID)) {
+                if (shop != null && shop.getSignLocation() != null && shop.getSignLocation().getWorld().getName().equals(plot.getArea().getWorldName())) {
+                    if (shop.getChestLocation() != null) {
+                        Location location = Location.at(
+                            shop.getChestLocation().getWorld().getName(), 
+                            shop.getChestLocation().getBlockX(), 
+                            shop.getChestLocation().getBlockY(), 
+                            shop.getChestLocation().getBlockZ()
+                        );
+                        if (plot.getArea().contains(location)) {
+                            plugin.getLogger().notice("Deleting Shop because PlotSquared Plot is being reset! " + shop);
+                            shop.delete();
+                            shopOwnersToSave.add(shopOwnerUUID);
+                            shopsDeleted++;
+                        }
+                    }
+                }
+            }
+        }
+
+        for(UUID shopOwner : shopOwnersToSave) {
+            plugin.getShopHandler().saveShops(shopOwner, true);
+        }
+
+        if (shopsDeleted > 0) {
+            plugin.getLogger().notice("(PlotSquared Hook) Deleted " + shopsDeleted + " Shops inside Plot `" + plot.getId() + "` during plot reset");
+        }
+    }
+}

--- a/core/src/main/java/com/snowgears/shop/hook/WorldGuardHook.java
+++ b/core/src/main/java/com/snowgears/shop/hook/WorldGuardHook.java
@@ -40,21 +40,23 @@ public class WorldGuardHook {
     // Note: WorldGuard only allows registering flags before it got enabled.
     public static void registerAllowShopFlag() {
         if (getPlugin() == null) return; // WorldGuard is not loaded
-            Internal.registerAllowShopFlag();
+
+        Internal.registerAllowShopFlag(Shop.getPlugin());
     }
 
     // Separate class that gets only accessed if WorldGuard is present. Avoids class loading issues.
     private static class Internal {
 
-        public static void registerAllowShopFlag() {
-            Shop.getPlugin().getLogger().debug("Registering WorldGuard flag '" + FLAG_ALLOW_SHOP + "'.");
+        public static void registerAllowShopFlag(Shop plugin) {
+            Bukkit.getLogger().log(Level.INFO,"[Shop] Registering WorldGuard flag '" + FLAG_ALLOW_SHOP + "'");
             try {
                 StateFlag allowShopFlag = new StateFlag(FLAG_ALLOW_SHOP, false);
                 WorldGuard.getInstance().getFlagRegistry().register(allowShopFlag);
+                Bukkit.getLogger().log(Level.INFO,"[Shop] Registered WorldGuard flag '" + FLAG_ALLOW_SHOP + "'");
             } catch (FlagConflictException | IllegalStateException e) {
                 // Another plugin has probably already registered this flag,
                 // or this plugin got hard reloaded by some plugin manager plugin.
-                Bukkit.getLogger().log(Level.SEVERE,"Couldn't register WorldGuard flag '" + FLAG_ALLOW_SHOP + "': " + e.getMessage());
+                Bukkit.getLogger().log(Level.SEVERE,"[Shop] Couldn't register WorldGuard flag '" + FLAG_ALLOW_SHOP + "': " + e.getMessage());
             }
         }
 

--- a/core/src/main/java/com/snowgears/shop/listener/CreativeSelectionListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/CreativeSelectionListener.java
@@ -24,8 +24,12 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryCreativeEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.*;
@@ -98,26 +102,48 @@ public class CreativeSelectionListener implements Listener {
     }
 
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onPlayerMove(PlayerMoveEvent event) {
         Player player = event.getPlayer();
         if (playerDataMap.get(player.getUniqueId()) != null) {
+            // Check if player is trying to move to a different block
             if (event.getFrom().getBlockZ() != event.getTo().getBlockZ()
                     || event.getFrom().getBlockX() != event.getTo().getBlockX()
                     || event.getFrom().getBlockY() != event.getTo().getBlockY()) {
-                player.teleport(event.getFrom());
+                
+                // Instead of teleporting, set the "to" location to match the "from" location
+                // This effectively cancels the movement without triggering a teleport event
+                Location fixedLocation = event.getFrom().clone();
+                
+                // Preserve the player's head rotation so they can still look around
+                fixedLocation.setYaw(event.getTo().getYaw());
+                fixedLocation.setPitch(event.getTo().getPitch());
+                
+                event.setTo(fixedLocation);
+                
+                // Send message to inform the player they're locked in place
                 sendPlayerLockedMessages(player, playerDataMap.get(player.getUniqueId()));
             }
         }
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onTeleport(PlayerTeleportEvent event){
         Player player = event.getPlayer();
         if (playerDataMap.get(player.getUniqueId()) != null) {
-            if (event.getFrom().distanceSquared(event.getTo()) > 4) {
+            // Always allow teleports that we're doing internally for shop selection
+            PlayerData data = playerDataMap.get(player.getUniqueId());
+            Location shopLocation = data.getShopSignLocation();
+            
+            // If this is a teleport from another plugin or command going far away, cancel it
+            if (event.getFrom().distanceSquared(event.getTo()) > 4 &&
+                (shopLocation == null || event.getTo().distanceSquared(shopLocation) > 4)) {
+                
+                // Cancel the teleport event entirely instead of teleporting them back
                 event.setCancelled(true);
-                sendPlayerLockedMessages(player, playerDataMap.get(player.getUniqueId()));
+                
+                // Send message to inform the player they're locked in place
+                sendPlayerLockedMessages(player, data);
             }
         }
     }
@@ -142,36 +168,38 @@ public class CreativeSelectionListener implements Listener {
     public void inventoryClose(InventoryCloseEvent event) {
         if (!(event.getPlayer() instanceof Player))
             return;
+        
+        Player player = (Player) event.getPlayer();
+        
         //don't remove player data if they just clicked the search icon
         try {
             Object view = event.getView();
             Method getTitle = view.getClass().getMethod("getTitle");
             getTitle.setAccessible(true);
-            if(getTitle.invoke(view).equals(Shop.getPlugin().getGuiHandler().getTitle(ShopGuiHandler.GuiTitle.HOME)) || getTitle.invoke(view).equals(Shop.getPlugin().getGuiHandler().getTitle(ShopGuiHandler.GuiTitle.LIST_SHOPS))){
+            // Check if they're in a special GUI window, if so return early
+            if(getTitle.invoke(view).equals(Shop.getPlugin().getGuiHandler().getTitle(ShopGuiHandler.GuiTitle.HOME)) || 
+               getTitle.invoke(view).equals(Shop.getPlugin().getGuiHandler().getTitle(ShopGuiHandler.GuiTitle.LIST_SHOPS))){
                 return;
             }
-        } catch (NoSuchMethodException e) {
-            throw new RuntimeException(e);
-        } catch (InvocationTargetException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            plugin.getLogger().log(Level.SEVERE, "Error checking inventory title", e);
         }
-        //for some reason this event is also called now on PlayerQuitEvent. Check that player didnt quit
-        plugin.getFoliaLib().getScheduler().runLater(() -> {
-            Player player = plugin.getServer().getPlayer(event.getPlayer().getUniqueId());
-            if(player != null) {
-                boolean removed = removePlayerFromCreativeSelection(player);
-                if (removed) {
-                    player.updateInventory();
-                }
-                // Check if we have a chat shop creation in process, and cancel it
-                ShopCreationProcess process = plugin.getMiscListener().getShopCreationProcess(player);
-                // If we are in the ITEM/BARTER_ITEM selection stage, then cancel the shop chat creation process!
-                if (process != null && (process.getStep() == ITEM || process.getStep() == BARTER_ITEM))
-                    plugin.getMiscListener().cancelShopCreationProcess(player);
+        
+        // Check if player is online - this handles the PlayerQuitEvent case as well
+        if (player.isOnline()) {
+            // Immediately remove from creative selection without delay
+            boolean removed = removePlayerFromCreativeSelection(player);
+            if (removed) {
+                player.updateInventory();
             }
-        }, 10); //0.5 second
+            
+            // Check if we have a chat shop creation in process, and cancel it
+            ShopCreationProcess process = plugin.getMiscListener().getShopCreationProcess(player);
+            // If we are in the ITEM/BARTER_ITEM selection stage, then cancel the shop chat creation process!
+            if (process != null && (process.getStep() == ITEM || process.getStep() == BARTER_ITEM)) {
+                plugin.getMiscListener().cancelShopCreationProcess(player);
+            }
+        }
     }
 
     @EventHandler
@@ -199,79 +227,81 @@ public class CreativeSelectionListener implements Listener {
             return;
         Player player = (Player) event.getWhoClicked();
         PlayerData playerData = PlayerData.loadFromFile(player);
-        if (playerData != null) {
+        
+        // If the player is not in a creative selection mode we're tracking, ignore the event
+        if (playerData == null) {
+            return;
+        }
 
-            //player dropped item outside the inventory
-            if (event.getSlot() == -999 && event.getCursor() != null) {
-                if (!playerData.isGuiSearch()) {
-                    AbstractShop shop = playerData.getShop();
-                    if (shop != null) {
-                        if (shop.getType() == ShopType.BUY || shop.getType() == ShopType.COMBO) {
+        // Store the cursor item before cancellation for use in shop initialization
+        ItemStack selectedItem = event.getCursor() != null ? event.getCursor().clone() : null;
+        
+        // Set event cancellation flags early to ensure nothing slips through
+        // even if there's an exception in the processing code
+        event.setResult(Event.Result.DENY);
+        event.setCursor(new ItemStack(Material.AIR));
+        event.setCancelled(true);
 
-                            PlayerInitializeShopEvent e = new PlayerInitializeShopEvent(player, shop);
-                            Bukkit.getServer().getPluginManager().callEvent(e);
+        // Only allow slot -999 (dropping outside the inventory) which is our intended
+        // mechanism for selecting an item
+        if (event.getSlot() == -999 && selectedItem != null) {
+            if (!playerData.isGuiSearch()) {
+                AbstractShop shop = playerData.getShop();
+                if (shop != null) {
+                    if (shop.getType() == ShopType.BUY || shop.getType() == ShopType.COMBO) {
 
-                            if (e.isCancelled()) {
-                                event.setResult(Event.Result.DENY);
-                                event.setCursor(new ItemStack(Material.AIR));
-                                event.setCancelled(true);
-                                return;
-                            }
+                        PlayerInitializeShopEvent e = new PlayerInitializeShopEvent(player, shop);
+                        Bukkit.getServer().getPluginManager().callEvent(e);
 
-                            shop.setItemStack(event.getCursor());
-                            plugin.getShopCreationUtil().sendCreationSuccess(player, shop);
-
-                        } else if (shop.getType() == ShopType.BARTER) {
-
-                            PlayerInitializeShopEvent e = new PlayerInitializeShopEvent(player, shop);
-                            Bukkit.getServer().getPluginManager().callEvent(e);
-
-                            if (e.isCancelled()) {
-                                event.setResult(Event.Result.DENY);
-                                event.setCursor(new ItemStack(Material.AIR));
-                                event.setCancelled(true);
-                                return;
-                            }
-
-                            shop.setSecondaryItemStack(event.getCursor());
-                            plugin.getShopCreationUtil().sendCreationSuccess(player, shop);
-                            plugin.getLogHandler().logAction(player, shop, ShopActionType.INIT);
+                        if (e.isCancelled()) {
+                            return;
                         }
+
+                        shop.setItemStack(selectedItem);
+                        plugin.getShopCreationUtil().sendCreationSuccess(player, shop);
+
+                    } else if (shop.getType() == ShopType.BARTER) {
+
+                        PlayerInitializeShopEvent e = new PlayerInitializeShopEvent(player, shop);
+                        Bukkit.getServer().getPluginManager().callEvent(e);
+
+                        if (e.isCancelled()) {
+                            return;
+                        }
+
+                        shop.setSecondaryItemStack(selectedItem);
+                        plugin.getShopCreationUtil().sendCreationSuccess(player, shop);
+                        plugin.getLogHandler().logAction(player, shop, ShopActionType.INIT);
+                    }
+                    removePlayerFromCreativeSelection(player);
+                }
+                //there is a chest creation process
+                else if(plugin.getMiscListener().getShopCreationProcess(player) != null) {
+
+                    //they just hit a chest with an open hand (so they are making a BUY shop) and now need to choose an item from creative selection
+                    ShopCreationProcess currentProcess = plugin.getMiscListener().getShopCreationProcess(player);
+                    if(currentProcess.getStep() == ITEM){
+                        currentProcess.setItemStack(selectedItem);
+                        currentProcess.setShopType(ShopType.BUY);
+                        currentProcess.displayFloatingText(ShopType.BUY.toString(), "createHitChestAmount");
                         removePlayerFromCreativeSelection(player);
                     }
-                    //there is a chest creation process
-                    else if(plugin.getMiscListener().getShopCreationProcess(player) != null) {
-
-                        //they just hit a chest with an open hand (so they are making a BUY shop) and now need to choose an item from creative selection
-                        ShopCreationProcess currentProcess = plugin.getMiscListener().getShopCreationProcess(player);
-                        if(currentProcess.getStep() == ITEM){
-                            currentProcess.setItemStack(event.getCursor());
-                            currentProcess.setShopType(ShopType.BUY);
-                            currentProcess.displayFloatingText(ShopType.BUY.toString(), "createHitChestAmount");
-                            removePlayerFromCreativeSelection(player);
-                        }
-                        //they just hit a chest with an open hand when creating a barter shop and need choose a barter item from creative selection
-                        else if(currentProcess.getStep() == ShopCreationProcess.ChatCreationStep.BARTER_ITEM){
-                            currentProcess.setBarterItemStack(event.getCursor());
-                            currentProcess.displayFloatingText(ShopType.BARTER.toString(), "createHitChestBarterAmount");
-                            removePlayerFromCreativeSelection(player);
-                        }
+                    //they just hit a chest with an open hand when creating a barter shop and need choose a barter item from creative selection
+                    else if(currentProcess.getStep() == ShopCreationProcess.ChatCreationStep.BARTER_ITEM){
+                        currentProcess.setBarterItemStack(selectedItem);
+                        currentProcess.displayFloatingText(ShopType.BARTER.toString(), "createHitChestBarterAmount");
+                        removePlayerFromCreativeSelection(player);
                     }
                 }
-                //player data is a GUI Search
-                else{
-                    removePlayerFromCreativeSelection(player);
-
-                    ListSearchResultsWindow searchResultsWindow = new ListSearchResultsWindow(player.getUniqueId(), event.getCursor());
-                    searchResultsWindow.setPrevWindow(new HomeWindow(player.getUniqueId()));
-                    plugin.getGuiHandler().setWindow(player, searchResultsWindow);
-                }
-//                event.setResult(Event.Result.DENY);
-//                event.setCancelled(true);
             }
-            event.setResult(Event.Result.DENY);
-            event.setCursor(new ItemStack(Material.AIR));
-            event.setCancelled(true);
+            //player data is a GUI Search
+            else{
+                removePlayerFromCreativeSelection(player);
+
+                ListSearchResultsWindow searchResultsWindow = new ListSearchResultsWindow(player.getUniqueId(), selectedItem);
+                searchResultsWindow.setPrevWindow(new HomeWindow(player.getUniqueId()));
+                plugin.getGuiHandler().setWindow(player, searchResultsWindow);
+            }
         }
     }
 
@@ -313,17 +343,26 @@ public class CreativeSelectionListener implements Listener {
         }
     }
 
-    //make sure that if player somehow quit without getting their old data back, return it to them when they login next
+    /**
+     * Make sure that if player somehow quit without getting their old data back, return it to them when they login next
+     */
     @EventHandler
     public void onLogin(PlayerLoginEvent event){
         final Player player = event.getPlayer();
-        Shop.getPlugin().getFoliaLib().getScheduler().runLater(() -> {
-            PlayerData data = PlayerData.loadFromFile(player);
-            if(data != null){
-                playerDataMap.remove(player.getUniqueId());
-                data.apply();
-            }
-        }, 20);
+        
+        // Immediately attempt to restore PlayerData if it exists
+        PlayerData data = PlayerData.loadFromFile(player);
+        if(data != null){
+            // Use minimal delay (1 tick) since we need to ensure player is fully logged in
+            // This is much safer than the previous 20-tick delay
+            Shop.getPlugin().getFoliaLib().getScheduler().runLater(() -> {
+                if (player.isOnline()) {
+                    playerDataMap.remove(player.getUniqueId());
+                    data.apply();
+                    player.updateInventory();
+                }
+            }, 1); // 1 tick = 0.05 seconds
+        }
     }
 
     private void sendPlayerLockedMessages(Player player, PlayerData playerData){
@@ -342,5 +381,247 @@ public class CreativeSelectionListener implements Listener {
                 process.displayFloatingTextList("creativeSelection", "enter");
             }
         }
+    }
+
+    /**
+     * Prevents players in creative selection mode from dragging items across inventory slots
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onInventoryDrag(InventoryDragEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) {
+            return;
+        }
+        
+        Player player = (Player) event.getWhoClicked();
+        
+        // If player is in creative selection mode, cancel the drag event
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            // Cancel the event immediately to prevent any item dragging
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Handle general inventory clicks to provide an additional layer of protection
+     * beyond the specific creative mode handler
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onInventoryClick(InventoryClickEvent event) {
+        if (!(event.getWhoClicked() instanceof Player)) {
+            return;
+        }
+        
+        Player player = (Player) event.getWhoClicked();
+        
+        // Check if player is in creative selection mode
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            PlayerData data = playerDataMap.get(player.getUniqueId());
+            
+            // For regular inventory clicks (not drop outside inventory)
+            if (event.getSlot() != -999) {
+                // Cancel all regular clicks to prevent inventory manipulation
+                event.setCancelled(true);
+                return;
+            }
+            
+            // Let the InventoryCreativeEvent handler manage clicks to drop items outside the inventory
+            // This is slot -999, which is handled by the onCreativeClick method
+        }
+    }
+
+    /**
+     * Prevent players from executing commands while in creative selection mode
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerCommand(PlayerCommandPreprocessEvent event) {
+        Player player = event.getPlayer();
+        
+        // Check if player is in creative selection mode
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            // Cancel all command execution
+            event.setCancelled(true);
+            
+            // Inform the player
+            ShopMessage.sendMessage(ShopMessage.getUnformattedMessage("creativeSelection", "noCommands"), player);
+            
+            // Reset the message time to prevent spamming locked in place messages
+            PlayerData data = playerDataMap.get(player.getUniqueId());
+            data.setLastMessageTime(System.currentTimeMillis());
+        }
+    }
+
+    /**
+     * Prevent players from swapping items between hands while in creative selection mode
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerSwapHandItems(PlayerSwapHandItemsEvent event) {
+        Player player = event.getPlayer();
+        
+        // Check if player is in creative selection mode
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            // Cancel the hand swap event
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Prevent players from changing gamemode while in creative selection mode
+     * and enforce creative mode if they're in the selection process
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onGameModeChange(PlayerGameModeChangeEvent event) {
+        Player player = event.getPlayer();
+        
+        // Check if player is in creative selection mode
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            // If they're trying to change to anything but creative mode, cancel it
+            if (event.getNewGameMode() != GameMode.CREATIVE) {
+                event.setCancelled(true);
+                
+                // Force them back to creative mode to be sure
+                player.setGameMode(GameMode.CREATIVE);
+            }
+        }
+    }
+
+    /**
+     * Prevent players from switching items in their hotbar during creative selection
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onItemHeldChange(PlayerItemHeldEvent event) {
+        Player player = event.getPlayer();
+        
+        // Check if player is in creative selection mode
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            // Cancel the hotbar slot change
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Prevent players from interacting with entities during creative selection
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+        Player player = event.getPlayer();
+        
+        // Check if player is in creative selection mode
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            // Cancel all entity interactions
+            event.setCancelled(true);
+        }
+    }
+    
+    /**
+     * Prevent players from interacting with entities at specific positions
+     * during creative selection (more specific entity interaction)
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerInteractAtEntity(PlayerInteractAtEntityEvent event) {
+        Player player = event.getPlayer();
+        
+        // Check if player is in creative selection mode
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            // Cancel all specific entity interactions
+            event.setCancelled(true);
+        }
+    }
+    
+    /**
+     * Prevent players from picking up items during creative selection
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onEntityPickupItem(EntityPickupItemEvent event) {
+        if (!(event.getEntity() instanceof Player)) {
+            return;
+        }
+        
+        Player player = (Player) event.getEntity();
+        
+        // Check if player is in creative selection mode
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            // Cancel all item pickups
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * If a player dies during creative selection, ensure their state is properly restored
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        
+        // Check if player is in creative selection mode
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            // Make sure we restore the player's state correctly
+            PlayerData data = playerDataMap.get(player.getUniqueId());
+            
+            // We're going to handle the player data restoration during respawn
+            // so we store the UUID in case they disconnect
+            plugin.getLogger().log(Level.WARNING, 
+                "Player " + player.getName() + " died during creative selection. " +
+                "Their gamemode will be restored on respawn.");
+        }
+    }
+    
+    /**
+     * When a player respawns after dying in creative selection mode, ensure their state is restored
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerRespawn(PlayerRespawnEvent event) {
+        Player player = event.getPlayer();
+        
+        // Check if player is in creative selection mode
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            // Restore the player's original gamemode and state
+            boolean removed = removePlayerFromCreativeSelection(player);
+            if (removed) {
+                player.updateInventory();
+                plugin.getLogger().log(Level.INFO, 
+                    "Player " + player.getName() + "'s gamemode restored after death during creative selection.");
+            }
+        }
+    }
+
+    /**
+     * Prevent players from toggling flight while in creative selection mode
+     */
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerToggleFlight(PlayerToggleFlightEvent event) {
+        Player player = event.getPlayer();
+        
+        // Check if player is in creative selection mode
+        if (playerDataMap.containsKey(player.getUniqueId())) {
+            // Cancel the flight toggle event
+            event.setCancelled(true);
+        }
+    }
+
+    /**
+     * Public method to check if a player is currently in creative selection mode
+     * This can be used by other listeners to prevent unnecessary operations
+     * 
+     * @param player The player to check
+     * @return true if the player is in creative selection mode, false otherwise
+     */
+    public boolean isPlayerInCreativeSelection(Player player) {
+        if (player == null) {
+            return false;
+        }
+        return playerDataMap.containsKey(player.getUniqueId());
+    }
+    
+    /**
+     * Public method to check if a player UUID is currently in creative selection mode
+     * 
+     * @param playerUuid The UUID of the player to check
+     * @return true if the player is in creative selection mode, false otherwise
+     */
+    public boolean isPlayerInCreativeSelection(UUID playerUuid) {
+        if (playerUuid == null) {
+            return false;
+        }
+        return playerDataMap.containsKey(playerUuid);
     }
 }

--- a/core/src/main/java/com/snowgears/shop/listener/CreativeSelectionListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/CreativeSelectionListener.java
@@ -158,22 +158,20 @@ public class CreativeSelectionListener implements Listener {
             throw new RuntimeException(e);
         }
         //for some reason this event is also called now on PlayerQuitEvent. Check that player didnt quit
-        plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
-            public void run() {
-                Player player = plugin.getServer().getPlayer(event.getPlayer().getUniqueId());
-                if(player != null) {
-                    boolean removed = removePlayerFromCreativeSelection(player);
-                    if (removed) {
-                        player.updateInventory();
-                    }
-                    // Check if we have a chat shop creation in process, and cancel it
-                    ShopCreationProcess process = plugin.getMiscListener().getShopCreationProcess(player);
-                    // If we are in the ITEM/BARTER_ITEM selection stage, then cancel the shop chat creation process!
-                    if (process != null && (process.getStep() == ITEM || process.getStep() == BARTER_ITEM))
-                        plugin.getMiscListener().cancelShopCreationProcess(player);
+        plugin.getFoliaLib().getScheduler().runLater(() -> {
+            Player player = plugin.getServer().getPlayer(event.getPlayer().getUniqueId());
+            if(player != null) {
+                boolean removed = removePlayerFromCreativeSelection(player);
+                if (removed) {
+                    player.updateInventory();
                 }
+                // Check if we have a chat shop creation in process, and cancel it
+                ShopCreationProcess process = plugin.getMiscListener().getShopCreationProcess(player);
+                // If we are in the ITEM/BARTER_ITEM selection stage, then cancel the shop chat creation process!
+                if (process != null && (process.getStep() == ITEM || process.getStep() == BARTER_ITEM))
+                    plugin.getMiscListener().cancelShopCreationProcess(player);
             }
-        }, 10L); //0.5 second
+        }, 10); //0.5 second
     }
 
     @EventHandler
@@ -319,14 +317,11 @@ public class CreativeSelectionListener implements Listener {
     @EventHandler
     public void onLogin(PlayerLoginEvent event){
         final Player player = event.getPlayer();
-        Bukkit.getScheduler().scheduleSyncDelayedTask(Shop.getPlugin(), new Runnable() {
-            @Override
-            public void run() {
-                PlayerData data = PlayerData.loadFromFile(player);
-                if(data != null){
-                    playerDataMap.remove(player.getUniqueId());
-                    data.apply();
-                }
+        Shop.getPlugin().getFoliaLib().getScheduler().runLater(() -> {
+            PlayerData data = PlayerData.loadFromFile(player);
+            if(data != null){
+                playerDataMap.remove(player.getUniqueId());
+                data.apply();
             }
         }, 20);
     }

--- a/core/src/main/java/com/snowgears/shop/listener/DisplayListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/DisplayListener.java
@@ -53,10 +53,12 @@ public class DisplayListener implements Listener {
                             }
                         } catch (IllegalStateException e) {
                             //do nothing, the block iterator missed a block for a player
+                        } catch (Exception e) {
+                            //do nothing, the block iterator missed a block for a player
                         }
                     }
                 }
-            }, 0, 15);
+            }, 1, 15);
         }
 
         // Run shop displays processing every 100 ticks (5 seconds)
@@ -66,7 +68,7 @@ public class DisplayListener implements Listener {
                     plugin.getShopHandler().processShopDisplaysNearPlayer(player);
                 }
             }
-        }, 0, 20);
+        }, 1, 20);
     }
 
     public DisplayListener(Shop instance) {

--- a/core/src/main/java/com/snowgears/shop/listener/DisplayListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/DisplayListener.java
@@ -66,7 +66,7 @@ public class DisplayListener implements Listener {
                     plugin.getShopHandler().processShopDisplaysNearPlayer(player);
                 }
             }
-        }, 0, 100);
+        }, 0, 20);
     }
 
     public DisplayListener(Shop instance) {

--- a/core/src/main/java/com/snowgears/shop/listener/DisplayListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/DisplayListener.java
@@ -27,77 +27,64 @@ import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.scheduler.BukkitRunnable;
-
 import java.util.*;
+import com.tcoded.folialib.wrapper.task.WrappedTask;
 
 public class DisplayListener implements Listener {
 
     public Shop plugin;
     private ArrayList<ItemStack> allServerRecipeResults = new ArrayList<>();
-    private int repeatingViewTask;
-    private int repeatingDisplayTask;
+    private WrappedTask repeatingViewTask;
+    private WrappedTask repeatingDisplayTask;
 
     public void startRepeatingDisplayViewTask() {
         if (plugin.getDisplayTagOption() == DisplayTagOption.VIEW_SIGN) {
             //run task every 15 ticks
-            repeatingViewTask = Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
+            repeatingViewTask = plugin.getFoliaLib().getScheduler().runTimer(() -> {
                 for (Player player : plugin.getServer().getOnlinePlayers()) {
                     if (player != null) {
-                            try {
-                                Block block = player.getTargetBlockExact(8);
-                                if (block != null && block.getBlockData() instanceof WallSign) {
-                                    AbstractShop shopObj = plugin.getShopHandler().getShop(block.getLocation());
-                                    if (shopObj != null) {
-                                        shopObj.getDisplay().showDisplayTags(player);
-                                    }
+                        try {
+                            Block block = player.getTargetBlockExact(8);
+                            if (block != null && block.getBlockData() instanceof WallSign) {
+                                AbstractShop shopObj = plugin.getShopHandler().getShop(block.getLocation());
+                                if (shopObj != null) {
+                                    shopObj.getDisplay().showDisplayTags(player);
                                 }
-                            } catch (IllegalStateException e) {
-                                //do nothing, the block iterator missed a block for a player
                             }
+                        } catch (IllegalStateException e) {
+                            //do nothing, the block iterator missed a block for a player
                         }
+                    }
                 }
             }, 0, 15);
         }
 
-        BukkitRunnable runnable = (new BukkitRunnable() {
-            @Override
-            public void run() {
-                for (Player player : plugin.getServer().getOnlinePlayers()) {
-                    if (player != null && player.isOnline()) {
-                        plugin.getShopHandler().processShopDisplaysNearPlayer(player);
-                    }
+        // Run shop displays processing every 100 ticks (5 seconds)
+        repeatingDisplayTask = plugin.getFoliaLib().getScheduler().runTimerAsync(() -> {
+            for (Player player : plugin.getServer().getOnlinePlayers()) {
+                if (player != null && player.isOnline()) {
+                    plugin.getShopHandler().processShopDisplaysNearPlayer(player);
                 }
             }
-        });
-        repeatingDisplayTask = runnable.runTaskTimerAsynchronously(plugin, 0L, 100L).getTaskId();
-        //run task every 100 ticks (5 seconds)
-//        repeatingDisplayTask = Bukkit.getServer().getScheduler().scheduleSyncRepeatingTask(plugin, () -> {
-//            for (Player player : plugin.getServer().getOnlinePlayers()) {
-//                if (player != null) {
-//                    plugin.getShopHandler().processShopDisplaysNearPlayer(player);
-//                }
-//            }
-//        }, 0, 100);
+        }, 0, 100);
     }
 
     public DisplayListener(Shop instance) {
         plugin = instance;
 
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                HashMap<ItemStack, Boolean> recipes = new HashMap();
-                Iterator<Recipe> recipeIterator = plugin.getServer().recipeIterator();
-                while(recipeIterator.hasNext()) {
-                    ItemStack result = recipeIterator.next().getResult();
-                    //System.out.println("[Shop] adding recipe for gamble. "+result.getType().toString()+" (x"+result.getAmount()+")");
-                    if(result.getAmount() != 0)
-                        recipes.put(result, true);
-                }
-                allServerRecipeResults.addAll(recipes.keySet());
-                Collections.shuffle(allServerRecipeResults);
+        // Load all recipes on server once all other plugins are loaded
+        plugin.getFoliaLib().getScheduler().runLater(task -> {
+            HashMap<ItemStack, Boolean> recipes = new HashMap();
+            Iterator<Recipe> recipeIterator = plugin.getServer().recipeIterator();
+            while(recipeIterator.hasNext()) {
+                ItemStack result = recipeIterator.next().getResult();
+                //System.out.println("[Shop] adding recipe for gamble. "+result.getType().toString()+" (x"+result.getAmount()+")");
+                if(result.getAmount() != 0)
+                    recipes.put(result, true);
             }
-        }.runTaskLater(this.plugin, 1); //load all recipes on server once all other plugins are loaded
+            allServerRecipeResults.addAll(recipes.keySet());
+            Collections.shuffle(allServerRecipeResults);
+        }, 1);
     }
 
     public ItemStack getRandomItem(AbstractShop shop){
@@ -218,7 +205,11 @@ public class DisplayListener implements Listener {
     }
 
     public void cancelRepeatingViewTask(){
-        Bukkit.getScheduler().cancelTask(repeatingViewTask);
-        Bukkit.getScheduler().cancelTask(repeatingDisplayTask);
+        if (repeatingViewTask != null) {
+            plugin.getFoliaLib().getScheduler().cancelTask(repeatingViewTask);
+        }
+        if (repeatingDisplayTask != null) {
+            plugin.getFoliaLib().getScheduler().cancelTask(repeatingDisplayTask);
+        }
     }
 }

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -290,8 +290,10 @@ public class MiscListener implements Listener {
                                 return;
                             }
 
-                            if(!plugin.getShopCreationUtil().shopCanBeCreated(player, clicked))
+                            if(!plugin.getShopCreationUtil().shopCanBeCreated(player, clicked)){
+                                event.setCancelled(true);
                                 return;
+                            }
                             BlockFace signFacing = plugin.getShopCreationUtil().calculateBlockFaceForSign(player, clicked, event.getBlockFace());
                             if(signFacing == null) {
                                 event.setCancelled(true);
@@ -351,8 +353,10 @@ public class MiscListener implements Listener {
                     return;
                 }
 
-                if(!plugin.getShopCreationUtil().shopCanBeCreated(player, clicked))
+                if(!plugin.getShopCreationUtil().shopCanBeCreated(player, clicked)){
+                    event.setCancelled(true);
                     return;
+                }
 
                 event.setCancelled(true);
                 BlockFace signFacing = plugin.getShopCreationUtil().calculateBlockFaceForSign(player, clicked, event.getBlockFace());

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -396,6 +396,7 @@ public class MiscListener implements Listener {
         Player player = event.getPlayer();
         if(playerChatCreationSteps.containsKey(player.getUniqueId())){
             ShopCreationProcess process = playerChatCreationSteps.get(player.getUniqueId());
+            plugin.getLogger().debug("Shop Creation Process: " + process.getStep() + " Player " + player.getName() + " input: " + event.getMessage(), true);
             switch (process.getStep()){
                 case SHOP_TYPE:
                     ShopType type = plugin.getShopCreationUtil().getShopType(event.getMessage());

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -166,24 +166,22 @@ public class MiscListener implements Listener {
                 }
 
                 //give player a limited amount of time to finish creating the shop until it is deleted
-                plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
-                    public void run() {
-                        //the shop has still not been initialized with an item from a player
-                        if (!shop.isInitialized()) {
-                            plugin.getShopHandler().removeShop(shop);
-                            if (b.getBlockData() instanceof WallSign) {
-                                String[] lines = ShopMessage.getTimeoutSignLines(shop);
-                                Sign sign = (Sign) b.getState();
-                                sign.setLine(0, lines[0]);
-                                sign.setLine(1, lines[1]);
-                                sign.setLine(2, lines[2]);
-                                sign.setLine(3, lines[3]);
-                                sign.update(true);
-                                cancelShopCreationProcess(player);
-                            }
+                plugin.getFoliaLib().getScheduler().runLater(() -> {
+                    //the shop has still not been initialized with an item from a player
+                    if (!shop.isInitialized()) {
+                        plugin.getShopHandler().removeShop(shop);
+                        if (b.getBlockData() instanceof WallSign) {
+                            String[] lines = ShopMessage.getTimeoutSignLines(shop);
+                            Sign sign = (Sign) b.getState();
+                            sign.setLine(0, lines[0]);
+                            sign.setLine(1, lines[1]);
+                            sign.setLine(2, lines[2]);
+                            sign.setLine(3, lines[3]);
+                            sign.update(true);
+                            cancelShopCreationProcess(player);
                         }
                     }
-                }, 30 * 20); //30 seconds * 20 ticks
+                }, 30 * 20); // 30 seconds * 20 ticks
             }
         }
     }
@@ -379,16 +377,14 @@ public class MiscListener implements Listener {
 
                 //give player a limited amount of time to finish creating the shop until it is deleted
                 final UUID originalProcessUUID = process.getUniqueID();
-                plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
-                    public void run() {
-                        //the shop has still not been initialized with an item from a player
-                        ShopCreationProcess process = playerChatCreationSteps.get(player.getUniqueId());
-                        if (process != null && process.getUniqueID().equals(originalProcessUUID)) {
-                            process.cleanup();
-                            playerChatCreationSteps.remove(player.getUniqueId());
-                            plugin.getCreativeSelectionListener().removePlayerFromCreativeSelection(player);
-                            ShopMessage.sendMessage("interactionIssue", "createHitChestTimeout", process, player);
-                        }
+                plugin.getFoliaLib().getScheduler().runLater(() -> {
+                    //the shop has still not been initialized with an item from a player
+                    ShopCreationProcess currentProcess = playerChatCreationSteps.get(player.getUniqueId());
+                    if (currentProcess != null && currentProcess.getUniqueID().equals(originalProcessUUID)) {
+                        currentProcess.cleanup();
+                        playerChatCreationSteps.remove(player.getUniqueId());
+                        plugin.getCreativeSelectionListener().removePlayerFromCreativeSelection(player);
+                        ShopMessage.sendMessage("interactionIssue", "createHitChestTimeout", currentProcess, player);
                     }
                 }, 30 * 20); // 30 seconds * 20 ticks
             }

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -370,7 +370,9 @@ public class MiscListener implements Listener {
                 process.displayFloatingText("createHitChest", null);
                 List<String> autocomplete = new ArrayList<>();
                 Arrays.asList(ShopType.values()).forEach((shopType -> autocomplete.add(shopType.toString().toLowerCase())));
-                player.setCustomChatCompletions(autocomplete);
+                try {
+                    player.setCustomChatCompletions(autocomplete);
+                } catch (Error error) {} // Suppress error if autocomplete is not supported
                 if((!plugin.usePerms() && player.isOp()) || (plugin.usePerms() && player.hasPermission("shop.operator"))) {
                     ShopMessage.sendMessage("adminCreateHitChest", null, process, player);
                 }

--- a/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
@@ -31,6 +31,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.permissions.PermissionAttachmentInfo;
 import org.bukkit.scheduler.BukkitRunnable;
+import com.tcoded.folialib.wrapper.task.WrappedTask;
 
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -378,7 +379,7 @@ public class ShopListener implements Listener {
         //setup a repeating task that checks if async sql calculations are still running, if they are done, send messages and cancel task
         OfflineTransactions offlineTransactions = transactionsWhileOffline.get(player.getUniqueId());
         if(offlineTransactions != null) {
-            new BukkitRunnable() {
+            BukkitRunnable runnable = new BukkitRunnable() {
                 public void run() {
                     if (transactionsWhileOffline.containsKey(player.getUniqueId())) {
                         if (offlineTransactions != null && !offlineTransactions.isCalculating()) {
@@ -390,11 +391,15 @@ public class ShopListener implements Listener {
                                 }
                             }
                             transactionsWhileOffline.remove(player.getUniqueId());
-                            this.cancel();
                         }
                     }
                 }
-            }.runTaskTimer(plugin, 10L, 2L);
+            };
+            WrappedTask task = plugin.getFoliaLib().getScheduler().runTimer(runnable, 1, 20);
+            // Let it attempt to run for 5 seconds before cancelling
+            plugin.getFoliaLib().getScheduler().runLater(() -> {
+                plugin.getFoliaLib().getScheduler().cancelTask(task);
+            }, 100);
         }
     }
 

--- a/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
@@ -50,11 +50,9 @@ public class ShopListener implements Listener {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event){
-        plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
-            public void run() {
-                recalculateShopPerms(event.getPlayer());
-            }
-        }, 5L);
+        plugin.getFoliaLib().getScheduler().runLater(() -> {
+            recalculateShopPerms(event.getPlayer());
+        }, 5);
     }
 
     public void recalculateShopPerms(Player player){
@@ -360,23 +358,21 @@ public class ShopListener implements Listener {
 
         //final Inventory inv = plugin.getEnderChestHandler().getInventory(player);
 
-        plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
-            public void run() {
-                if(plugin.getCurrencyType() == CurrencyType.EXPERIENCE) {
-                    PlayerExperience exp = PlayerExperience.loadFromFile(player);
-                    if(exp != null){
-                        exp.apply();
-                    }
+        plugin.getFoliaLib().getScheduler().runLater(() -> {
+            if(plugin.getCurrencyType() == CurrencyType.EXPERIENCE) {
+                PlayerExperience exp = PlayerExperience.loadFromFile(player);
+                if(exp != null){
+                    exp.apply();
                 }
+            }
 //                if(plugin.useEnderChests() && inv != null){
 //                    player.getEnderChest().setContents(inv.getContents());
 //                    plugin.getEnderChestHandler().saveInventory(player, inv);
 //                }
 
-                plugin.getShopHandler().clearShopDisplaysNearPlayer(player);
-                plugin.getShopHandler().processShopDisplaysNearPlayer(player);
-            }
-        }, 2L);
+            plugin.getShopHandler().clearShopDisplaysNearPlayer(player);
+            plugin.getShopHandler().processShopDisplaysNearPlayer(player);
+        }, 2);
 
 
         //setup a repeating task that checks if async sql calculations are still running, if they are done, send messages and cancel task
@@ -426,11 +422,9 @@ public class ShopListener implements Listener {
     public void onTeleport(PlayerTeleportEvent event){
         plugin.getShopHandler().processShopDisplaysNearPlayer(event.getPlayer());
         //if(!event.getTo().getWorld().getUID().equals(event.getFrom().getWorld().getUID())) {
-            plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
-                public void run() {
-                    plugin.getShopHandler().processShopDisplaysNearPlayer(event.getPlayer());
-                }
-            }, 5L);
+            plugin.getFoliaLib().getScheduler().runLater(() -> {
+                plugin.getShopHandler().processShopDisplaysNearPlayer(event.getPlayer());
+            }, 5);
         //}
     }
 

--- a/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
@@ -416,9 +416,14 @@ public class ShopListener implements Listener {
 
     @EventHandler
     public void onLogout(PlayerQuitEvent event){
+        Player player = event.getPlayer();
+        
+        // Clear shop displays and connection cache for this player
+        plugin.getShopHandler().clearShopDisplaysNearPlayer(player);
+        
         if(plugin.getCurrencyType() == CurrencyType.EXPERIENCE) {
             //this automatically saves to file
-            new PlayerExperience(event.getPlayer());
+            new PlayerExperience(player);
         }
     }
 

--- a/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
@@ -3,6 +3,7 @@ package com.snowgears.shop.listener;
 import com.snowgears.shop.Shop;
 import com.snowgears.shop.display.DisplayTagOption;
 import com.snowgears.shop.hook.WorldGuardHook;
+import com.snowgears.shop.listener.CreativeSelectionListener;
 import com.snowgears.shop.shop.AbstractShop;
 import com.snowgears.shop.shop.ShopType;
 import com.snowgears.shop.util.*;
@@ -425,6 +426,13 @@ public class ShopListener implements Listener {
     public void onTeleport(PlayerTeleportEvent event){
         final Player player = event.getPlayer();
         
+        // Skip shop display processing if player is in creative selection mode
+        CreativeSelectionListener creativeModeListener = plugin.getCreativeSelectionListener();
+        if (creativeModeListener != null && creativeModeListener.isPlayerInCreativeSelection(player)) {
+            plugin.getLogger().debug("Skipping shop display refresh for " + player.getName() + " (in creative selection)");
+            return;
+        }
+        
         // Immediate attempt right after teleport
         plugin.getShopHandler().forceProcessShopDisplaysNearPlayer(player);
         
@@ -432,6 +440,11 @@ public class ShopListener implements Listener {
         // First delayed attempt - wait for chunks to load
         plugin.getFoliaLib().getScheduler().runLater(() -> {
             if (player.isOnline()) {
+                // Check again inside the delayed task in case player entered selection during the delay
+                if (creativeModeListener != null && creativeModeListener.isPlayerInCreativeSelection(player)) {
+                    plugin.getLogger().debug("Skipping delayed shop display refresh for " + player.getName() + " (in creative selection)");
+                    return;
+                }
                 plugin.getLogger().debug("First display refresh for " + player.getName() + " after teleport");
                 plugin.getShopHandler().forceProcessShopDisplaysNearPlayer(player);
             }
@@ -440,6 +453,11 @@ public class ShopListener implements Listener {
         // Second attempt - for completeness
         plugin.getFoliaLib().getScheduler().runLater(() -> {
             if (player.isOnline()) {
+                // Check again inside the delayed task in case player entered selection during the delay
+                if (creativeModeListener != null && creativeModeListener.isPlayerInCreativeSelection(player)) {
+                    plugin.getLogger().debug("Skipping delayed shop display refresh for " + player.getName() + " (in creative selection)");
+                    return;
+                }
                 plugin.getLogger().debug("Second display refresh for " + player.getName() + " after teleport");
                 plugin.getShopHandler().forceProcessShopDisplaysNearPlayer(player);
             }

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -543,6 +543,9 @@ public abstract class AbstractShop {
 
                 signBlock.update(true);
                 signLinesRequireRefresh = false;
+
+                // Update the floating holograms for anybody who currently has them open
+                display.updateDisplayTags();
             }
         }, 2L);
     }

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -505,49 +505,48 @@ public abstract class AbstractShop {
 
         signLines = ShopMessage.getSignLines(this, this.type);
 
-        Shop.getPlugin().getServer().getScheduler().scheduleSyncDelayedTask(Shop.getPlugin(), new Runnable() {
-            public void run() {
-                // Update the GUI Icon since the sign needs an update.
-                refreshGuiIcon();
+        // Use the sign's location to ensure the update runs in the correct region in Folia
+        Shop.getPlugin().getFoliaLib().getScheduler().runAtLocationLater(signLocation, task -> {
+            // Update the GUI Icon since the sign needs an update.
+            refreshGuiIcon();
 
-                Sign signBlock;
-                try {
-                    signBlock = (Sign) signLocation.getBlock().getState();
-                } catch (ClassCastException e){
-                    Shop.getPlugin().getShopHandler().removeShop(AbstractShop.this);
-                    return;
-                }
-
-                String[] lines = signLines.clone();
-
-                if (!isInitialized()) {
-                    signBlock.setLine(0, ChatColor.RED + ChatColor.stripColor(lines[0]));
-                    signBlock.setLine(1, ChatColor.RED + ChatColor.stripColor(lines[1]));
-                    signBlock.setLine(2, ChatColor.RED + ChatColor.stripColor(lines[2]));
-                    signBlock.setLine(3, ChatColor.RED + ChatColor.stripColor(lines[3]));
-                } else {
-                    signBlock.setLine(0, lines[0]);
-                    signBlock.setLine(1, lines[1]);
-                    signBlock.setLine(2, lines[2]);
-                    signBlock.setLine(3, lines[3]);
-                }
-
-                if(isMCVersion17Plus()) {
-                    if (Shop.getPlugin().getGlowingSignText()) {
-                        signBlock.setGlowingText(true);
-                    }
-                    else{
-                        signBlock.setGlowingText(false);
-                    }
-                }
-
-                signBlock.update(true);
-                signLinesRequireRefresh = false;
-
-                // Update the floating holograms for anybody who currently has them open
-                display.updateDisplayTags();
+            Sign signBlock;
+            try {
+                signBlock = (Sign) signLocation.getBlock().getState();
+            } catch (ClassCastException e){
+                Shop.getPlugin().getShopHandler().removeShop(AbstractShop.this);
+                return;
             }
-        }, 2L);
+
+            String[] lines = signLines.clone();
+
+            if (!isInitialized()) {
+                signBlock.setLine(0, ChatColor.RED + ChatColor.stripColor(lines[0]));
+                signBlock.setLine(1, ChatColor.RED + ChatColor.stripColor(lines[1]));
+                signBlock.setLine(2, ChatColor.RED + ChatColor.stripColor(lines[2]));
+                signBlock.setLine(3, ChatColor.RED + ChatColor.stripColor(lines[3]));
+            } else {
+                signBlock.setLine(0, lines[0]);
+                signBlock.setLine(1, lines[1]);
+                signBlock.setLine(2, lines[2]);
+                signBlock.setLine(3, lines[3]);
+            }
+
+            if(isMCVersion17Plus()) {
+                if (Shop.getPlugin().getGlowingSignText()) {
+                    signBlock.setGlowingText(true);
+                }
+                else{
+                    signBlock.setGlowingText(false);
+                }
+            }
+
+            signBlock.update(true);
+            signLinesRequireRefresh = false;
+
+            // Update the floating holograms for anybody who currently has them open
+            display.updateDisplayTags();
+        }, 2);
     }
 
     public void delete() {

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -408,25 +408,35 @@ public abstract class AbstractShop {
     }
 
     public ItemStack removeZeroDamageMeta(ItemStack item) {
-        // In the past we used to explicitly set the durability of an item to be 0, this caused blocks/items to be saved
-        // with extra NBT data that we don't actually want. For example, dirt shouldn't have a damage of 0.
-        // Detect if we set it to 0, and if so, remove it from the ItemMeta!
-        if (item.getItemMeta() instanceof Damageable && ((Damageable) item.getItemMeta()).getDamage() == 0) {
-            String components = item.getItemMeta().getAsComponentString(); // example: "[minecraft:damage=53]"
+        try {
+            // In the past we used to explicitly set the durability of an item to be 0, this caused blocks/items to be saved
+            // with extra NBT data that we don't actually want. For example, dirt shouldn't have a damage of 0.
+            // Detect if we set it to 0, and if so, remove it from the ItemMeta!
+            if (item.getItemMeta() instanceof Damageable && ((Damageable) item.getItemMeta()).getDamage() == 0) {
+                String components = item.getItemMeta().getAsComponentString(); // example: "[minecraft:damage=53]"
 
-            // Remove it from the array
-            components = components.replace(",minecraft:damage=0", ""); // Middle of an array
-            components = components.replace("minecraft:damage=0,", ""); // Start of an array
-            components = components.replace("minecraft:damage=0", ""); // Only object in array
+                // Remove it from the array
+                components = components.replace(",minecraft:damage=0", ""); // Middle of an array
+                components = components.replace("minecraft:damage=0,", ""); // Start of an array
+                components = components.replace("minecraft:damage=0", ""); // Only object in array
 
-            // Convert it back into an item
-            String itemTypeKey = item.getType().getKey().toString(); // example: "minecraft:diamond_sword"
-            String itemAsString = itemTypeKey + components; // results in: "minecraft:diamond_sword[minecraft:damage=53]"
-            return Bukkit.getItemFactory().createItemStack(itemAsString);
+                // Convert it back into an item
+                String itemTypeKey = item.getType().getKey().toString(); // example: "minecraft:diamond_sword"
+                String itemAsString = itemTypeKey + components; // results in: "minecraft:diamond_sword[minecraft:damage=53]"
+                return Bukkit.getItemFactory().createItemStack(itemAsString);
+            }
+
+            // Default return original item
+            return item;
+        } catch (Exception e) {
+            Shop.getPlugin().getLogger().warning("Error removing zero damage meta from item: " + item);
+            Shop.getPlugin().getLogger().warning("checkItemDurability feature may be unsupported on your version of Paper/Spigot!");
+            return item;
+        } catch (Error e) {
+            Shop.getPlugin().getLogger().warning("Error removing zero damage meta from item: " + item);
+            Shop.getPlugin().getLogger().warning("checkItemDurability feature may be unsupported on your version of Paper/Spigot!");
+            return item;
         }
-
-        // Default return original item
-        return item;
     }
 
     public void setOwner(UUID newOwner){

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -545,7 +545,7 @@ public abstract class AbstractShop {
             signLinesRequireRefresh = false;
 
             // Update the floating holograms for anybody who currently has them open
-            display.updateDisplayTags();
+            if (display != null) display.updateDisplayTags();
         }, 2);
     }
 

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -397,10 +397,14 @@ public abstract class AbstractShop {
 
         // Remove "0 Damage" from item meta (old config bug)
         this.item = this.removeZeroDamageMeta(is.clone());
+        this.signLinesRequireRefresh = true;
+        this.calculateStock();
     }
 
     public void setSecondaryItemStack(ItemStack is) {
         this.secondaryItem = this.removeZeroDamageMeta(is.clone());
+        this.signLinesRequireRefresh = true;
+        this.calculateStock();
     }
 
     public ItemStack removeZeroDamageMeta(ItemStack item) {

--- a/core/src/main/java/com/snowgears/shop/shop/ComboShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/ComboShop.java
@@ -39,6 +39,10 @@ public class ComboShop extends AbstractShop {
         return Shop.getPlugin().getPriceComboString(this.price, this.priceSell, false);
     }
 
+    public double getPriceBuy(){
+        return priceBuy;
+    }
+
     public double getPriceSell(){
         return priceSell;
     }

--- a/core/src/main/java/com/snowgears/shop/shop/GambleShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/GambleShop.java
@@ -9,7 +9,6 @@ import org.bukkit.Location;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.UUID;
 
@@ -42,21 +41,18 @@ public class GambleShop extends AbstractShop {
         setGambleItem();
         this.getDisplay().spawn(player);
 
-        new BukkitRunnable() {
-            @Override
-            public void run() {
-                setItemStack(Shop.getPlugin().getGambleDisplayItem());
-                if(initialDisplayType == null) {
-                    display.setType(Shop.getPlugin().getDisplayType(), false);
-                    getDisplay().spawn(player);
-                }
-                else {
-                    display.setType(initialDisplayType, false);
-                    getDisplay().spawn(player);
-                }
-                isPerformingTransaction = false;
+        Shop.getPlugin().getFoliaLib().getScheduler().runLater(() -> {
+            setItemStack(Shop.getPlugin().getGambleDisplayItem());
+            if(initialDisplayType == null) {
+                display.setType(Shop.getPlugin().getDisplayType(), false);
+                getDisplay().spawn(player);
             }
-        }.runTaskLater(Shop.getPlugin(), 20);
+            else {
+                display.setType(initialDisplayType, false);
+                getDisplay().spawn(player);
+            }
+            isPerformingTransaction = false;
+        }, 20);
     }
 
     public void setGambleItem(){

--- a/core/src/main/java/com/snowgears/shop/util/ItemNameUtil.java
+++ b/core/src/main/java/com/snowgears/shop/util/ItemNameUtil.java
@@ -67,6 +67,17 @@ public class ItemNameUtil {
             }
         }
 
+        // Add custom potion formatting
+        if(item.getItemMeta() != null && item.getItemMeta() instanceof PotionMeta){
+            PotionMeta potionMeta = (PotionMeta) item.getItemMeta();
+            if (potionMeta.getBasePotionType() != null) {
+                String formattedName = UtilMethods.capitalize(item.getType().name().replace("_", " ").toLowerCase());
+                formattedName += " of ";
+                formattedName += UtilMethods.capitalize(potionMeta.getBasePotionType().toString().replace("_", " ").toLowerCase());
+                return new TextComponent(formattedName);
+            }
+        }
+
         // Fallback to the material name
         return getNameTranslatable(item.getType());
     }

--- a/core/src/main/java/com/snowgears/shop/util/ItemNameUtil.java
+++ b/core/src/main/java/com/snowgears/shop/util/ItemNameUtil.java
@@ -10,6 +10,7 @@ import org.bukkit.inventory.meta.ArmorMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.ChatColor;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -39,6 +40,30 @@ public class ItemNameUtil {
             SkullMeta skullMeta = (SkullMeta) item.getItemMeta();
             if (skullMeta.getOwningPlayer() != null) {
                 return new TextComponent(skullMeta.getOwnerProfile().getName() + "'s Head");
+            }
+        }
+
+        // Add support for displaying smithing template types
+        if(item.getItemMeta() != null) {
+            String itemType = item.getType().name();
+            if(itemType.endsWith("_SMITHING_TEMPLATE")) {
+                String templateType = itemType.replace("_SMITHING_TEMPLATE", "");
+                // Extract the template pattern name (e.g., "EYE" from "EYE_ARMOR_TRIM_SMITHING_TEMPLATE")
+                if(templateType.endsWith("_ARMOR_TRIM")) {
+                    ChatColor trimNameColor = ChatColor.YELLOW;
+                    // Aqua: "Vex", "Spire", "Eye" and "Ward"
+                    if (templateType.contains("VEX") || templateType.contains("SPIRE") || templateType.contains("EYE") || templateType.contains("WARD")) {
+                        trimNameColor = ChatColor.AQUA;
+                    } else if (templateType.contains("SILENCE")) {  trimNameColor = ChatColor.LIGHT_PURPLE; }
+                    String formattedName = UtilMethods.capitalize(templateType.toLowerCase().replace("_", " "));
+                    return new TextComponent(trimNameColor.toString() + formattedName);
+                } else if(templateType.equals("NETHERITE_UPGRADE")) {
+                    return new TextComponent(ChatColor.YELLOW.toString() + "Netherite Upgrade Template");
+                } else {
+                    // For any other potential smithing templates
+                    String formattedName = UtilMethods.capitalize(templateType.toLowerCase().replace("_", " "));
+                    return new TextComponent(ChatColor.YELLOW.toString() + formattedName);
+                }
             }
         }
 

--- a/core/src/main/java/com/snowgears/shop/util/ItemNameUtil.java
+++ b/core/src/main/java/com/snowgears/shop/util/ItemNameUtil.java
@@ -78,6 +78,15 @@ public class ItemNameUtil {
             }
         }
 
+        try {
+            // Ominous Bottle's are Yellow *shrug*
+            if (item.getItemMeta() != null && item.getItemMeta() instanceof org.bukkit.inventory.meta.OminousBottleMeta) {
+                TextComponent name = getNameTranslatable(item.getType());
+                name.setColor(net.md_5.bungee.api.ChatColor.YELLOW);
+                return name;
+            }
+        } catch (Exception e) {} catch (Error e) {} // Backwards compatibility
+
         // Fallback to the material name
         return getNameTranslatable(item.getType());
     }

--- a/core/src/main/java/com/snowgears/shop/util/NBTAdapter.java
+++ b/core/src/main/java/com/snowgears/shop/util/NBTAdapter.java
@@ -124,8 +124,6 @@ public class NBTAdapter {
             }
             plugin.getLogger().severe("[NBTAdapter] Please install the latest version of the NBTAPI plugin! https://www.spigotmc.org/resources/nbt-api.7939/");
             plugin.getLogger().severe("[NBTAdapter] Error message: " + message);
-        } else {
-            plugin.getLogger().severe("[NBTAdapter] Too many NBTAPI errors! Throttled logging! Please install the latest version of the NBTAPI plugin! https://www.spigotmc.org/resources/nbt-api.7939/");
         }
     }
 }

--- a/core/src/main/java/com/snowgears/shop/util/NMSBullshitHandler.java
+++ b/core/src/main/java/com/snowgears/shop/util/NMSBullshitHandler.java
@@ -30,11 +30,11 @@ public class NMSBullshitHandler {
 
     public void init() {
         String mcVersion = plugin.getServer().getClass().getPackage().getName();
-        Shop.getPlugin().getLogger().log(Level.FINE, "mcVersion: " + mcVersion);
+        Shop.getPlugin().getLogger().debug("mcVersion: " + mcVersion);
 
         // Check if we are on Paper 1.20.5 or later, it will not include the CB relocation version (i.e. "1_20_R3")
         if (!mcVersion.equals("org.bukkit.craftbukkit")) {
-            Shop.getPlugin().getLogger().log(Level.WARNING, "Minecraft version is old or Spigot, loaded version is: " + mcVersion);
+            Shop.getPlugin().getLogger().warning("Minecraft version is old or Spigot, loaded version is: " + mcVersion);
 
             String[] mcVersionSplit = mcVersion.replace(".", ",").split(",");
             // Convert mcVersion into a number like 120.4 (1_20_R4) or 121.1 (1_21_R1) so that we can use it later
@@ -42,8 +42,8 @@ public class NMSBullshitHandler {
         }
 
         // log the server version we are on, it will be 0 when we are on a Paper server
-        Shop.getPlugin().getLogger().log(Level.FINE, "Server Version: " + this.getServerVersion());
-        Shop.getPlugin().getLogger().log(Level.FINE, "Is Server Version over 117.0D: " + (Math.floor(this.getServerVersion()) >= 117.0D));
+        Shop.getPlugin().getLogger().debug("Server Version: " + this.getServerVersion());
+        Shop.getPlugin().getLogger().debug("Is Server Version over 117.0D: " + (Math.floor(this.getServerVersion()) >= 117.0D));
 
         try {
             this.craftItemStackClass = Class.forName(mcVersion + ".inventory.CraftItemStack");
@@ -55,13 +55,19 @@ public class NMSBullshitHandler {
 
                 // java.lang.ClassNotFoundException: net.minecraft.server.v1_17_R1.ItemStack
 
-                Shop.getPlugin().getLogger().spam("CraftItemStack: " + this.craftItemStackClass.toString());
-                Shop.getPlugin().getLogger().spam("CraftWorld: " + this.craftWorldClass.toString());
-                Shop.getPlugin().getLogger().spam("CraftPlayer: " + this.craftPlayerClass.toString());
+                Shop.getPlugin().getLogger().debug("CraftItemStack: " + this.craftItemStackClass.toString());
+                Shop.getPlugin().getLogger().debug("CraftWorld: " + this.craftWorldClass.toString());
+                Shop.getPlugin().getLogger().debug("CraftPlayer: " + this.craftPlayerClass.toString());
             }
         } catch (ClassNotFoundException e) {
+            Shop.getPlugin().getLogger().severe("Unable to retrieve a NMS class used for NBT data.");
             e.printStackTrace();
-            Shop.getPlugin().getLogger().log(Level.SEVERE, "Unable to retrieve a NMS class used for NBT data.");
+        } catch (Exception e) {
+            Shop.getPlugin().getLogger().severe("Unable to retrieve a NMS class used for NBT data.");
+            e.printStackTrace();
+        } catch (Error e) {
+            Shop.getPlugin().getLogger().severe("Unable to retrieve a NMS class used for NBT data.");
+            e.printStackTrace();
         }
     }
 

--- a/core/src/main/java/com/snowgears/shop/util/PriceNegotiator.java
+++ b/core/src/main/java/com/snowgears/shop/util/PriceNegotiator.java
@@ -302,7 +302,7 @@ public class PriceNegotiator {
         double minQty = Math.min(buyerMaxQtyPurchase, sellerMaxQtySale);
         
         // Special case for fractional payments: don't floor to zero if there's a valid partial purchase
-        if (supportsFractionalPayments && minQty > 0 && minQty < 1) {
+        if (supportsFractionalPayments && minQty > 0) {
             return minQty; // Keep the fractional quantity when fractional payments are enabled
         }
         

--- a/core/src/main/java/com/snowgears/shop/util/PriceNegotiator.java
+++ b/core/src/main/java/com/snowgears/shop/util/PriceNegotiator.java
@@ -299,7 +299,14 @@ public class PriceNegotiator {
         double sellerMaxQtySale = sellerInventoryQuantity / itemsPerPrice;
 
         // The maximum qty that we can buy/sell with our available funds
-        return Math.floor(Math.min(buyerMaxQtyPurchase, sellerMaxQtySale) + ROUNDING_ERROR_MARGIN);
+        double minQty = Math.min(buyerMaxQtyPurchase, sellerMaxQtySale);
+        
+        // Special case for fractional payments: don't floor to zero if there's a valid partial purchase
+        if (supportsFractionalPayments && minQty > 0 && minQty < 1) {
+            return minQty; // Keep the fractional quantity when fractional payments are enabled
+        }
+        
+        return Math.floor(minQty + ROUNDING_ERROR_MARGIN);
     }
     
     /**

--- a/core/src/main/java/com/snowgears/shop/util/PriceNegotiator.java
+++ b/core/src/main/java/com/snowgears/shop/util/PriceNegotiator.java
@@ -21,20 +21,29 @@ import java.math.RoundingMode;
  * are calculated the same way in both modes to ensure consistent behavior.
  */
 public class PriceNegotiator {
-    boolean TX_DEBUG_LOGGING = false;
-    
-    // Constant for price precision (cents)
+    // Constants for price calculations and validations
     private static final int PRICE_PRECISION = 2;
+    private static final double MINIMUM_VALID_PRICE = 0.01;
+    private static final double EXTREMELY_LOW_PRICE_THRESHOLD = 0.00999;
+    private static final double ROUNDING_ERROR_MARGIN = 1e-5;
+    private static final double DEFAULT_ITEM_RATIO = 1.0;
+    private static final int NO_SPECIFIC_AMOUNT = -1;
+    private static final int PROPORTION_SCALE = 10;
     
-    // Flag to determine if fractional payments are supported
+    // Debug flag - should be private for encapsulation
+    private final boolean debugLogging;
+    
+    // Payment mode flag
     private final boolean supportsFractionalPayments;
 
-    double price = 0;
-    double originalPrice = 0;
-    double negotiatedPrice = -1;
-    int amountBeingSold = 0;
-    int originalAmountBeingSold = 0;
-    int negotiatedAmountBeingSold = -1;
+    // Transaction state
+    private double price = 0;
+    private double originalPrice = 0;
+    private double negotiatedPrice = NO_SPECIFIC_AMOUNT;
+    private int amountBeingSold = 0;
+    private int originalAmountBeingSold = 0;
+    private int negotiatedAmountBeingSold = NO_SPECIFIC_AMOUNT;
+    
     /**
      * Creates a new PriceNegotiator.
      *
@@ -44,22 +53,23 @@ public class PriceNegotiator {
      * @param supportsFractionalPayments Whether to enable fractional payments (prices with decimal places)
      */
     public PriceNegotiator(boolean debugLogging, double originalPrice, int originalAmountBeingSold, boolean supportsFractionalPayments) {
-        if (!TX_DEBUG_LOGGING) { TX_DEBUG_LOGGING = debugLogging; }
+        this.debugLogging = debugLogging;
         this.originalPrice = originalPrice;
         this.originalAmountBeingSold = originalAmountBeingSold;
         this.supportsFractionalPayments = supportsFractionalPayments;
     }
     
     /**
-     * Rounds a decimal value to cents precision (2 decimal places).
-     * Uses half-up rounding to ensure proper currency handling.
+     * Rounds a value to the specified scale using the specified rounding mode.
      *
      * @param value The value to round
-     * @return The value rounded to 2 decimal places
+     * @param scale The scale (number of decimal places) to round to
+     * @param roundingMode The rounding mode to use
+     * @return The rounded value
      */
-    private double roundToCents(double value) {
+    private double roundValue(double value, int scale, RoundingMode roundingMode) {
         BigDecimal bd = new BigDecimal(Double.toString(value)); // Use string to avoid floating point precision issues
-        bd = bd.setScale(PRICE_PRECISION, RoundingMode.HALF_UP);
+        bd = bd.setScale(scale, roundingMode);
         return bd.doubleValue();
     }
     
@@ -70,230 +80,325 @@ public class PriceNegotiator {
      * @param items The number of items to purchase
      * @param pricePerItem The price per individual item
      * @return The calculated price, either rounded to cents (fractional) or rounded up (integer).
-     *         Returns -1 if the calculation would result in a price too small (zero).
+     *         Returns NO_SPECIFIC_AMOUNT if the calculation would result in a price too small (zero).
      */
     private double calculateExactPrice(int items, double pricePerItem) {
         // Check for extreme edge cases that would result in a price that's too small
-        // For both fractional and non-fractional, we need to check this for edge cases
-        if (items * pricePerItem < 0.01) {
-            return -1; // Indicate that this is an invalid price (will trigger "no purchase")
+        if (items * pricePerItem < MINIMUM_VALID_PRICE) {
+            return NO_SPECIFIC_AMOUNT; // Indicate that this is an invalid price (will trigger "no purchase")
         }
         
-        // Always use BigDecimal for the calculation to avoid floating-point precision issues
-        BigDecimal itemsBD = BigDecimal.valueOf(items);
-        BigDecimal pricePerItemBD = new BigDecimal(Double.toString(pricePerItem));
-        BigDecimal result = itemsBD.multiply(pricePerItemBD);
+        // Calculate the raw price
+        double rawPrice = items * pricePerItem;
         
-        if (supportsFractionalPayments) {
-            // Round to 2 decimal places (cents) using HALF_UP rounding
-            result = result.setScale(PRICE_PRECISION, RoundingMode.HALF_UP);
-            double finalPrice = result.doubleValue();
-            
-            // Double-check if the final price is too small to be valid (would be zero)
-            if (finalPrice < 0.01) {
-                return -1; // Indicate "no purchase" for extremely small prices
-            }
-            return finalPrice;
-        } else {
-            // For integer payments, round up to the next whole number
-            // But first check if the original value is too small
-            double rawValue = result.doubleValue();
-            if (rawValue < 0.01) {
-                return -1; // Avoid prices that are too small
-            }
-            result = result.setScale(0, RoundingMode.HALF_UP);
-            return result.doubleValue();
+        // Apply appropriate rounding based on payment mode
+        int scale = supportsFractionalPayments ? PRICE_PRECISION : 0;
+        double finalPrice = roundValue(rawPrice, scale, RoundingMode.HALF_UP);
+        
+        // Validate the final price
+        if (finalPrice < MINIMUM_VALID_PRICE) {
+            return NO_SPECIFIC_AMOUNT;
         }
+        
+        return finalPrice;
     }
     
+    /**
+     * Negotiates a purchase based on the available funds, inventory, and desired amount.
+     * This method determines the final price and quantity for the transaction.
+     * 
+     * @param allowPartialSales Whether to allow selling partial amounts
+     * @param buyerAvailableFunds The amount of money the buyer has available
+     * @param sellerInventoryQuantity The number of items the seller has in inventory
+     * @param desiredAmount The specific amount the buyer wants to purchase (-1 for maximum possible)
+     */
     public void negotiatePurchase(boolean allowPartialSales, double buyerAvailableFunds, int sellerInventoryQuantity, int desiredAmount) {
-        // Clear out negotiated price
-        this.negotiatedPrice = -1;
-        this.negotiatedAmountBeingSold = -1;
-
-        // Check max amount being bought
+        // Reset negotiation state
+        resetNegotiationState();
+        
+        // Determine maximum purchase amount
+        int maxPurchaseAmount = determineMaxPurchaseAmount(desiredAmount);
+        
+        // Calculate price ratios
+        double pricePerItem = calculatePricePerItem();
+        double itemsPerPrice = calculateItemsPerPrice(pricePerItem);
+        
+        logPriceRatios(pricePerItem, itemsPerPrice);
+        
+        // Handle special case for extremely low price per item
+        if (isExtremelyLowPricePerItem(pricePerItem, desiredAmount)) {
+            return;
+        }
+        
+        // Special handling for exact amount with fractional payments
+        if (handleExactAmountFractionalPayment(desiredAmount, sellerInventoryQuantity, buyerAvailableFunds)) {
+            return;
+        }
+        
+        // Calculate maximum quantities based on buyer funds and seller inventory
+        double maxPurchasableQuantity = calculateMaxPurchasableQuantity(
+            buyerAvailableFunds, pricePerItem, itemsPerPrice, sellerInventoryQuantity);
+            
+        // Calculate items being bought and price being paid
+        int itemsBeingBought = calculateItemsBeingBought(maxPurchasableQuantity, itemsPerPrice);
+        double priceBeingPaid = calculateExactPrice(itemsBeingBought, pricePerItem);
+        
+        logPurchaseDetails(maxPurchasableQuantity, itemsBeingBought, priceBeingPaid, 
+            buyerAvailableFunds, sellerInventoryQuantity);
+        
+        // Check if we can't complete the purchase
+        if (isInvalidPurchase(maxPurchasableQuantity, itemsBeingBought, priceBeingPaid)) {
+            resetToOriginalValues();
+            return;
+        }
+        
+        // Handle partial sales restrictions if needed
+        if (!allowPartialSales) {
+            handleNoPartialSales(maxPurchasableQuantity, itemsPerPrice, pricePerItem);
+            
+            // Update itemsBeingBought and priceBeingPaid after handling no partial sales
+            itemsBeingBought = this.amountBeingSold;
+            priceBeingPaid = this.price;
+            
+            // If no valid price was negotiated, return
+            if (itemsBeingBought == 0 || priceBeingPaid <= 0) {
+                return;
+            }
+        }
+        
+        // Ensure we don't exceed max purchase amount
+        itemsBeingBought = ensureMaxPurchaseLimit(itemsBeingBought, maxPurchaseAmount, pricePerItem);
+        priceBeingPaid = calculateExactPrice(itemsBeingBought, pricePerItem);
+        
+        // Final validation check
+        if (itemsBeingBought == 0 || priceBeingPaid <= 0) {
+            return;
+        }
+        
+        // Set the final negotiated values
+        setFinalNegotiatedValues(itemsBeingBought, priceBeingPaid);
+    }
+    
+    /**
+     * Resets the negotiation state to prepare for a new calculation.
+     */
+    private void resetNegotiationState() {
+        this.negotiatedPrice = NO_SPECIFIC_AMOUNT;
+        this.negotiatedAmountBeingSold = NO_SPECIFIC_AMOUNT;
+    }
+    
+    /**
+     * Determines the maximum purchase amount based on original amount and desired amount.
+     */
+    private int determineMaxPurchaseAmount(int desiredAmount) {
         int maxPurchaseAmount = this.originalAmountBeingSold;
+        
         // Check if we passed in the amount that we want to purchase, sometimes we want to purchase more
-        if (desiredAmount != -1 && desiredAmount > 0 && desiredAmount > this.originalAmountBeingSold) {
+        if (desiredAmount != NO_SPECIFIC_AMOUNT && 
+            desiredAmount > 0 && 
+            desiredAmount > this.originalAmountBeingSold) {
             maxPurchaseAmount = desiredAmount;
         }
-
-        // Price for a single item
-        // Greater than 1 if price is higher than amount being sold
-        // Less than one if price is lower than amount being sold
-        double pricePerItem = originalPrice / originalAmountBeingSold;
-        // The number of items to equal one price unit
-        double itemsPerPrice = 1;
+        
+        return maxPurchaseAmount;
+    }
+    
+    /**
+     * Calculates the price per individual item.
+     */
+    private double calculatePricePerItem() {
+        return originalPrice / originalAmountBeingSold;
+    }
+    
+    /**
+     * Calculates how many items equal one price unit.
+     */
+    private double calculateItemsPerPrice(double pricePerItem) {
+        double itemsPerPrice = DEFAULT_ITEM_RATIO;
+        
         // If our price is less than 1, then we are buying multiple items with each order
-        if (pricePerItem < 1) {
-            itemsPerPrice = 1 / pricePerItem;
+        if (pricePerItem < DEFAULT_ITEM_RATIO) {
+            itemsPerPrice = DEFAULT_ITEM_RATIO / pricePerItem;
         }
-
-        if (TX_DEBUG_LOGGING) {
+        
+        return itemsPerPrice;
+    }
+    
+    /**
+     * Logs price ratio information if debug logging is enabled.
+     */
+    private void logPriceRatios(double pricePerItem, double itemsPerPrice) {
+        if (debugLogging) {
             System.out.println("* pricePerItem: " + pricePerItem);
             System.out.println("* itemsPerPrice: " + itemsPerPrice);
         }
-
-        // Special case for extreme ratios: if price per item is too small, cancel the purchase
-        if (supportsFractionalPayments && pricePerItem < 0.00001) {
+    }
+    
+    /**
+     * Handles the special case of extremely low price per item.
+     * 
+     * @return true if the purchase was handled or canceled, false otherwise
+     */
+    private boolean isExtremelyLowPricePerItem(double pricePerItem, int desiredAmount) {
+        if (supportsFractionalPayments && pricePerItem < EXTREMELY_LOW_PRICE_THRESHOLD) {
             if (desiredAmount == originalAmountBeingSold) {
                 // Only allow the full purchase in this case
-                this.negotiatedAmountBeingSold = originalAmountBeingSold;
-                this.negotiatedPrice = originalPrice;
-                this.amountBeingSold = originalAmountBeingSold;
-                this.price = originalPrice;
-                return;
+                setFinalNegotiatedValues(originalAmountBeingSold, originalPrice);
+                return true;
             } else if (desiredAmount < originalAmountBeingSold) {
                 // For partial purchases of extremely low-price items, ensure the minimum price is 0.01
                 double calculatedPrice = (double)desiredAmount / originalAmountBeingSold * originalPrice;
-                if (calculatedPrice < 0.01) {
+                if (calculatedPrice < MINIMUM_VALID_PRICE) {
                     // Can't complete the purchase, price would be too small
-                    return;
+                    return true;
                 }
             }
         }
-
-        // Special handling for fixed desiredAmount when using fractional payments
+        return false;
+    }
+    
+    /**
+     * Handles exact amount purchase with fractional payments.
+     * 
+     * @return true if the purchase was handled, false otherwise
+     */
+    private boolean handleExactAmountFractionalPayment(int desiredAmount, int sellerInventoryQuantity, double buyerAvailableFunds) {
         if (supportsFractionalPayments && desiredAmount > 0 && desiredAmount <= sellerInventoryQuantity) {
-            // Use BigDecimal for exact price calculation
-            BigDecimal desiredAmountBD = BigDecimal.valueOf(desiredAmount);
-            BigDecimal originalAmountBeingSoldBD = BigDecimal.valueOf(originalAmountBeingSold);
-            BigDecimal originalPriceBD = new BigDecimal(Double.toString(originalPrice));
+            // Calculate the exact proportion of the price
+            double proportion = (double) desiredAmount / originalAmountBeingSold;
+            double exactPrice = originalPrice * proportion;
             
-            // Calculate exact proportion
-            BigDecimal proportion = desiredAmountBD.divide(originalAmountBeingSoldBD, 10, RoundingMode.HALF_UP);
-            BigDecimal exactPrice = originalPriceBD.multiply(proportion);
-            
-            // Round to cents
-            exactPrice = exactPrice.setScale(PRICE_PRECISION, RoundingMode.HALF_UP);
+            // Round to the appropriate precision
+            exactPrice = roundValue(exactPrice, PRICE_PRECISION, RoundingMode.HALF_UP);
             
             // Check for extremely small prices that would be invalid
-            if (exactPrice.compareTo(BigDecimal.valueOf(0.01)) < 0) {
-                // Price is too small (less than 0.01), can't complete purchase
-                return;
+            if (exactPrice < MINIMUM_VALID_PRICE) {
+                // Price is too small, can't complete purchase
+                return true;
             }
             
             // Check if buyer can afford this exact amount
-            if (buyerAvailableFunds >= exactPrice.doubleValue()) {
+            if (buyerAvailableFunds >= exactPrice) {
                 // Buyer can afford the exact amount
-                this.amountBeingSold = desiredAmount;
-                this.price = exactPrice.doubleValue();
-                this.negotiatedAmountBeingSold = desiredAmount;
-                this.negotiatedPrice = exactPrice.doubleValue();
-                return;
+                setFinalNegotiatedValues(desiredAmount, exactPrice);
+                return true;
             }
         }
-
+        return false;
+    }
+    
+    /**
+     * Calculates the maximum purchasable quantity based on available funds and inventory.
+     */
+    private double calculateMaxPurchasableQuantity(double buyerAvailableFunds, double pricePerItem, 
+                                                double itemsPerPrice, int sellerInventoryQuantity) {
         // Calculate the maximum qty that the buyer can afford to buy
-        double buyerMaxQtyPurchase;
-        if (supportsFractionalPayments) {
-            // For fractional payments, we use the same approach as integer payments
-            // to ensure consistent behavior - the only difference is in the price rounding
-            // This ensures that both modes buy the same number of items with the same funds
-            buyerMaxQtyPurchase = (buyerAvailableFunds / pricePerItem) / itemsPerPrice;
-        } else {
-            // For integer payments, use original calculation
-            buyerMaxQtyPurchase = (buyerAvailableFunds / pricePerItem) / itemsPerPrice;
-        }
+        double buyerMaxQtyPurchase = (buyerAvailableFunds / pricePerItem) / itemsPerPrice;
         
         // Calculate the maximum items the seller has to sell
         double sellerMaxQtySale = sellerInventoryQuantity / itemsPerPrice;
 
         // The maximum qty that we can buy/sell with our available funds
-        double FIX_ROUNDING = 1e-5; // Fix rounding errors (where one of the quantities comes out as x.99999~, make sure that is rounded to a while number
-        double maxPurchasableQuantity = Math.floor(Math.min(buyerMaxQtyPurchase, sellerMaxQtySale) + FIX_ROUNDING);
-
-        // The number of items we are buying
+        return Math.floor(Math.min(buyerMaxQtyPurchase, sellerMaxQtySale) + ROUNDING_ERROR_MARGIN);
+    }
+    
+    /**
+     * Calculates the number of items being bought.
+     */
+    private int calculateItemsBeingBought(double maxPurchasableQuantity, double itemsPerPrice) {
         int itemsBeingBought = (int) Math.floor(maxPurchasableQuantity * itemsPerPrice);
-        if (TX_DEBUG_LOGGING) { System.out.println("*-* itemsBeingBought (pre-round): " + (maxPurchasableQuantity * itemsPerPrice)); }
         
-        // The overall price we are paying
-        double priceBeingPaid = calculateExactPrice(itemsBeingBought, pricePerItem);
-        
-        // Check if the calculated price indicates a "no purchase" situation
-        if (priceBeingPaid == -1) {
-            // The price is too small or otherwise invalid, can't complete the purchase
-            return;
+        if (debugLogging) { 
+            System.out.println("*-* itemsBeingBought (pre-round): " + (maxPurchasableQuantity * itemsPerPrice)); 
         }
         
-        if (TX_DEBUG_LOGGING) { 
-            System.out.println("*-* priceBeingPaid (pre-round): " + (itemsBeingBought * pricePerItem));
-            System.out.println("* buyerMaxQtyPurchase: " + buyerMaxQtyPurchase);
-            System.out.println("* this.seller.getInventoryQuantity(this.itemBeingSold): " + sellerInventoryQuantity);
-            System.out.println("* sellerMaxQtySale: " + sellerMaxQtySale);
+        return itemsBeingBought;
+    }
+    
+    /**
+     * Logs purchase details if debug logging is enabled.
+     */
+    private void logPurchaseDetails(double maxPurchasableQuantity, int itemsBeingBought, double priceBeingPaid,
+                                   double buyerAvailableFunds, int sellerInventoryQuantity) {
+        if (debugLogging) { 
+            System.out.println("*-* priceBeingPaid (pre-round): " + (itemsBeingBought * calculatePricePerItem()));
+            System.out.println("* buyerMaxQtyPurchase: " + (buyerAvailableFunds / calculatePricePerItem()) / calculateItemsPerPrice(calculatePricePerItem()));
+            System.out.println("* sellerInventoryQuantity: " + sellerInventoryQuantity);
+            System.out.println("* sellerMaxQtySale: " + sellerInventoryQuantity / calculateItemsPerPrice(calculatePricePerItem()));
             System.out.println("* maxPurchasableQuantity: " + maxPurchasableQuantity);
             System.out.println("* itemsBeingBought: " + itemsBeingBought);
             System.out.println("* priceBeingPaid: " + priceBeingPaid);
         }
+    }
+    
+    /**
+     * Checks if the purchase is invalid due to insufficient funds or inventory.
+     */
+    private boolean isInvalidPurchase(double maxPurchasableQuantity, int itemsBeingBought, double priceBeingPaid) {
+        return maxPurchasableQuantity <= 0 || itemsBeingBought <= 0 || priceBeingPaid <= 0;
+    }
+    
+    /**
+     * Resets price and amount values to original values.
+     */
+    private void resetToOriginalValues() {
+        this.price = originalPrice;
+        this.amountBeingSold = originalAmountBeingSold;
+    }
+    
+    /**
+     * Handles the case where partial sales are not allowed.
+     */
+    private void handleNoPartialSales(double maxPurchasableQuantity, double itemsPerPrice, double pricePerItem) {
+        // Multiple Quantity of original amount sales code (for full stack sales)
+        double quantityPerOriginalAmount = originalAmountBeingSold / itemsPerPrice;
+        // Force the quantity to be a multiple of our original amount when performing multiple sales
+        int roundedQuantity = (int) (Math.floor(maxPurchasableQuantity / quantityPerOriginalAmount) * quantityPerOriginalAmount);
 
-        // If we don't have enough to buy/sell, then we can't negotiate a new price! Return so normal error handling can occur.
-        if (maxPurchasableQuantity <= 0 || itemsBeingBought <= 0 || priceBeingPaid <= 0) {
-            // Reset variables
-            this.price = originalPrice;
-            this.amountBeingSold = originalAmountBeingSold;
-            return;
+        // Partial sales are not allowed, we need to default to a multiple of our default amount/price
+        int itemsBeingBought = (int) Math.floor(roundedQuantity * itemsPerPrice);
+        
+        // Calculate price with our helper method
+        double priceBeingPaid = calculateExactPrice(itemsBeingBought, pricePerItem);
+        
+        // Update class state
+        this.amountBeingSold = itemsBeingBought;
+        this.price = priceBeingPaid;
+
+        if (debugLogging) {
+            System.out.println("*** roundedQuantity: " + roundedQuantity);
+            System.out.println("*** quantityPerOriginalAmount: " + quantityPerOriginalAmount);
+            System.out.println("*** itemsBeingBought: " + itemsBeingBought);
+            System.out.println("*** priceBeingPaid: " + priceBeingPaid);
         }
-
-        // Check if partial sales are not allowed
-        if (!allowPartialSales) {
-            // Multiple Quantity of original amount sales code (for full stack sales)
-            double quantityPerOriginalAmount = originalAmountBeingSold / itemsPerPrice;
-            // Force the quantity to be a multiple of our original amount when performing multiple sales
-            int roundedQuantity = (int) (Math.floor(maxPurchasableQuantity / quantityPerOriginalAmount) * quantityPerOriginalAmount);
-
-            // Partial sales are not allowed, we need to default to a multiple of our default amount/price
-            itemsBeingBought = (int) Math.floor(roundedQuantity * itemsPerPrice);
-            
-            // Calculate price with our helper method
-            priceBeingPaid = calculateExactPrice(itemsBeingBought, pricePerItem);
-            
-            // Check again for "no purchase" response
-            if (priceBeingPaid == -1) {
-                return;
-            }
-
-            // Set max purchase amount to be rounded down to a multiple of our original amount
-            maxPurchaseAmount = (int) (Math.floor(maxPurchaseAmount / originalAmountBeingSold) * originalAmountBeingSold);
-
-            if (TX_DEBUG_LOGGING) {
-                System.out.println("*** roundedQuantity: " + roundedQuantity);
-                System.out.println("*** quantityPerOriginalAmount: " + quantityPerOriginalAmount);
-                System.out.println("*** itemsBeingBought: " + itemsBeingBought);
-                System.out.println("*** priceBeingPaid: " + priceBeingPaid);
-                System.out.println("*** maxPurchaseAmount: " + maxPurchaseAmount);
-            }
-        }
-
-        // Make sure we only sell up to our maxPurchaseAmount (normally the original amount, but can be set higher)
+    }
+    
+    /**
+     * Ensures we don't exceed the maximum purchase limit.
+     */
+    private int ensureMaxPurchaseLimit(int itemsBeingBought, int maxPurchaseAmount, double pricePerItem) {
         if (itemsBeingBought > maxPurchaseAmount) {
-            if (TX_DEBUG_LOGGING) { System.out.println("itemsBeingBought > maxPurchaseAmount: " + itemsBeingBought + " > " + maxPurchaseAmount); }
-            itemsBeingBought = maxPurchaseAmount;
-            
-            // Calculate price with our helper method
-            priceBeingPaid = calculateExactPrice(itemsBeingBought, pricePerItem);
-            
-            // Check again for "no purchase" response
-            if (priceBeingPaid == -1) {
-                return;
+            if (debugLogging) { 
+                System.out.println("itemsBeingBought > maxPurchaseAmount: " + itemsBeingBought + " > " + maxPurchaseAmount); 
             }
             
-            if (TX_DEBUG_LOGGING) { System.out.println("*-* itemsBeingBought: " + itemsBeingBought); }
-            if (TX_DEBUG_LOGGING) { System.out.println("*-* priceBeingPaid: " + priceBeingPaid); }
+            return maxPurchaseAmount;
         }
-
-        // If we are not able to buy/sell, just leave the price/amount being sold as-is for error handling
-        if (itemsBeingBought == 0 || priceBeingPaid <= 0) {
-            return;
-        }
-
-        // We are a valid price, go ahead and set it!
+        
+        return itemsBeingBought;
+    }
+    
+    /**
+     * Sets the final negotiated values for the transaction.
+     */
+    private void setFinalNegotiatedValues(int itemsBeingBought, double priceBeingPaid) {
         this.amountBeingSold = itemsBeingBought;
         this.price = priceBeingPaid;
         // Store explicitly negotiated price (used in tests)
         this.negotiatedAmountBeingSold = itemsBeingBought;
         this.negotiatedPrice = priceBeingPaid;
 
-        if (TX_DEBUG_LOGGING) {
+        if (debugLogging) {
             System.out.println("-* amountBeingSold: " + this.amountBeingSold);
             System.out.println("-* price: " + this.price);
             System.out.println("-* originalAmountBeingSold: " + originalAmountBeingSold);
@@ -301,18 +406,38 @@ public class PriceNegotiator {
         }
     }
 
+    /**
+     * Gets the final negotiated price.
+     * 
+     * @return The final price for the transaction
+     */
     public double getPrice() {
         return price;
     }
 
+    /**
+     * Gets the final negotiated amount.
+     * 
+     * @return The final amount for the transaction
+     */
     public int getAmountBeingSold() {
         return amountBeingSold;
     }
 
+    /**
+     * Gets the explicitly negotiated price.
+     * 
+     * @return The explicitly negotiated price or NO_SPECIFIC_AMOUNT if negotiation wasn't completed
+     */
     public double getNegotiatedPrice() {
         return negotiatedPrice;
     }
 
+    /**
+     * Gets the explicitly negotiated amount.
+     * 
+     * @return The explicitly negotiated amount or NO_SPECIFIC_AMOUNT if negotiation wasn't completed
+     */
     public int getNegotiatedAmountBeingSold() {
         return negotiatedAmountBeingSold;
     }

--- a/core/src/main/java/com/snowgears/shop/util/PriceNegotiator.java
+++ b/core/src/main/java/com/snowgears/shop/util/PriceNegotiator.java
@@ -2,9 +2,32 @@ package com.snowgears.shop.util;
 
 import com.snowgears.shop.Shop;
 import com.snowgears.shop.shop.ShopType;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 
+/**
+ * Handles price negotiations for shop transactions.
+ * <p>
+ * This class calculates the final price and quantity for shop transactions based on
+ * available funds, inventory, and desired purchase amount.
+ * <p>
+ * The negotiator supports two payment modes:
+ * <ul>
+ *   <li>Integer payments (default): Prices are always rounded up to the next full unit.</li>
+ *   <li>Fractional payments: Prices can have decimal precision (up to 2 decimal places).</li>
+ * </ul>
+ * <p>
+ * The only difference between the two modes is how prices are rounded. Item quantities
+ * are calculated the same way in both modes to ensure consistent behavior.
+ */
 public class PriceNegotiator {
     boolean TX_DEBUG_LOGGING = false;
+    
+    // Constant for price precision (cents)
+    private static final int PRICE_PRECISION = 2;
+    
+    // Flag to determine if fractional payments are supported
+    private final boolean supportsFractionalPayments;
 
     double price = 0;
     double originalPrice = 0;
@@ -12,21 +35,86 @@ public class PriceNegotiator {
     int amountBeingSold = 0;
     int originalAmountBeingSold = 0;
     int negotiatedAmountBeingSold = -1;
-
-    public PriceNegotiator(boolean debugLogging, double originalPrice, int originalAmountBeingSold) {
+    /**
+     * Creates a new PriceNegotiator.
+     *
+     * @param debugLogging              Whether to enable debug logging
+     * @param originalPrice             The original price for the items
+     * @param originalAmountBeingSold   The original quantity of items
+     * @param supportsFractionalPayments Whether to enable fractional payments (prices with decimal places)
+     */
+    public PriceNegotiator(boolean debugLogging, double originalPrice, int originalAmountBeingSold, boolean supportsFractionalPayments) {
         if (!TX_DEBUG_LOGGING) { TX_DEBUG_LOGGING = debugLogging; }
         this.originalPrice = originalPrice;
         this.originalAmountBeingSold = originalAmountBeingSold;
+        this.supportsFractionalPayments = supportsFractionalPayments;
     }
+    
+    /**
+     * Rounds a decimal value to cents precision (2 decimal places).
+     * Uses half-up rounding to ensure proper currency handling.
+     *
+     * @param value The value to round
+     * @return The value rounded to 2 decimal places
+     */
+    private double roundToCents(double value) {
+        BigDecimal bd = new BigDecimal(Double.toString(value)); // Use string to avoid floating point precision issues
+        bd = bd.setScale(PRICE_PRECISION, RoundingMode.HALF_UP);
+        return bd.doubleValue();
+    }
+    
+    /**
+     * Calculates the exact price based on the items and price per item.
+     * Uses different rounding strategies depending on the payment mode.
+     *
+     * @param items The number of items to purchase
+     * @param pricePerItem The price per individual item
+     * @return The calculated price, either rounded to cents (fractional) or rounded up (integer).
+     *         Returns -1 if the calculation would result in a price too small (zero).
+     */
+    private double calculateExactPrice(int items, double pricePerItem) {
+        // Check for extreme edge cases that would result in a price that's too small
+        // For both fractional and non-fractional, we need to check this for edge cases
+        if (items * pricePerItem < 0.01) {
+            return -1; // Indicate that this is an invalid price (will trigger "no purchase")
+        }
+        
+        // Always use BigDecimal for the calculation to avoid floating-point precision issues
+        BigDecimal itemsBD = BigDecimal.valueOf(items);
+        BigDecimal pricePerItemBD = new BigDecimal(Double.toString(pricePerItem));
+        BigDecimal result = itemsBD.multiply(pricePerItemBD);
+        
+        if (supportsFractionalPayments) {
+            // Round to 2 decimal places (cents) using HALF_UP rounding
+            result = result.setScale(PRICE_PRECISION, RoundingMode.HALF_UP);
+            double finalPrice = result.doubleValue();
+            
+            // Double-check if the final price is too small to be valid (would be zero)
+            if (finalPrice < 0.01) {
+                return -1; // Indicate "no purchase" for extremely small prices
+            }
+            return finalPrice;
+        } else {
+            // For integer payments, round up to the next whole number
+            // But first check if the original value is too small
+            double rawValue = result.doubleValue();
+            if (rawValue < 0.01) {
+                return -1; // Avoid prices that are too small
+            }
+            result = result.setScale(0, RoundingMode.HALF_UP);
+            return result.doubleValue();
+        }
+    }
+    
     public void negotiatePurchase(boolean allowPartialSales, double buyerAvailableFunds, int sellerInventoryQuantity, int desiredAmount) {
         // Clear out negotiated price
         this.negotiatedPrice = -1;
         this.negotiatedAmountBeingSold = -1;
 
         // Check max amount being bought
-        int maxPurchaseAmount = originalAmountBeingSold;
+        int maxPurchaseAmount = this.originalAmountBeingSold;
         // Check if we passed in the amount that we want to purchase, sometimes we want to purchase more
-        if (desiredAmount != -1) {
+        if (desiredAmount != -1 && desiredAmount > 0 && desiredAmount > this.originalAmountBeingSold) {
             maxPurchaseAmount = desiredAmount;
         }
 
@@ -41,8 +129,73 @@ public class PriceNegotiator {
             itemsPerPrice = 1 / pricePerItem;
         }
 
+        if (TX_DEBUG_LOGGING) {
+            System.out.println("* pricePerItem: " + pricePerItem);
+            System.out.println("* itemsPerPrice: " + itemsPerPrice);
+        }
+
+        // Special case for extreme ratios: if price per item is too small, cancel the purchase
+        if (supportsFractionalPayments && pricePerItem < 0.00001) {
+            if (desiredAmount == originalAmountBeingSold) {
+                // Only allow the full purchase in this case
+                this.negotiatedAmountBeingSold = originalAmountBeingSold;
+                this.negotiatedPrice = originalPrice;
+                this.amountBeingSold = originalAmountBeingSold;
+                this.price = originalPrice;
+                return;
+            } else if (desiredAmount < originalAmountBeingSold) {
+                // For partial purchases of extremely low-price items, ensure the minimum price is 0.01
+                double calculatedPrice = (double)desiredAmount / originalAmountBeingSold * originalPrice;
+                if (calculatedPrice < 0.01) {
+                    // Can't complete the purchase, price would be too small
+                    return;
+                }
+            }
+        }
+
+        // Special handling for fixed desiredAmount when using fractional payments
+        if (supportsFractionalPayments && desiredAmount > 0 && desiredAmount <= sellerInventoryQuantity) {
+            // Use BigDecimal for exact price calculation
+            BigDecimal desiredAmountBD = BigDecimal.valueOf(desiredAmount);
+            BigDecimal originalAmountBeingSoldBD = BigDecimal.valueOf(originalAmountBeingSold);
+            BigDecimal originalPriceBD = new BigDecimal(Double.toString(originalPrice));
+            
+            // Calculate exact proportion
+            BigDecimal proportion = desiredAmountBD.divide(originalAmountBeingSoldBD, 10, RoundingMode.HALF_UP);
+            BigDecimal exactPrice = originalPriceBD.multiply(proportion);
+            
+            // Round to cents
+            exactPrice = exactPrice.setScale(PRICE_PRECISION, RoundingMode.HALF_UP);
+            
+            // Check for extremely small prices that would be invalid
+            if (exactPrice.compareTo(BigDecimal.valueOf(0.01)) < 0) {
+                // Price is too small (less than 0.01), can't complete purchase
+                return;
+            }
+            
+            // Check if buyer can afford this exact amount
+            if (buyerAvailableFunds >= exactPrice.doubleValue()) {
+                // Buyer can afford the exact amount
+                this.amountBeingSold = desiredAmount;
+                this.price = exactPrice.doubleValue();
+                this.negotiatedAmountBeingSold = desiredAmount;
+                this.negotiatedPrice = exactPrice.doubleValue();
+                return;
+            }
+        }
+
         // Calculate the maximum qty that the buyer can afford to buy
-        double buyerMaxQtyPurchase = (buyerAvailableFunds / pricePerItem) / itemsPerPrice;
+        double buyerMaxQtyPurchase;
+        if (supportsFractionalPayments) {
+            // For fractional payments, we use the same approach as integer payments
+            // to ensure consistent behavior - the only difference is in the price rounding
+            // This ensures that both modes buy the same number of items with the same funds
+            buyerMaxQtyPurchase = (buyerAvailableFunds / pricePerItem) / itemsPerPrice;
+        } else {
+            // For integer payments, use original calculation
+            buyerMaxQtyPurchase = (buyerAvailableFunds / pricePerItem) / itemsPerPrice;
+        }
+        
         // Calculate the maximum items the seller has to sell
         double sellerMaxQtySale = sellerInventoryQuantity / itemsPerPrice;
 
@@ -53,13 +206,18 @@ public class PriceNegotiator {
         // The number of items we are buying
         int itemsBeingBought = (int) Math.floor(maxPurchasableQuantity * itemsPerPrice);
         if (TX_DEBUG_LOGGING) { System.out.println("*-* itemsBeingBought (pre-round): " + (maxPurchasableQuantity * itemsPerPrice)); }
+        
         // The overall price we are paying
-        double priceBeingPaid = Math.ceil(itemsBeingBought * pricePerItem);
-        if (TX_DEBUG_LOGGING) { System.out.println("*-* priceBeingPaid (pre-round): " + (itemsBeingBought * pricePerItem)); }
-
-        if (TX_DEBUG_LOGGING) {
-            System.out.println("* pricePerItem: " + pricePerItem);
-            System.out.println("* itemsPerPrice: " + itemsPerPrice);
+        double priceBeingPaid = calculateExactPrice(itemsBeingBought, pricePerItem);
+        
+        // Check if the calculated price indicates a "no purchase" situation
+        if (priceBeingPaid == -1) {
+            // The price is too small or otherwise invalid, can't complete the purchase
+            return;
+        }
+        
+        if (TX_DEBUG_LOGGING) { 
+            System.out.println("*-* priceBeingPaid (pre-round): " + (itemsBeingBought * pricePerItem));
             System.out.println("* buyerMaxQtyPurchase: " + buyerMaxQtyPurchase);
             System.out.println("* this.seller.getInventoryQuantity(this.itemBeingSold): " + sellerInventoryQuantity);
             System.out.println("* sellerMaxQtySale: " + sellerMaxQtySale);
@@ -85,7 +243,14 @@ public class PriceNegotiator {
 
             // Partial sales are not allowed, we need to default to a multiple of our default amount/price
             itemsBeingBought = (int) Math.floor(roundedQuantity * itemsPerPrice);
-            priceBeingPaid = Math.ceil(itemsBeingBought * pricePerItem);
+            
+            // Calculate price with our helper method
+            priceBeingPaid = calculateExactPrice(itemsBeingBought, pricePerItem);
+            
+            // Check again for "no purchase" response
+            if (priceBeingPaid == -1) {
+                return;
+            }
 
             // Set max purchase amount to be rounded down to a multiple of our original amount
             maxPurchaseAmount = (int) (Math.floor(maxPurchaseAmount / originalAmountBeingSold) * originalAmountBeingSold);
@@ -103,13 +268,21 @@ public class PriceNegotiator {
         if (itemsBeingBought > maxPurchaseAmount) {
             if (TX_DEBUG_LOGGING) { System.out.println("itemsBeingBought > maxPurchaseAmount: " + itemsBeingBought + " > " + maxPurchaseAmount); }
             itemsBeingBought = maxPurchaseAmount;
-            priceBeingPaid = Math.ceil(maxPurchaseAmount * pricePerItem);
+            
+            // Calculate price with our helper method
+            priceBeingPaid = calculateExactPrice(itemsBeingBought, pricePerItem);
+            
+            // Check again for "no purchase" response
+            if (priceBeingPaid == -1) {
+                return;
+            }
+            
             if (TX_DEBUG_LOGGING) { System.out.println("*-* itemsBeingBought: " + itemsBeingBought); }
             if (TX_DEBUG_LOGGING) { System.out.println("*-* priceBeingPaid: " + priceBeingPaid); }
         }
 
         // If we are not able to buy/sell, just leave the price/amount being sold as-is for error handling
-        if (itemsBeingBought == 0 || priceBeingPaid == 0) {
+        if (itemsBeingBought == 0 || priceBeingPaid <= 0) {
             return;
         }
 
@@ -142,5 +315,14 @@ public class PriceNegotiator {
 
     public int getNegotiatedAmountBeingSold() {
         return negotiatedAmountBeingSold;
+    }
+    
+    /**
+     * Checks if this negotiator supports fractional payments.
+     *
+     * @return true if fractional payments (with decimal precision) are enabled, false otherwise
+     */
+    public boolean supportsFractionalPayments() {
+        return supportsFractionalPayments;
     }
 }

--- a/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
@@ -18,6 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.tcoded.folialib.wrapper.task.WrappedTask;
+
 public class ShopCreationProcess {
 
     private ChatCreationStep step;
@@ -130,30 +132,28 @@ public class ShopCreationProcess {
 
     public void createShop(Player player){
         final ShopCreationProcess process = this;
-        Shop.getPlugin().getServer().getScheduler().runTask(Shop.getPlugin(), new Runnable() {
-            @Override
-            public void run() {
-                //TODO do some calculation here if clickedFace is filled with a block or UP / DOWN was clicked
-                Block signBlock = clickedChest.getRelative(clickedFace);
-                signBlock.setType(Material.OAK_WALL_SIGN);
+        // Run task at the chest block location to ensure it runs in the correct region in Folia
+        Shop.getPlugin().getFoliaLib().getScheduler().runAtLocation(clickedChest.getLocation(), task -> {
+            //TODO do some calculation here if clickedFace is filled with a block or UP / DOWN was clicked
+            Block signBlock = clickedChest.getRelative(clickedFace);
+            signBlock.setType(Material.OAK_WALL_SIGN);
 
-                if(signBlock.getBlockData() instanceof WallSign) {
-                    Directional wallSignData = (Directional) signBlock.getBlockData();
-                    wallSignData.setFacing(clickedFace);
-                    signBlock.setBlockData(wallSignData);
-                }
+            if(signBlock.getBlockData() instanceof WallSign) {
+                Directional wallSignData = (Directional) signBlock.getBlockData();
+                wallSignData.setFacing(clickedFace);
+                signBlock.setBlockData(wallSignData);
+            }
 
-                AbstractShop shop = Shop.getPlugin().getShopCreationUtil().createShop(Bukkit.getPlayer(playerUUID), clickedChest, signBlock, getPricePair(), getItemAmount(), isAdmin, shopType, clickedFace, true);
-                if(shop == null) {
-                    return;
-                }
+            AbstractShop shop = Shop.getPlugin().getShopCreationUtil().createShop(Bukkit.getPlayer(playerUUID), clickedChest, signBlock, getPricePair(), getItemAmount(), isAdmin, shopType, clickedFace, true);
+            if(shop == null) {
+                return;
+            }
 
-                boolean initializedShop = Shop.getPlugin().getShopCreationUtil().initializeShop(shop, player, itemStack, barterItemStack);
+            boolean initializedShop = Shop.getPlugin().getShopCreationUtil().initializeShop(shop, player, itemStack, barterItemStack);
 
-                if(initializedShop) {
-                    Shop.getPlugin().getShopCreationUtil().sendCreationSuccess(player, shop);
-                    Shop.getPlugin().getLogHandler().logAction(player, shop, ShopActionType.INIT);
-                }
+            if(initializedShop) {
+                Shop.getPlugin().getShopCreationUtil().sendCreationSuccess(player, shop);
+                Shop.getPlugin().getLogHandler().logAction(player, shop, ShopActionType.INIT);
             }
         });
     }

--- a/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
@@ -213,7 +213,7 @@ public class ShopCreationProcess {
         // Build the lines
         String unformatted = ShopMessage.getUnformattedMessage(key, subkey);
         String formatted = ShopMessage.format(unformatted, this.placeholderContext).toLegacyText();
-        List<String> lines = UtilMethods.splitStringIntoLines(formatted, 35);
+        List<String> lines = UtilMethods.splitStringIntoLines(formatted, ShopMessage.getTargetMaxLength());
         // Display the lines
         displayFloatingLines(lines);
     }
@@ -232,7 +232,7 @@ public class ShopCreationProcess {
         for (String unformatted : ShopMessage.getUnformattedMessageList(key, subkey)) {
             if (unformatted != null && !unformatted.isEmpty()){
                 String formatted = ShopMessage.format(unformatted, this.placeholderContext).toLegacyText();
-                lines.addAll(UtilMethods.splitStringIntoLines(formatted, 35));
+                lines.addAll(UtilMethods.splitStringIntoLines(formatted, ShopMessage.getTargetMaxLength()));
             }
         }
         // Display the lines

--- a/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
@@ -213,7 +213,7 @@ public class ShopCreationProcess {
         // Build the lines
         String unformatted = ShopMessage.getUnformattedMessage(key, subkey);
         String formatted = ShopMessage.format(unformatted, this.placeholderContext).toLegacyText();
-        List<String> lines = UtilMethods.splitStringIntoLines(formatted, 40);
+        List<String> lines = UtilMethods.splitStringIntoLines(formatted, 35);
         // Display the lines
         displayFloatingLines(lines);
     }
@@ -232,7 +232,7 @@ public class ShopCreationProcess {
         for (String unformatted : ShopMessage.getUnformattedMessageList(key, subkey)) {
             if (unformatted != null && !unformatted.isEmpty()){
                 String formatted = ShopMessage.format(unformatted, this.placeholderContext).toLegacyText();
-                lines.addAll(UtilMethods.splitStringIntoLines(formatted, 40));
+                lines.addAll(UtilMethods.splitStringIntoLines(formatted, 35));
             }
         }
         // Display the lines

--- a/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
@@ -55,7 +55,9 @@ public class ShopCreationProcess {
     }
 
     public void cleanup() {
-        this.display.removeDisplayEntities(player, true);
+        if (this.display.isEnabled()) {
+            this.display.removeDisplayEntities(player, true);
+        }
     }
 
     public Block getClickedChest() {
@@ -204,7 +206,7 @@ public class ShopCreationProcess {
 
     public void displayFloatingText(String key, String subkey) {
         // Check if feature is enabled or not.
-        if (!Shop.getPlugin().getConfig().getBoolean("displayFloatingCreateText")) {
+        if (!Shop.getPlugin().getConfig().getBoolean("displayFloatingCreateText") || !this.display.isEnabled()) {
             ShopMessage.sendMessage(key, subkey, this, player);
             return;
         }
@@ -218,7 +220,7 @@ public class ShopCreationProcess {
 
     public void displayFloatingTextList(String key, String subkey) {
         // Check if feature is enabled or not.
-        if (!Shop.getPlugin().getConfig().getBoolean("displayFloatingCreateText")) {
+        if (!Shop.getPlugin().getConfig().getBoolean("displayFloatingCreateText") || !this.display.isEnabled()) {
             for (String message : ShopMessage.getUnformattedMessageList(key, subkey)) {
                 if (message != null && !message.isEmpty())
                     ShopMessage.sendMessage(message, player);
@@ -238,6 +240,10 @@ public class ShopCreationProcess {
     }
 
     public void displayFloatingLines(List<String> lines) {
+        if (!this.display.isEnabled()) {
+            Shop.getPlugin().getLogger().warning("Unable to display floating text for player " + player.getName() + ", Display is disabled");
+            return;
+        }
         // Remove any existing text
         this.display.removeDisplayEntities(player, true);
 

--- a/core/src/main/java/com/snowgears/shop/util/ShopCreationUtil.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopCreationUtil.java
@@ -232,7 +232,7 @@ public class ShopCreationUtil {
     }
 
     public void sendCreationSuccess(Player player, AbstractShop shop){
-        shop.getDisplay().spawn(player);
+        if (shop.getDisplay() != null) shop.getDisplay().spawn(player);
         Shop.getPlugin().getLogger().trace("[ShopCreationUtil.sendCreationSuccess] updateSign");
         shop.setSignLinesRequireRefresh(true);
         shop.updateSign();

--- a/core/src/main/java/com/snowgears/shop/util/ShopLogger.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopLogger.java
@@ -183,12 +183,15 @@ public class ShopLogger extends Logger {
     public void notice(String message) { logFilterLevel(NOTICE, addColor(INTENSE_CYAN, "[Notice] " + message)); }
     public void helpful(String message) { logFilterLevel(HELPFUL, addColor(CYAN, "[Helpful] " + message)); }
     public void debug(String message) { logFilterLevel(DEBUG, addColor(DIM_GREY, "[Debug] " + message)); }
-
+    public void debug(String message, boolean withChatColors) {
+        if (this.getLogLevel().intValue() > DEBUG.intValue()) { return; }
+        Bukkit.getConsoleSender().sendMessage(INTENSE_WHITE + "[" + plugin.getDescription().getName() + "] " + DIM_GREY + "[Debug] " + message + RESET);
+    }
     public void trace(String message) { logFilterLevel(TRACE, addColor(VERY_DIM_GREY, "[Trace] " + message)); }
     public void spam(String message) { logFilterLevel(SPAM, addColor(VERY_VERY_DIM_GREY, "[Spam] " + message)); }
     public void spam(String message, boolean withChatColors) {
-        if (this.getLogLevel().intValue() > DEBUG.intValue()) { return; }
-        Bukkit.getConsoleSender().sendMessage(INTENSE_WHITE + "[" + plugin.getDescription().getName() + "] " + DIM_GREY + "[Debug] " + message + RESET);
+        if (this.getLogLevel().intValue() > SPAM.intValue()) { return; }
+        Bukkit.getConsoleSender().sendMessage(INTENSE_WHITE + "[" + plugin.getDescription().getName() + "] " + DIM_GREY + "[Spam] " + message + RESET);
     }
     public void hyper(String message) { logFilterLevel(SPAM, addColor(ALMOST_BLACK, "[Hyper] " + message)); }
 

--- a/core/src/main/java/com/snowgears/shop/util/ShopLogger.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopLogger.java
@@ -178,9 +178,9 @@ public class ShopLogger extends Logger {
     // Normal Logging functions
     public void severe(String message) { super.log(Level.SEVERE, addColor(BOLD + INTENSE_RED, message)); }
     public void warning(String message) { super.log(Level.WARNING, addColor(BOLD + INTENSE_YELLOW, message)); }
-    public void info(String message) { super.log(Level.INFO, addColor(INTENSE_WHITE, message)); }
+    public void info(String message) { super.log(Level.INFO, addColor(YELLOW, message)); }
     // Additional Log Levels
-    public void notice(String message) { logFilterLevel(NOTICE, addColor(INTENSE_CYAN, "[Notice] " + message)); }
+    public void notice(String message) { logFilterLevel(NOTICE, addColor(BLUE, "[Notice] " + message)); }
     public void helpful(String message) { logFilterLevel(HELPFUL, addColor(CYAN, "[Helpful] " + message)); }
     public void debug(String message) { logFilterLevel(DEBUG, addColor(DIM_GREY, "[Debug] " + message)); }
     public void debug(String message, boolean withChatColors) {

--- a/core/src/main/java/com/snowgears/shop/util/ShopLogger.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopLogger.java
@@ -147,6 +147,10 @@ public class ShopLogger extends Logger {
         setLevel(Level.ALL);
     }
 
+    public boolean isLevelEnabled(Level level) {
+        return this.getLogLevel().intValue() <= level.intValue();
+    }
+
     @Override
     public void log(@NotNull Level level, @NotNull String message) {
 

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -525,7 +525,7 @@ public class ShopMessage {
 
     private static HoverEvent getTransactionsHoverEvent(PlaceholderContext context) {
         try {
-            TextComponent hoverText = new TextComponent(context.getOfflineTransactions().getTransactionsLore());
+            BaseComponent hoverText = TextComponent.fromLegacy(context.getOfflineTransactions().getTransactionsLore());
             return new HoverEvent(HoverEvent.Action.SHOW_TEXT, new BaseComponent[]{hoverText});
         } catch (Exception e) {}
         return null;

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -242,8 +242,9 @@ public class ShopMessage {
     public static void sendMessage(String message, Player player, PlaceholderContext context) {
         TextComponent fancyMessage = format(message, context);
         // Verify we are not trying to send an empty string or null
-        if(!ChatColor.stripColor(fancyMessage.toLegacyText()).trim().isEmpty())
-            player.spigot().sendMessage(fancyMessage);
+        // if(!ChatColor.stripColor(fancyMessage.toLegacyText()).trim().isEmpty())
+        plugin.getLogger().debug("Sent msg to player " + player.getName() + ": " + fancyMessage.toLegacyText(), true);
+        player.spigot().sendMessage(fancyMessage);
     }
 
     /**

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -7,6 +7,8 @@ import com.snowgears.shop.shop.AbstractShop;
 import com.snowgears.shop.shop.ComboShop;
 import com.snowgears.shop.shop.ShopType;
 import net.md_5.bungee.api.chat.*;
+import net.md_5.bungee.api.chat.hover.content.Item;
+
 import org.bukkit.Bukkit;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Location;
@@ -534,6 +536,14 @@ public class ShopMessage {
             hoverItem.setAmount(1);
             BaseComponent[] component = new BaseComponent[]{new TextComponent(plugin.getNBTAdapter().getNBTforItem(hoverItem))};
             return new HoverEvent(HoverEvent.Action.SHOW_ITEM, component);
+            // 1.21.5 Paper - hover event is borked: https://github.com/PaperMC/Paper/issues/12289
+
+            // In theory in the future we could remove the NBTAPI dependency and do:
+            // String itemId = item.getType().getKey().toString();
+            // String nbt = item.getItemMeta().getAsString(); // Special Bukkit function to get the NBT as a string built for HoverEvents!
+            // ItemTag tag = ItemTag.ofNbt(nbt);
+            // Item itemContent = new Item(itemId, item.getAmount(), tag);
+            // return new HoverEvent(HoverEvent.Action.SHOW_ITEM, itemContent);
         } catch (Exception e) {
             return null;
         }

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -782,8 +782,10 @@ public class ShopMessage {
     //      # [server name] : The name of the server #
     public static String[] getSignLines(AbstractShop shop, ShopType shopType){
 
-        DisplayType displayType = shop.getDisplay().getType();
-        if(displayType == null)
+        DisplayType displayType = null;
+        if (shop.getDisplay() != null)
+            displayType = shop.getDisplay().getType();
+        if (displayType == null)
             displayType = Shop.getPlugin().getDisplayType();
 
         String shopFormat;

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -108,7 +108,10 @@ public class ShopMessage {
             } catch (Exception e) {
                 // Log the exception
                 Bukkit.getLogger().warning("Error replacing placeholder " + placeholder + ": " + e.getMessage());
-                e.printStackTrace();
+                // e.printStackTrace();
+            } catch (Error e) {
+                Bukkit.getLogger().warning("Error replacing placeholder " + placeholder + ": " + e.getMessage());
+                // e.printStackTrace();
             }
         }
         // If placeholder not found, remove the placeholder and just return an empty string
@@ -526,11 +529,17 @@ public class ShopMessage {
     }
 
     private static TextComponent embedItem(TextComponent message, ItemStack item) {
-        if (item == null) { return null; }
-        BaseComponent msg = TextComponent.fromLegacy(UtilMethods.removeColorsIfOnlyWhite(message.toLegacyText()));
-        HoverEvent event = getItemHoverEvent(item);
-        if (event != null) { msg.setHoverEvent(event); }
-        return (TextComponent) msg;
+        try {
+            if (item == null) { return null; }
+            BaseComponent msg = TextComponent.fromLegacy(UtilMethods.removeColorsIfOnlyWhite(message.toLegacyText()));
+            HoverEvent event = getItemHoverEvent(item);
+            if (event != null) { msg.setHoverEvent(event); }
+            return (TextComponent) msg;
+        } catch (Exception e) {
+            return message;
+        } catch (Error e) {
+            return message;
+        }
     }
 
     private static HoverEvent getTransactionsHoverEvent(PlaceholderContext context) {

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -27,7 +27,7 @@ public class ShopMessage {
 
     private static final Map<String, Function<PlaceholderContext, TextComponent>> placeholders = new HashMap<>();
     // Regex pattern to identify placeholders within square brackets, e.g., [owner]
-    private static final String COLOR_CODE_REGEX = "([&§][0-9A-FK-ORa-fk-or])";
+    private static final String COLOR_CODE_REGEX = "([&§][0-9A-FK-ORXa-fk-orx])";
     private static final String HEX_CODE_REGEX = "(#[0-9a-fA-F]{6})";
     // Modified placeholder regex to only match real placeholders
     private static final String PLACEHOLDER_REGEX = "(\\[([^&§#\\[\\]]+)\\])";
@@ -517,10 +517,10 @@ public class ShopMessage {
 
     private static TextComponent embedItem(TextComponent message, ItemStack item) {
         if (item == null) { return null; }
-        TextComponent msg = new TextComponent(message);
+        BaseComponent msg = TextComponent.fromLegacy(message.toLegacyText());
         HoverEvent event = getItemHoverEvent(item);
         if (event != null) { msg.setHoverEvent(event); }
-        return msg;
+        return (TextComponent) msg;
     }
 
     private static HoverEvent getTransactionsHoverEvent(PlaceholderContext context) {

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -57,7 +57,7 @@ public class ShopMessage {
     private static YamlConfiguration chatConfig;
     private static YamlConfiguration signConfig;
     private static YamlConfiguration displayConfig;
-
+    private static int targetMaxLength;
     public ShopMessage(Shop plugin) {
 
         File chatConfigFile = new File(plugin.getDataFolder(), "chatConfig.yml");
@@ -75,6 +75,7 @@ public class ShopMessage {
         freePriceWord = signConfig.getString("sign_text.zeroPrice");
         adminStockWord = signConfig.getString("sign_text.adminStock");
         serverDisplayName = signConfig.getString("sign_text.serverDisplayName");
+        targetMaxLength = displayConfig.getInt("targetMaxLength", 40);
 
         // Load in our placeholders
         this.loadPlaceholders();
@@ -886,8 +887,16 @@ public class ShopMessage {
             formattedLine = formatMessage(line, shop, null, false);
 //            formattedLine = ChatColor.translateAlternateColorCodes('&', formattedLine);
 
-            if(formattedLine != null && !formattedLine.isEmpty() && !ChatColor.stripColor(formattedLine).trim().isEmpty())
-                formattedLines.add(formattedLine);
+            Boolean splitLine = formattedLine.contains("[split]");
+            formattedLine = formattedLine.replace("[split]", "");
+            if(formattedLine != null && !formattedLine.isEmpty() && !ChatColor.stripColor(formattedLine).trim().isEmpty()) {
+                if (splitLine) {
+                    List<String> splitLines = UtilMethods.splitStringIntoLines(formattedLine, targetMaxLength);
+                    formattedLines.addAll(splitLines);
+                } else {
+                    formattedLines.add(formattedLine);
+                }
+            }
         }
         return formattedLines;
     }
@@ -1207,5 +1216,9 @@ public class ShopMessage {
             creationWords.put("COMBO", comboString.toLowerCase());
         else
             creationWords.put("COMBO", "combo");
+    }
+
+    public static int getTargetMaxLength() {
+        return targetMaxLength;
     }
 }

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -135,8 +135,8 @@ public class ShopMessage {
      * @return The formatted message with all placeholders replaced
      */
     public static TextComponent format(String message, PlaceholderContext context) {
-        TextComponent formattedMessage = new TextComponent("");
-        if (message == null) { return formattedMessage; }
+        TextComponent formattedMessage = null;
+        if (message == null) { return new TextComponent(""); }
         plugin.getLogger().spam("[ShopMessage] pre-format: " + ChatColor.translateAlternateColorCodes('&', message), true);
 
         // Define the regex pattern
@@ -200,7 +200,10 @@ public class ShopMessage {
                     plugin.getLogger().hyper("[ShopMessage.format]     replacing placeholder... " + part);
                     partComponent = replacePlaceholder(part, context);
                     // Check if we set a color inside our part (for example [stock color])
-                    if (partComponent.getColor() != latestColor && partComponent.getColor() != null && partComponent.getColor() != ChatColor.WHITE) { latestColor = partComponent.getColor(); }
+                    if (partComponent.getColor() != latestColor && partComponent.getColor() != null && partComponent.getColor() != ChatColor.WHITE) { 
+                        plugin.getLogger().hyper("[ShopMessage.format]     getting latestColor from partComponent: " + partComponent.getColor().getName().toUpperCase());
+                        latestColor = partComponent.getColor(); 
+                    }
                 }
             }
 
@@ -214,13 +217,18 @@ public class ShopMessage {
             partComponent.setStrikethrough(isStrikethrough);
             partComponent.setUnderlined(isUnderlined);
             partComponent.setObfuscated(isObfuscated);
-            // Add the part of the string to the
-            formattedMessage.addExtra(partComponent);
+            if (formattedMessage == null) {
+                formattedMessage = partComponent;
+            } else {
+                // Add the part of the string to the
+                formattedMessage.addExtra(partComponent);
+            }
             addedText = true;
             plugin.getLogger().hyper("[ShopMessage.format] *** add part TextComponent to main message: " + partComponent);
         }
 
         // Handle if we are just a color code with an empty string
+        if (formattedMessage == null) formattedMessage = new TextComponent("");
         if (!addedText && latestColor != null) formattedMessage.setColor(latestColor);
 
         plugin.getLogger().spam("[ShopMessage] postFormat: " + formattedMessage.toLegacyText(), true);
@@ -517,7 +525,7 @@ public class ShopMessage {
 
     private static TextComponent embedItem(TextComponent message, ItemStack item) {
         if (item == null) { return null; }
-        BaseComponent msg = TextComponent.fromLegacy(message.toLegacyText());
+        BaseComponent msg = TextComponent.fromLegacy(UtilMethods.removeColorsIfOnlyWhite(message.toLegacyText()));
         HoverEvent event = getItemHoverEvent(item);
         if (event != null) { msg.setHoverEvent(event); }
         return (TextComponent) msg;

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -178,6 +178,7 @@ public class ShopMessage {
                             isStrikethrough = false;
                             isUnderlined = false;
                             isObfuscated = false;
+                            formattedMessage.addExtra("§r");
                         } else {
                             latestColor = newColor;
                         }

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -604,7 +604,10 @@ public class ShopMessage {
             Iterator<ShopType> typeIterator = typeList.iterator();
             while (typeIterator.hasNext()) {
                 ShopType type = typeIterator.next();
-                if (!player.hasPermission("shop.operator") && !player.hasPermission("shop.create." + type.toString())) {
+                if (
+                    !player.hasPermission("shop.operator") 
+                    && !player.hasPermission("shop.create." + type.toString()) 
+                    && !player.hasPermission("shop.create")) {
                     typeIterator.remove();
                 }
             }

--- a/core/src/main/java/com/snowgears/shop/util/Transaction.java
+++ b/core/src/main/java/com/snowgears/shop/util/Transaction.java
@@ -98,6 +98,12 @@ public class Transaction {
     public void negotiatePurchase(int desiredAmount) {
         // Don't perform this processing if we are a gamble shop!
         if (shop.getType() == ShopType.GAMBLE) { return; }
+        // Handle free transactions
+        if (shop.getPrice() == 0) {
+            this.price = 0;
+            this.amountBeingSold = this.shop.getAmount();
+            return;
+        }
 
         PriceNegotiator negotiator = new PriceNegotiator(
             TX_DEBUG_LOGGING, 

--- a/core/src/main/java/com/snowgears/shop/util/Transaction.java
+++ b/core/src/main/java/com/snowgears/shop/util/Transaction.java
@@ -109,7 +109,7 @@ public class Transaction {
             TX_DEBUG_LOGGING, 
             this.originalPrice, 
             this.originalAmountBeingSold, 
-            Shop.getPlugin().getCurrencyType() == CurrencyType.VAULT
+            Shop.getPlugin().getAllowFractionalCurrency()
         );
 
         negotiator.negotiatePurchase(

--- a/core/src/main/java/com/snowgears/shop/util/Transaction.java
+++ b/core/src/main/java/com/snowgears/shop/util/Transaction.java
@@ -53,7 +53,22 @@ public class Transaction {
         this.itemBeingSold = shop.getItemStack();
         this.amountBeingSold = shop.getAmount();
 
-        if (transactionType == ShopType.GAMBLE) {
+        if (shop instanceof ComboShop) {
+            this.price = ((ComboShop)shop).getPriceSell();
+            // From players perspective, they are selling to the shop
+            if (transactionType == ShopType.SELL) {
+                this.buyer = new TransactionParty(false, shop.isAdmin(), shop.getOwner(), shop.getInventory());
+                this.seller = new TransactionParty(true, false, player, player.getInventory());
+                this.price = ((ComboShop)shop).getPriceSell();
+            } 
+            // From players perspective, they are buying from the shop
+            else if (transactionType == ShopType.BUY) {
+                this.buyer = new TransactionParty(true, false, player, player.getInventory());
+                this.seller = new TransactionParty(false, shop.isAdmin(), shop.getOwner(), shop.getInventory());
+                this.price = ((ComboShop)shop).getPriceBuy();
+            }
+        }
+        else if (transactionType == ShopType.GAMBLE) {
             this.buyer = new TransactionParty(true, false, player, player.getInventory());
             this.seller = new TransactionParty(false, shop.isAdmin(), shop.getOwner(), shop.getInventory());
 
@@ -76,11 +91,6 @@ public class Transaction {
             // Shop is selling to the player
             this.buyer = new TransactionParty(true, false, player, player.getInventory());
             this.seller = new TransactionParty(false, shop.isAdmin(), shop.getOwner(), shop.getInventory());
-
-            // If we are a combo shop, then we need to grab the sell price
-            if (shop instanceof ComboShop) {
-                this.price = ((ComboShop)shop).getPriceSell();
-            }
         }
 
         // Store the original values for the price/amount that comes from the shop directly

--- a/core/src/main/java/com/snowgears/shop/util/Transaction.java
+++ b/core/src/main/java/com/snowgears/shop/util/Transaction.java
@@ -99,7 +99,12 @@ public class Transaction {
         // Don't perform this processing if we are a gamble shop!
         if (shop.getType() == ShopType.GAMBLE) { return; }
 
-        PriceNegotiator negotiator = new PriceNegotiator(TX_DEBUG_LOGGING, this.originalPrice, this.originalAmountBeingSold);
+        PriceNegotiator negotiator = new PriceNegotiator(
+            TX_DEBUG_LOGGING, 
+            this.originalPrice, 
+            this.originalAmountBeingSold, 
+            Shop.getPlugin().getCurrencyType() == CurrencyType.VAULT
+        );
 
         negotiator.negotiatePurchase(
                 Shop.getPlugin().getAllowPartialSales(),

--- a/core/src/main/java/com/snowgears/shop/util/UpdateChecker.java
+++ b/core/src/main/java/com/snowgears/shop/util/UpdateChecker.java
@@ -14,8 +14,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
-import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import com.tcoded.folialib.wrapper.task.WrappedTask;
 
 import javax.net.ssl.HttpsURLConnection;
 import java.io.BufferedReader;
@@ -41,6 +41,7 @@ public class UpdateChecker {
     //PermissionDefault.TRUE == all OPs are notified regardless of having the permission.
     private static final Permission UPDATE_PERM = new Permission("shop.update", PermissionDefault.FALSE);
     private static final long CHECK_INTERVAL = 12_000; //In ticks.
+    private WrappedTask task;
 
 
     public UpdateChecker(final Shop plugin) {
@@ -49,7 +50,7 @@ public class UpdateChecker {
     }
 
     public void checkForUpdate() {
-        plugin.getFoliaLib().getScheduler().runTimer(new BukkitRunnable() {
+        task = plugin.getFoliaLib().getScheduler().runTimer(new BukkitRunnable() {
             @Override
             public void run() {
                 //The request is executed asynchronously as to not block the main thread.
@@ -62,7 +63,7 @@ public class UpdateChecker {
                     } catch (final IOException e) {
                         Bukkit.getServer().getConsoleSender().sendMessage(ChatColor.translateAlternateColorCodes('&', ERR_MSG));
                         e.printStackTrace();
-                        // cancel();
+                        cancelTask();
                         return;
                     }
 
@@ -100,10 +101,14 @@ public class UpdateChecker {
                         }, plugin));
                     }
 
-                    // cancel(); //Cancel the runnable as an update has been found.
+                    cancelTask(); //Cancel the runnable as an update has been found.
                 });
             }
         }, 1, CHECK_INTERVAL);
+    }
+
+    public void cancelTask() {
+        plugin.getFoliaLib().getScheduler().cancelTask(task);
     }
 
     private String embedVersions(String msg, String runningVersion, String latestReleasedVersion) {

--- a/core/src/main/java/com/snowgears/shop/util/UpdateChecker.java
+++ b/core/src/main/java/com/snowgears/shop/util/UpdateChecker.java
@@ -49,7 +49,7 @@ public class UpdateChecker {
     }
 
     public void checkForUpdate() {
-        new BukkitRunnable() {
+        plugin.getFoliaLib().getScheduler().runTimer(new BukkitRunnable() {
             @Override
             public void run() {
                 //The request is executed asynchronously as to not block the main thread.
@@ -62,7 +62,7 @@ public class UpdateChecker {
                     } catch (final IOException e) {
                         Bukkit.getServer().getConsoleSender().sendMessage(ChatColor.translateAlternateColorCodes('&', ERR_MSG));
                         e.printStackTrace();
-                        cancel();
+                        // cancel();
                         return;
                     }
 
@@ -100,10 +100,10 @@ public class UpdateChecker {
                         }, plugin));
                     }
 
-                    cancel(); //Cancel the runnable as an update has been found.
+                    // cancel(); //Cancel the runnable as an update has been found.
                 });
             }
-        }.runTaskTimer(plugin, 0, CHECK_INTERVAL);
+        }, 1, CHECK_INTERVAL);
     }
 
     private String embedVersions(String msg, String runningVersion, String latestReleasedVersion) {

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -478,6 +478,25 @@ public class UtilMethods {
                 formattedMessage.addExtra(" (" + material.replace(" Material", "") + ")]");
             }
         }
+        
+        // Add support for displaying music disc information and goat horn sounds
+        if(item.getItemMeta() != null) {
+            String itemType = item.getType().name();
+            
+            // Add support for displaying music disc information
+            if(itemType.startsWith("MUSIC_DISC_")) {
+                String trackName = itemType.replace("MUSIC_DISC_", "");
+                String formattedName = capitalize(trackName.toLowerCase().replace("_", " "));
+                formattedMessage.addExtra(" [Song: " + formattedName + "]");
+            }
+            // Handle legacy music disc naming that doesn't follow the MUSIC_DISC_ prefix pattern
+            else if(itemType.equals("MUSIC_DISC")) { formattedMessage.addExtra(" [Song: Unknown]"); }
+            else if(itemType.equals("PIGSTEP")) { formattedMessage.addExtra(" [Song: Pigstep]"); }
+            else if(itemType.equals("OTHERSIDE")) { formattedMessage.addExtra(" [Song: Otherside]"); }
+            else if(itemType.equals("FIVE")) { formattedMessage.addExtra(" [Song: 5]"); }
+            else if(itemType.equals("RELIC")) { formattedMessage.addExtra(" [Song: Relic]"); }
+            
+        }
 
         // Add custom potion formatting
         if(item.getItemMeta() != null && item.getItemMeta() instanceof PotionMeta){
@@ -820,8 +839,6 @@ public class UtilMethods {
                             currentLine = new StringBuilder(latestColors);
                         }
                     }
-                    // Set the current line to the new color, ignore any old colors
-                    currentLine = new StringBuilder(latestColors);
                 }
 
                 continue;

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -804,9 +804,21 @@ public class UtilMethods {
 
                 if (!latestColors.equals(newColors)) {
                     latestColors = newColors;
-                    // New color, add the line and start a new line
-                    if (ChatColor.stripColor(currentLine.toString()).length() > 0) {
-                        linesByColor.add(currentLine.toString());
+                    if (currentLine.toString().contains(" ")) {
+                        // New color, add the line and start a new line
+                        if (ChatColor.stripColor(currentLine.toString()).length() > 0) {
+                            linesByColor.add(currentLine.toString());
+                        }
+                        // Set the current line to the new color, ignore any old colors
+                        currentLine = new StringBuilder(latestColors);
+                    } else {
+                        // If our current line has text other than color codes, add the latest color code.
+                        if (ChatColor.stripColor(currentLine.toString()).length() > 0) {
+                            currentLine.append(word);
+                        } else {
+                            // We are just useless colors, wipe them and start the line again with our current colors.
+                            currentLine = new StringBuilder(latestColors);
+                        }
                     }
                     // Set the current line to the new color, ignore any old colors
                     currentLine = new StringBuilder(latestColors);

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -53,7 +53,7 @@ public class UtilMethods {
             // Handle color codes (they don't take up width)
             if ((c == '§' || c == '&') && i + 1 < text.length()) {
                 char nextChar = text.charAt(i + 1);
-                if ("0123456789abcdefklmnorABCDEFKLMNOR".indexOf(nextChar) != -1) {
+                if ("0123456789abcdefklmnorxABCDEFKLMNORX".indexOf(nextChar) != -1) {
                     result.append(c).append(nextChar);
                     i++; // Skip the next character (color code)
                     continue;

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -798,7 +798,7 @@ public class UtilMethods {
             int potentialLength = ChatColor.stripColor(currentLine.toString()).length() + ChatColor.stripColor(word).length() + 1;
             Shop.getPlugin().getLogger().spam("[ShopMessage.format]     potentialLength: " + potentialLength + " maxLineLength: " + maxLineLength);
             if (word.matches(" ") && potentialLength > maxLineLength) {
-                Shop.getPlugin().getLogger().debug("[ShopMessage.format]     adding line: " + currentLine.toString().trim());
+                Shop.getPlugin().getLogger().spam("[ShopMessage.format]     adding line: " + currentLine.toString().trim(), true);
                 linesByColor.add(currentLine.toString());
                 currentLine = new StringBuilder(latestColors);
             } else {
@@ -808,7 +808,7 @@ public class UtilMethods {
 
         // Append the last line if there's any content left
         if (currentLine.length() > 0) {
-            Shop.getPlugin().getLogger().debug("[ShopMessage.format]     adding line: " + currentLine.toString().trim());
+            Shop.getPlugin().getLogger().spam("[ShopMessage.format]     adding line: " + currentLine.toString().trim(), true);
             linesByColor.add(currentLine.toString());
         }
 

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -496,6 +496,24 @@ public class UtilMethods {
             else if(itemType.equals("FIVE")) { formattedMessage.addExtra(" [Song: 5]"); }
             else if(itemType.equals("RELIC")) { formattedMessage.addExtra(" [Song: Relic]"); }
             
+            // Add support for displaying goat horn sounds
+            else if(itemType.equals("GOAT_HORN")) {
+                // Try to get the instrument type from item data if available
+                try {
+                    org.bukkit.inventory.meta.MusicInstrumentMeta instrumentMeta = (org.bukkit.inventory.meta.MusicInstrumentMeta) item.getItemMeta();
+                    if (instrumentMeta != null && instrumentMeta.getInstrument() != null) {
+                        String instrumentKey = instrumentMeta.getInstrument().getKey().getKey();
+                        // Format the instrument key properly (e.g., "ponder_goat_horn" -> "Ponder")
+                        String soundType = instrumentKey.replace("_goat_horn", "");
+                        formattedMessage.addExtra(" [Sound: " + capitalize(soundType) + "]");
+                    } else {
+                        formattedMessage.addExtra(" [Sound: Unknown]");
+                    }
+                } catch (Exception e) {
+                    // Fallback for older versions or if the meta is not available
+                    formattedMessage.addExtra(" [Sound: Unknown]");
+                }
+            }
         }
 
         // Add custom potion formatting

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -736,15 +736,47 @@ public class UtilMethods {
         StringBuilder currentLine = new StringBuilder();
         List<String> linesByColor = new ArrayList<>();
 
-        String latestColor = "";
+        String latestColors = "";
+        ChatColor latestColor = ChatColor.WHITE;
+        boolean isBold = false;
+        boolean isItalic = false;
+        boolean isStrikethrough = false;
+        boolean isUnderlined = false;
+        boolean isObfuscated = false;
         for (String word : words) {
             if (word.matches(COLOR_CODE_REGEX)) {
-                if (!latestColor.equals(word)) {
-                    latestColor = word;
+                ChatColor newColor = ChatColor.getByChar(word.charAt(1));
+                if (newColor == ChatColor.BOLD) isBold = true;
+                else if (newColor == ChatColor.ITALIC) isItalic = true;
+                else if (newColor == ChatColor.STRIKETHROUGH) isStrikethrough = true;
+                else if (newColor == ChatColor.UNDERLINE) isUnderlined = true;
+                else if (newColor == ChatColor.MAGIC) isObfuscated = true;
+                else if (newColor == ChatColor.RESET) {
+                    Shop.getPlugin().getLogger().hyper("[ShopMessage.format]     matched RESET color code: " + word);
+                    latestColor = ChatColor.WHITE;
+                    isBold = false;
+                    isItalic = false;
+                    isStrikethrough = false;
+                    isUnderlined = false;
+                    isObfuscated = false;
+                } else {
+                    latestColor = newColor;
+                }
+
+                String newColors = latestColor.toString();
+                if (isBold) newColors += ChatColor.BOLD;
+                if (isItalic) newColors += ChatColor.ITALIC;
+                if (isStrikethrough) newColors += ChatColor.STRIKETHROUGH;
+                if (isUnderlined) newColors += ChatColor.UNDERLINE;
+                if (isObfuscated) newColors += ChatColor.MAGIC;
+
+                if (!latestColors.equals(newColors)) {
+                    latestColors = newColors;
                     // New color, add the line and start a new line
                     linesByColor.add(currentLine.toString().trim());
-                    currentLine = new StringBuilder(latestColor);
+                    currentLine = new StringBuilder(latestColors);
                 }
+
                 continue;
             }
 
@@ -752,7 +784,8 @@ public class UtilMethods {
             int potentialLength = ChatColor.stripColor(currentLine.toString()).length() + ChatColor.stripColor(word).length() + 1;
             if (word.matches(" ") && potentialLength > maxLineLength) {
                 linesByColor.add(currentLine.toString().trim());
-                currentLine = new StringBuilder(latestColor);
+                Shop.getPlugin().getLogger().hyper("[ShopMessage.format]     matched RESET color code: " + word);
+                currentLine = new StringBuilder(latestColors);
             } else {
                 currentLine.append(word);
             }

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -725,9 +725,10 @@ public class UtilMethods {
     }
 
     public static List<String> splitStringIntoLines(String text, int maxLineLength) {
+        final String HEX_COLOR_CODE_REGEX = "(§x§.§.§.§.§.§.)"; // Hex code format using mc color codes
         final String COLOR_CODE_REGEX = "([&§][0-9A-FK-ORa-fk-or])";
 
-        Matcher matcher = Pattern.compile(COLOR_CODE_REGEX + "| |[^&§\\s]+").matcher(text);
+        Matcher matcher = Pattern.compile(HEX_COLOR_CODE_REGEX + "|" + COLOR_CODE_REGEX + "| |[^&§\\s]+").matcher(text);
         List<String> words = new ArrayList<>();
         while (matcher.find()) {
             words.add(matcher.group());
@@ -744,6 +745,7 @@ public class UtilMethods {
         boolean isUnderlined = false;
         boolean isObfuscated = false;
         for (String word : words) {
+            Shop.getPlugin().getLogger().hyper("[ShopMessage.format]     word: " + word);
             if (word.matches(COLOR_CODE_REGEX)) {
                 ChatColor newColor = ChatColor.getByChar(word.charAt(1));
                 if (newColor == ChatColor.BOLD) isBold = true;
@@ -773,7 +775,7 @@ public class UtilMethods {
                 if (!latestColors.equals(newColors)) {
                     latestColors = newColors;
                     // New color, add the line and start a new line
-                    linesByColor.add(currentLine.toString().trim());
+                    linesByColor.add(currentLine.toString());
                     currentLine = new StringBuilder(latestColors);
                 }
 
@@ -782,9 +784,10 @@ public class UtilMethods {
 
             // Also split if the single color line is too long!
             int potentialLength = ChatColor.stripColor(currentLine.toString()).length() + ChatColor.stripColor(word).length() + 1;
+            Shop.getPlugin().getLogger().spam("[ShopMessage.format]     potentialLength: " + potentialLength + " maxLineLength: " + maxLineLength);
             if (word.matches(" ") && potentialLength > maxLineLength) {
-                linesByColor.add(currentLine.toString().trim());
-                Shop.getPlugin().getLogger().hyper("[ShopMessage.format]     matched RESET color code: " + word);
+                Shop.getPlugin().getLogger().debug("[ShopMessage.format]     adding line: " + currentLine.toString().trim());
+                linesByColor.add(currentLine.toString());
                 currentLine = new StringBuilder(latestColors);
             } else {
                 currentLine.append(word);
@@ -793,7 +796,8 @@ public class UtilMethods {
 
         // Append the last line if there's any content left
         if (currentLine.length() > 0) {
-            linesByColor.add(currentLine.toString().trim());
+            Shop.getPlugin().getLogger().debug("[ShopMessage.format]     adding line: " + currentLine.toString().trim());
+            linesByColor.add(currentLine.toString());
         }
 
         // Now we need to start taking the "blocks" of text and combining them into lines, limited by maxLineLength
@@ -803,14 +807,14 @@ public class UtilMethods {
             // Add it if we are less than the max line length or if the line is only a color
             if (currentLine.length() + line.length() <= maxLineLength || ChatColor.stripColor(line).length() == 0) {
                 if (currentLine.toString().trim().length() == 0 || ChatColor.stripColor(line).trim().length() == 0) currentLine.append(line);
-                else currentLine.append(" " + line);
+                else currentLine.append(line);
             } else {
-                result.add(currentLine.toString().trim());
+                result.add(currentLine.toString().trim()); // only trim on final add
                 currentLine = new StringBuilder(line);
             }
         }
         if (currentLine.length() > 0) {
-            result.add(currentLine.toString().trim());
+            result.add(currentLine.toString().trim()); // only trim on final add
         }
         return result;
     }

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -3,6 +3,7 @@ package com.snowgears.shop.util;
 import net.md_5.bungee.api.ChatColor;
 import com.snowgears.shop.Shop;
 import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.*;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -432,6 +433,17 @@ public class UtilMethods {
         return " " + romanNumerals[number - 1];
     }
 
+    // Remove white color codes if the message only contains white color codes
+    // This can occur since we are building up TextComponents and it adds white color codes to the start of messages
+    public static String removeColorsIfOnlyWhite(String message){
+        String COLOR_CODE_REGEX_NO_WHITE = "([&§][0-9A-EK-ORXa-ek-orx])";
+        // Check if there are any non-white color codes in the message
+        boolean hasOtherColors = Pattern.compile(COLOR_CODE_REGEX_NO_WHITE).matcher(message).find();
+        String msgStr = message;
+        if (!hasOtherColors) { msgStr = ChatColor.stripColor(msgStr); }
+        return msgStr;
+    }
+
     public static TextComponent getEnchantmentsComponent(ItemStack item){
         TextComponent formattedMessage = new TextComponent("");
 
@@ -487,8 +499,8 @@ public class UtilMethods {
             if (power == 0) power = 1;
             formattedMessage.addExtra(" [Duration " + power + "]");
         }
-        
-        return formattedMessage;
+
+        return new TextComponent(ChatColor.stripColor(formattedMessage.toLegacyText()));
     }
 
     private static TextComponent getPotionEffects(List<PotionEffect> effects){

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -552,14 +552,26 @@ public class UtilMethods {
             }
         }
 
+        // Add Ominous Bottle support (Bad Omen level)
+        try {
+            if(item.getItemMeta() != null && item.getItemMeta() instanceof org.bukkit.inventory.meta.OminousBottleMeta) {
+                org.bukkit.inventory.meta.OminousBottleMeta ominousMeta = (org.bukkit.inventory.meta.OminousBottleMeta) item.getItemMeta();
+                int level = ominousMeta.hasAmplifier() ? ominousMeta.getAmplifier() + 1 : 1; // zero based
+                formattedMessage.addExtra(" [Bad Omen" + formatRomanNumerals(level) + "]");
+            }
+        } catch (Error e) {} catch (Exception e) {  /* This might happen on older versions where OminousBottleMeta isn't available */ }
+
         // Add custom potion formatting
         if(item.getItemMeta() != null && item.getItemMeta() instanceof PotionMeta){
             PotionMeta potionMeta = (PotionMeta) item.getItemMeta();
             if (potionMeta.getBasePotionType() != null) {
                 formattedMessage.addExtra(getPotionEffects(potionMeta.getBasePotionType().getPotionEffects()));
             }
-            if (potionMeta.getCustomEffects().size() > 0) {
-                formattedMessage.addExtra(getPotionEffects(potionMeta.getCustomEffects()));
+            
+            // Check for custom effects
+            List<PotionEffect> customEffects = potionMeta.getCustomEffects();
+            if(!customEffects.isEmpty()) {
+                formattedMessage.addExtra(getPotionEffects(customEffects));
             }
         }
 

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -514,6 +514,42 @@ public class UtilMethods {
                     formattedMessage.addExtra(" [Sound: Unknown]");
                 }
             }
+            
+            // Add support for displaying bee hive/nest information
+            else if(itemType.equals("BEE_NEST") || itemType.equals("BEEHIVE")) {
+                try {
+                    if(item.getItemMeta() instanceof org.bukkit.inventory.meta.BlockStateMeta) {
+                        org.bukkit.inventory.meta.BlockStateMeta blockStateMeta = (org.bukkit.inventory.meta.BlockStateMeta) item.getItemMeta();
+                        
+                        if(blockStateMeta.hasBlockState() && blockStateMeta.getBlockState() instanceof org.bukkit.block.Beehive) {
+                            org.bukkit.block.Beehive beehive = (org.bukkit.block.Beehive) blockStateMeta.getBlockState();
+                            
+                            int honeyLevel = 0;
+                            int beeCount = 0;
+                            
+                            // Get honey level (this is from BlockData)
+                            try {
+                                org.bukkit.block.data.type.Beehive beehiveData = (org.bukkit.block.data.type.Beehive) beehive.getBlockData();
+                                honeyLevel = beehiveData.getHoneyLevel();
+                            } catch (Exception e) { }
+                            // Get bee count (this is from the entity storage)
+                            try { beeCount = beehive.getEntityCount(); } catch (Exception e) {}
+                            
+                            // Format the message
+                            if(honeyLevel > 0 || beeCount > 0) {
+                                StringBuilder beeInfo = new StringBuilder(" [");
+                                if(honeyLevel > 0) {
+                                    beeInfo.append("Honey: ").append(honeyLevel).append("/5");
+                                    if(beeCount > 0) { beeInfo.append(", "); }
+                                }
+                                if(beeCount > 0) { beeInfo.append("Bees: ").append(beeCount); }
+                                beeInfo.append("]");
+                                formattedMessage.addExtra(beeInfo.toString());
+                            }
+                        }
+                    }
+                } catch (Exception e) { /* Silently handle any exceptions for backward compatibility */ }
+            }
         }
 
         // Add custom potion formatting

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -555,10 +555,7 @@ public class UtilMethods {
         // Add custom potion formatting
         if(item.getItemMeta() != null && item.getItemMeta() instanceof PotionMeta){
             PotionMeta potionMeta = (PotionMeta) item.getItemMeta();
-            String formattedName = "";
             if (potionMeta.getBasePotionType() != null) {
-                formattedName = UtilMethods.capitalize(potionMeta.getBasePotionType().toString().replace("_", " ").toLowerCase());
-                formattedMessage.addExtra(" [" + formattedName + "]");
                 formattedMessage.addExtra(getPotionEffects(potionMeta.getBasePotionType().getPotionEffects()));
             }
             if (potionMeta.getCustomEffects().size() > 0) {
@@ -584,8 +581,22 @@ public class UtilMethods {
         for (int i = 0; i < numEffects; i++) {
             PotionEffect effect = effects.get(i);
             formattedEffects.addExtra(new TranslatableComponent(effect.getType().getTranslationKey()));
-            if(effect.getAmplifier() > 0) formattedEffects.addExtra(formatRomanNumerals(effect.getAmplifier()));
-            if(effect.getDuration() > 0) formattedEffects.addExtra(formatTickTime(effect.getDuration()));
+            
+            // Show level for all potions, not just those with amplifier > 0
+            // For potions with amplifier 0, we don't add any suffix (it's the base level)
+            if(effect.getAmplifier() > 0) {
+                formattedEffects.addExtra(formatRomanNumerals(effect.getAmplifier() + 1)); // +1 because amplifier is 0-based
+            }
+            
+            // Only add duration for non-instant effects
+            // Instant effects like Instant Health and Instant Damage shouldn't show duration
+            boolean isInstantEffect = effect.getType().equals(org.bukkit.potion.PotionEffectType.INSTANT_HEALTH) || 
+                                     effect.getType().equals(org.bukkit.potion.PotionEffectType.INSTANT_DAMAGE);
+            
+            if(effect.getDuration() > 0 && !isInstantEffect) {
+                formattedEffects.addExtra(formatTickTime(effect.getDuration()));
+            }
+            
             // if we have more than one effect, add a comma, dont add a comma after the last effect
             if(i < numEffects - 1)
                 formattedEffects.addExtra(", ");

--- a/core/src/main/resources/chatConfig.yml
+++ b/core/src/main/resources/chatConfig.yml
@@ -164,8 +164,8 @@ interaction:
       opDestroy: "&7You have destroyed a combo shop owned by [owner]."
       opOpen: "&7You are opening a combo shop owned by [owner]."
       createHitChestAmount: '&eEnter in chat the amount of &a[item](s)&b[item enchants] &eyou want to buy/sell per transaction.'
-      createHitChestPrice: '&eEnter in chat the price players will &dBUY &a[item](x[item amount])&b[item enchants] &efor.'
-      createHitChestPriceCombo: '&eEnter in chat the price players you will &dSELL &a[item](x[item amount])&b[item enchants] &efor.'
+      createHitChestPrice: '&eEnter in chat the price you will &dBUY &a[item](x[item amount])&b[item enchants] &efor.'
+      createHitChestPriceCombo: '&eEnter in chat the price you will &dSELL &a[item](x[item amount])&b[item enchants] &efor.'
    GAMBLE:
       create: "&eYou have created a gambling shop."
       opDestroy: "&7You have destroyed a gambling shop owned by [server name]."

--- a/core/src/main/resources/chatConfig.yml
+++ b/core/src/main/resources/chatConfig.yml
@@ -246,7 +246,7 @@ permission:
    use: "&cYou are not authorized to use [shop type] shops."
    create: "&cYou are not authorized to create [shop type] shops."
    destroy: "&cYou are not authorized to destroy shops."
-   buildLimit: "&cYou have already reached your build limit of [build limit] shops."
+   buildLimit: "&cYou have already reached your build limit of [user amount]/[build limit] shops."
 
 hover:
    location:

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -51,6 +51,10 @@ currency:
    name: "Emerald(s)"
    format: "[price] [name]"
 
+# Does your currency support fractional units?
+# false (default) - Only allow whole currency units
+# true - Allow fractional units down to 0.01 (Vault Required!)
+allowFractionalCurrency: false
 # This allows shops to sell partial stacks for a calculated partial rate if the shop is low on stock #
 # https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#allowpartialsales #
 allowPartialSales: true

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -1,4 +1,3 @@
-
 # =================================================================== #
 #                         GENERAL SETTINGS                            #
 # =================================================================== #
@@ -127,6 +126,7 @@ setGlowingItemFrame: false
 
 # This controls whether shop sign text should be glowing by default #
 # THIS CAN ONLY BE USED IN MINECRAFT 1.17 OR ABOVE #
+# Signs on Bedrock Edition might look dimmed out
 setGlowingSignText: false
 
 # =================================================================== #
@@ -289,6 +289,38 @@ bluemap-marker:
       </div>
    minDistance: 0
    maxDistance: 500
+
+# =================================================================== #
+#                   SHOP PERFORMANCE OPTIMIZATIONS                    #
+# =================================================================== #
+
+# You should not need to change these settings, we have tried to balance them for performance & experience. #
+# If you are experiencing performance issues however, you can try to tune them. #
+
+# How often (in seconds) to check for shop displays that need to be shown to players
+# Lower values make shop displays appear faster.
+# You can increase this if you are experiencing performance issues to reduce the number of checks.
+displayProcessInterval: 1
+
+# How far a player needs to move (in blocks) before shop display checks should be processed
+# This prevents unnecessary processing when players are standing still
+# Recommended range: 1-4, default: 1.0
+displayMovementThreshold: 1.0
+
+# Maximum distance (in blocks) at which shop displays will be shown to players.
+# Mainly affects player performance, not server performance.
+# Recommended range: 10-20, default: 16.0
+# For an extra smooth experience, you can set this higher to around 32 (radius 2), but this will also increase resource usage on the server.
+# NOTE: Default "Entity Render Distance" settings for the Minecraft client is 20 blocks,
+#       so setting this higher than 20 will only "preload" shop displays for players beyond this distance.
+maxShopDisplayDistance: 16.0
+
+# Radius (in chunks) around a player to search for shops
+# Each increment searches exponentially more chunks (1=3x3 area, 2=5x5 area, etc)
+# Recommended: 1, default: 1
+# You can set this higher, but unless you are going above 20, you should not see any difference.
+# The code is highly optimized, so you can set this higher, but you should not need to.
+shopSearchRadius: 1
 
 # =================================================================== #
 #                            DEBUG TOOLS                              #

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -340,6 +340,22 @@ maxShopDisplayDistance: 20.0
 # The code is highly optimized, so you can set this higher, but you should not need to.
 shopSearchRadius: 1
 
+# Number of shop displays to process in a single batch when sending to a player
+# This setting helps make shop displays appear more smoothly by sending them in smaller groups
+# Lower values create a smoother experience but take longer to fully load all displays
+# Higher values load displays faster but may cause momentary client lag
+# This primarily affects client-side performance, not server performance
+# Recommended range: 5-20, default: 10
+displayBatchSize: 10
+
+# Delay between batches of shop displays in server ticks (20 ticks = 1 second)
+# This setting controls how much time passes between sending each batch of displays to a player
+# Lower values make all displays appear faster but may cause client stuttering
+# Higher values create a smoother appearance but take longer to show all displays
+# This primarily affects client-side experience, not server performance
+# Recommended range: 1-3, default: 2
+displayBatchDelay: 2
+
 # =================================================================== #
 #                            DEBUG TOOLS                              #
 # =================================================================== #

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -1,6 +1,11 @@
+#
+# WIKI PAGE: https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml) #
+#
+
 # =================================================================== #
 #                         GENERAL SETTINGS                            #
 # =================================================================== #
+# https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#general-settings
 # This runs a check and notifies operators on login that a new Shop version is available #
 checkUpdates: true
 
@@ -24,6 +29,7 @@ deletePlayerShopsAfterXHoursOffline: 0
 # =================================================================== #
 #                      CURRENCY AND ECONOMY                           #
 # =================================================================== #
+# https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#currency-and-economy-settings
 
 # type :
 # ITEM - shops will use a specified item as the currency (default is Emerald). To change this item in-game, run the
@@ -46,6 +52,7 @@ currency:
    format: "[price] [name]"
 
 # This allows shops to sell partial stacks for a calculated partial rate if the shop is low on stock #
+# https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#allowpartialsales #
 allowPartialSales: true
 # This will make it so shops will only complete transactions if the item durabilities are the same #
 checkItemDurability: true
@@ -93,6 +100,7 @@ priceSuffixes:
 # =================================================================== #
 #                           SHOP DISPLAY                              #
 # =================================================================== #
+# https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#shop-display
 
 # This will change the type of item display that shops will use by default above their chests #
 # The options are: NONE, ITEM, GLASS_CASE, LARGE_ITEM, ITEM_FRAME #
@@ -132,6 +140,7 @@ setGlowingSignText: false
 # =================================================================== #
 #                         SHOP INTERACTIONS                           #
 # =================================================================== #
+# https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#shop-interactions
 
 # Here you can map player actions on shops to specific controls
 #   - NONE
@@ -215,6 +224,7 @@ enabledContainers:
 #                    DATABASE LOGGING SETTINGS                        #
 #                  OFFLINE PURCHASE NOTIFICATIONS                     #
 # =================================================================== #
+# https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#database-logging--notifications
 
 # Database logging for player Shop Actions & Transactions #
 # Required for Offline Purchase Notifications to be sent, default enabled with FILE database #
@@ -240,6 +250,7 @@ logging:
       - "useSSL=false"
 
 # Logging must be enabled for purchase notifications to appear!
+# Check chatConfig.yml to customize the offline purchase notification message #
 offlinePurchaseNotifications:
    # Should offline purchases be shown to the user
    enabled: true
@@ -247,6 +258,7 @@ offlinePurchaseNotifications:
 # =================================================================== #
 #                    INTEGRATION HOOK SETTINGS                        #
 # =================================================================== #
+# https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#integrations
 
 # The following plugins are automatically integrated when detected (no configuration needed):
 # - LWC: Protects shops from being broken into by non-owners & allows player purchases
@@ -259,6 +271,7 @@ offlinePurchaseNotifications:
 # If WorldGuard is installed Shop will by default ALWAYS respect the WG flags 'passthrough', 'build', 'chest-access'. #
 # If you would like to ADDITIONALLY require Shops to be created in WorldGuard regions with a Shop flag set (flag=allow-shop), set `hookWorldGuard` to `true` #
 # WorldGuard plugin must be installed for this feature to work #
+# For more details: https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#hookWorldGuard #
 hookWorldGuard: false
 
 # Setting this to true will force all Shops to be created in Towny regions where the players are residents #
@@ -293,6 +306,7 @@ bluemap-marker:
 # =================================================================== #
 #                   SHOP PERFORMANCE OPTIMIZATIONS                    #
 # =================================================================== #
+# https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#shop-performance-optimizations
 
 # You should not need to change these settings, we have tried to balance them for performance & experience. #
 # If you are experiencing performance issues however, you can try to tune them. #
@@ -325,6 +339,7 @@ shopSearchRadius: 1
 # =================================================================== #
 #                            DEBUG TOOLS                              #
 # =================================================================== #
+# https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#debug-tools
 
 # Normally Developer Use only, but helpful if you are running into bugs and want more details!
 #

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -244,6 +244,14 @@ offlinePurchaseNotifications:
 #                    INTEGRATION HOOK SETTINGS                        #
 # =================================================================== #
 
+# The following plugins are automatically integrated when detected (no configuration needed):
+# - LWC: Protects shops from being broken into by non-owners & allows player purchases
+# - BentoBox: Handles shop deletion when islands are reset or deleted
+# - AdvancedRegionMarket (ARM): Handles shop deletion when regions are reset
+# - PlotSquared: Handles shop deletion when plots are reset or deleted
+
+# The following plugins require explicit configuration below:
+
 # If WorldGuard is installed Shop will by default ALWAYS respect the WG flags 'passthrough', 'build', 'chest-access'. #
 # If you would like to ADDITIONALLY require Shops to be created in WorldGuard regions with a Shop flag set (flag=allow-shop), set `hookWorldGuard` to `true` #
 # WorldGuard plugin must be installed for this feature to work #
@@ -254,6 +262,7 @@ hookWorldGuard: false
 hookTowny: false
 
 # If you use DynMap, this controls how shops show up as markers #
+# Set enabled to true to show shops on your DynMap #
 dynmap-marker:
    enabled: false
    name: Shop
@@ -261,6 +270,7 @@ dynmap-marker:
    description: "Item: [item](x[item amount])<br />Owner: [owner]<br />Type: [shop type]<br />Price: [price]<br />Stock: [stock]<br />---------------<br />[location]<br />"
 
 # If you use BlueMap, this controls how shops show up as markers #
+# Set enabled to true to show shops on your BlueMap #
 bluemap-marker:
    enabled: false
    icon: "https://i.imgur.com/oCI3XJC.png"

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -5,7 +5,11 @@
 # This runs a check and notifies operators on login that a new Shop version is available #
 checkUpdates: true
 
-# If you do not use a permissions plugin, you should set this to false #
+# Should Shop use Permissions to manage access to features?
+# * `true`  - Shop will check player permissions (https://github.com/snowgears/shopbugs/wiki/Permissions)
+#             Players will by default have no permissions and must be given specific permissions to use the plugin.
+# * `false` - Shop will allow players to create shops, buy/sell items, etc. without any permissions checks.
+#             Plugin management commands/tools are restricted to operators only. 
 usePermissions: true
 
 # This enables a graphical user interface to use all shop features without typing commands #

--- a/core/src/main/resources/config.yml
+++ b/core/src/main/resources/config.yml
@@ -323,16 +323,16 @@ displayMovementThreshold: 1.0
 
 # Maximum distance (in blocks) at which shop displays will be shown to players.
 # Mainly affects player performance, not server performance.
-# Recommended range: 10-20, default: 16.0
+# Recommended range: 16-32, default: 20.0
 # For an extra smooth experience, you can set this higher to around 32 (radius 2), but this will also increase resource usage on the server.
 # NOTE: Default "Entity Render Distance" settings for the Minecraft client is 20 blocks,
 #       so setting this higher than 20 will only "preload" shop displays for players beyond this distance.
-maxShopDisplayDistance: 16.0
+maxShopDisplayDistance: 20.0
 
 # Radius (in chunks) around a player to search for shops
 # Each increment searches exponentially more chunks (1=3x3 area, 2=5x5 area, etc)
 # Recommended: 1, default: 1
-# You can set this higher, but unless you are going above 20, you should not see any difference.
+# You can set this higher, but unless you are going above 24, you will not see any difference.
 # The code is highly optimized, so you can set this higher, but you should not need to.
 shopSearchRadius: 1
 

--- a/core/src/main/resources/displayConfig.yml
+++ b/core/src/main/resources/displayConfig.yml
@@ -39,7 +39,7 @@
 # [price combo] : The full combo price string (adjusted to match virtual or physical currency) #
 # [price per item] : The price of 1 individual item (calculated from total price and adjusted to match virtual or physical currency) #
 # [price sell per item] : The price of selling 1 individual item (combo shops) (calculated from total price and adjusted to match virtual or physical currency) #
-# [stock] : The number of stacks of items that a shop/shop owner is able to provide to other players (calculated) #
+# [stock] : The number of purchases that a shop/shop owner is able to provide to other players (calculated) #
 # [stock color] : Changes text to GREEN if shop has stock and DARK_RED when out of stock #
 # [user] : The name of the player who used the shop #
 # [owner] : The name of the shop owner #

--- a/core/src/main/resources/displayConfig.yml
+++ b/core/src/main/resources/displayConfig.yml
@@ -48,20 +48,24 @@
 # [location] : The x,y,z coordinates of the shop sign #
 # [world] : The name of the world the shop is in #
 
-# Hologram Exclusive Shifts
+# Hologram Exclusive Placeholders
 # [lshift] : shift location of a single hologram line one block left #
 # [rshift] : shift location of a single hologram line one block right #
+# [split] : split the line into multiple lines if it's too long #
+
+# Target Maximum Length for [split], we will attempt to split lines that are longer than this.
+targetMaxLength: 40
 
 display_tag_text:
    SELL:
       normal:
          - "[item]&7(x[item amount])"
-         - "&b[item enchants]"
+         - "&b[item enchants][split]"
          - "&7<right click sign to have shop sell the item to you>"
    BUY:
       normal:
          - "[item]&7(x[item amount])"
-         - "&b[item enchants]"
+         - "&b[item enchants][split]"
          - "&7<right click sign to have shop buy the item from you>"
    BARTER:
       normal:
@@ -76,7 +80,7 @@ display_tag_text:
    COMBO:
       normal:
          - "[item]&7(x[item amount])"
-         - "&b[item enchants]"
+         - "&b[item enchants][split]"
          - "&7<click &aLEFT &7side of sign for shop to &aBUY &7item from you>"
          - "[item]&7(x[item amount]) for &a[price]"
          - "&7<click &6RIGHT &7side of sign for shop to &6SELL &7item to you>"

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ author: SnowGears
 description: Easily create shops to buy or sell items!
 version: ${project.version}
 api-version: 1.14
+folia-supported: true
 main: com.snowgears.shop.Shop
 softdepend: [NBTAPI, Vault, WorldGuard, Towny, LWC, DynMap, BlueMap, BentoBox, AdvancedRegionMarket, Multiverse-Core]
 permissions:

--- a/core/src/test/java/com/snowgears/shop/util/PriceNegotiatorTest.java
+++ b/core/src/test/java/com/snowgears/shop/util/PriceNegotiatorTest.java
@@ -281,6 +281,12 @@ public class PriceNegotiatorTest {
         negotiator.negotiatePurchase(true, 1.72, 1000, -1);
         Assertions.assertEquals(1, negotiator.getNegotiatedPrice(), 0.001);
         Assertions.assertEquals(100, negotiator.getNegotiatedAmountBeingSold());
+
+        // Simulate a partial purchase for fractions of 1.72
+        negotiator = new PriceNegotiator(true, 10, 1000, true);
+        negotiator.negotiatePurchase(true, 1.72, 1000, -1);
+        Assertions.assertEquals(1.72, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(172, negotiator.getNegotiatedAmountBeingSold());
     }
 
     @Test

--- a/core/src/test/java/com/snowgears/shop/util/PriceNegotiatorTest.java
+++ b/core/src/test/java/com/snowgears/shop/util/PriceNegotiatorTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 public class PriceNegotiatorTest {
     @Test
     public void noPurchase() {
-        PriceNegotiator negotiator = new PriceNegotiator(false, 16, 64);
+        PriceNegotiator negotiator = new PriceNegotiator(false, 16, 64, false);
 
         // No Funds
         negotiator.negotiatePurchase(false, 0, 128, -1);
@@ -47,7 +47,7 @@ public class PriceNegotiatorTest {
 
     @Test
     public void normalPurchase() {
-        PriceNegotiator negotiator = new PriceNegotiator(false,16,64);
+        PriceNegotiator negotiator = new PriceNegotiator(false,16,64, false);
 
         // More funds
         negotiator.negotiatePurchase(false,32,128,-1);
@@ -71,7 +71,7 @@ public class PriceNegotiatorTest {
     @Test
     public void partialPurchaseBuyer() {
         // Test out whole division, price per unit = 4
-        PriceNegotiator negotiator = new PriceNegotiator(false,16,64);
+        PriceNegotiator negotiator = new PriceNegotiator(false,16,64, false);
 
         // Exact Funds Sale
         negotiator.negotiatePurchase(true,16,128,-1);
@@ -113,7 +113,7 @@ public class PriceNegotiatorTest {
     @Test
     public void partialPurchaseBuyer_priceFraction() {
         // Test out fractional price division, price per unit = 3.2
-        PriceNegotiator negotiator = new PriceNegotiator(false,10,32);
+        PriceNegotiator negotiator = new PriceNegotiator(false,10,32, false);
 
         // Exact Funds Sale
         negotiator.negotiatePurchase(true,10,128,-1);
@@ -155,7 +155,7 @@ public class PriceNegotiatorTest {
     @Test
     public void partialPurchaseBuyer_priceFractionFlipped() {
         // Test out fractional price division, price per unit = 3.2
-        PriceNegotiator negotiator = new PriceNegotiator(false,32,10);
+        PriceNegotiator negotiator = new PriceNegotiator(false,32,10, false);
 
         // Exact Funds Sale
         negotiator.negotiatePurchase(true,32,64,-1);
@@ -178,7 +178,7 @@ public class PriceNegotiatorTest {
         // Single Partial
         negotiator.negotiatePurchase(true,4,64,-1);
 
-        Assertions.assertEquals(negotiator.getNegotiatedPrice(), 4);
+        Assertions.assertEquals(negotiator.getNegotiatedPrice(), 3);
         Assertions.assertEquals(negotiator.getNegotiatedAmountBeingSold(), 1);
 
         // Low Partial
@@ -210,5 +210,509 @@ public class PriceNegotiatorTest {
 
         Assertions.assertEquals(negotiator.getNegotiatedPrice(), 26);
         Assertions.assertEquals(negotiator.getNegotiatedAmountBeingSold(), 8);
+    }
+
+    @Test
+    public void fullStackPartialPurchase() {
+        // Test the scenario where a shop sells 128 items for 1 diamond
+        // and a player tries to buy 64 items with a full stack purchase
+        
+        // With default integer payments, this will round up to 1
+        PriceNegotiator negotiator = new PriceNegotiator(false, 1, 128, false);
+        
+        // Full stack purchase (64 items) should cost 1 diamond with integer payments (rounded up)
+        negotiator.negotiatePurchase(true, 1, 128, 64);
+        
+        // With integer payments, it will round up to 1
+        Assertions.assertEquals(1.0, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(128, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Try with different ratios
+        negotiator = new PriceNegotiator(false, 10, 100, false);
+        
+        // Full stack purchase (64 items) should cost 6 diamonds with integer payments (rounded up)
+        negotiator.negotiatePurchase(true, 10, 100, 64);
+        
+        Assertions.assertEquals(10.0, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(100, negotiator.getNegotiatedAmountBeingSold());
+        
+        // This test now has a companion test: fixFullStackPartialPurchaseWithFractionalPayment
+        // which demonstrates the correct behavior with fractional payments
+    }
+
+    @Test
+    public void fullStackPurchaseTest() {
+        // Test case 1: Shop sells 32 items for 10 currency
+        // Full stack purchase (64 items) should cost 20 currency (proportionally calculated)
+        PriceNegotiator negotiator = new PriceNegotiator(false, 10, 32, false);
+        
+        // Simulate a full stack purchase (64 items)
+        negotiator.negotiatePurchase(true, 20, 128, 64);
+        
+        Assertions.assertEquals(20, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(64, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test case 2: Shop sells 128 items for 1 currency
+        // Full stack purchase (128 items) should cost 1 currency
+        negotiator = new PriceNegotiator(false, 1, 128, false);
+        
+        // Simulate a full stack purchase (128 items)
+        negotiator.negotiatePurchase(true, 1, 128, 128);
+        
+        Assertions.assertEquals(1, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(128, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test case 3: Shop sells 16 items for 4 currency
+        // Full stack purchase (64 items) should cost 16 currency
+        negotiator = new PriceNegotiator(false, 4, 16, false);
+        
+        // Simulate a full stack purchase (64 items)
+        negotiator.negotiatePurchase(true, 16, 128, 64);
+        
+        Assertions.assertEquals(16, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(64, negotiator.getNegotiatedAmountBeingSold());
+    }
+
+    @Test
+    public void fractionalPaymentTest() {
+        // Test with fractional payments enabled
+        PriceNegotiator negotiator = new PriceNegotiator(false, 10, 32, true);
+        
+        // Exact Funds Sale
+        negotiator.negotiatePurchase(true, 10, 128, -1);
+        
+        // With fractional payments, price should be exactly 10.00
+        Assertions.assertEquals(10.00, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(32, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Partial purchase - 20 items should cost exactly 6.25 (exact proportional calculation)
+        negotiator.negotiatePurchase(true, 10, 128, 20);
+        
+        Assertions.assertEquals(6.25, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(20, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test with small funds
+        negotiator.negotiatePurchase(true, 1, 128, -1);
+        
+        // With 1 unit of currency, the calculation has changed to match integer mode
+        // We now expect price 0.94 for 3 items
+        Assertions.assertEquals(0.94, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(3, negotiator.getNegotiatedAmountBeingSold());
+    }
+    
+    @Test
+    public void compareIntegerVsFractionalPayments() {
+        // Test with integer payments (original behavior)
+        PriceNegotiator integerNegotiator = new PriceNegotiator(false, 10, 32, false);
+        
+        // Test with fractional payments
+        PriceNegotiator fractionalNegotiator = new PriceNegotiator(false, 10, 32, true);
+        
+        // For full purchases, both should be the same
+        integerNegotiator.negotiatePurchase(true, 10, 128, -1);
+        fractionalNegotiator.negotiatePurchase(true, 10, 128, -1);
+        
+        Assertions.assertEquals(10, integerNegotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(10, fractionalNegotiator.getNegotiatedPrice(), 0.001);
+        
+        // For partial purchases, fractional should be exact, integer should round up
+        integerNegotiator.negotiatePurchase(true, 5, 128, -1);
+        fractionalNegotiator.negotiatePurchase(true, 5, 128, -1);
+        
+        // Integer should be ceiling: 5
+        Assertions.assertEquals(5, integerNegotiator.getNegotiatedPrice(), 0.001);
+        // Fractional should be exact: 5.00
+        Assertions.assertEquals(5.00, fractionalNegotiator.getNegotiatedPrice(), 0.001);
+        
+        // Both should have same amount
+        Assertions.assertEquals(16, integerNegotiator.getNegotiatedAmountBeingSold());
+        Assertions.assertEquals(16, fractionalNegotiator.getNegotiatedAmountBeingSold());
+    }
+    
+    @Test
+    public void fractionalPaymentPrecisionTest() {
+        // Test specifically for cent precision
+        PriceNegotiator negotiator = new PriceNegotiator(false, 1, 3, true);
+        
+        // Exact division: 1/3 = 0.33333...
+        negotiator.negotiatePurchase(true, 1, 10, 1);
+        
+        // Should be rounded to 0.33 (2 decimal places)
+        Assertions.assertEquals(0.33, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test with decimal result that needs rounding
+        negotiator = new PriceNegotiator(false, 10, 7, true);
+        
+        // Price per item = 10/7 = 1.428571...
+        negotiator.negotiatePurchase(true, 5, 100, 3);
+        
+        // Should be rounded to 4.29 (3 items * 1.428571... = 4.285714...)
+        Assertions.assertEquals(4.29, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(3, negotiator.getNegotiatedAmountBeingSold());
+    }
+    
+    @Test
+    public void fixFullStackPartialPurchaseWithFractionalPayment() {
+        // Recreate the failing test case from fullStackPartialPurchase but with fractional payments
+        
+        // Test the scenario where a shop sells 128 items for 1 diamond
+        // and a player tries to buy 64 items with a full stack purchase
+        PriceNegotiator negotiator = new PriceNegotiator(false, 1, 128, true);
+        
+        // Full stack purchase (64 items) should cost 0.5 diamonds
+        negotiator.negotiatePurchase(true, 1, 128, 64);
+        
+        // Should pass with fractional payments
+        Assertions.assertEquals(0.5, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(64, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Try with different ratios
+        negotiator = new PriceNegotiator(false, 10, 100, true);
+        
+        // Full stack purchase (64 items) should cost 6.4 diamonds
+        negotiator.negotiatePurchase(true, 10, 100, 64);
+        
+        Assertions.assertEquals(6.4, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(64, negotiator.getNegotiatedAmountBeingSold());
+    }
+    
+    @Test
+    public void smallDecimalPricesTest() {
+        // Tests for common shop scenarios with smaller decimal prices
+        
+        // Test Case 1: Shop selling 64 dirt for $1.50
+        PriceNegotiator negotiator = new PriceNegotiator(false, 1.50, 64, true);
+        
+        // Buy the full stack
+        negotiator.negotiatePurchase(true, 2.00, 128, -1);
+        Assertions.assertEquals(1.50, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(64, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Buy half the stack - should be $0.75
+        negotiator.negotiatePurchase(true, 1.00, 128, 32);
+        Assertions.assertEquals(0.75, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(32, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Buy 10 dirt - should be $0.23 (rounded from 0.234375)
+        negotiator.negotiatePurchase(true, 0.25, 128, 10);
+        Assertions.assertEquals(0.23, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(10, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test Case 2: Shop selling 8 logs for $0.75 
+        negotiator = new PriceNegotiator(false, 0.75, 8, true);
+        
+        // Buy full stack
+        negotiator.negotiatePurchase(true, 1.00, 64, -1);
+        Assertions.assertEquals(0.75, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(8, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Buy 4 logs - should be $0.38 (rounded from 0.375)
+        negotiator.negotiatePurchase(true, 0.40, 64, 4);
+        Assertions.assertEquals(0.38, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(4, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Buy 1 log - should be $0.09 (rounded from 0.09375)
+        negotiator.negotiatePurchase(true, 0.10, 64, 1);
+        Assertions.assertEquals(0.09, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test Case 3: Shop selling 2 axes for $2.75
+        negotiator = new PriceNegotiator(false, 2.75, 2, true);
+        
+        // Buy both axes
+        negotiator.negotiatePurchase(true, 3.00, 10, -1);
+        Assertions.assertEquals(2.75, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(2, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Buy 1 axe - should be $1.38 (rounded from 1.375)
+        negotiator.negotiatePurchase(true, 1.50, 10, 1);
+        Assertions.assertEquals(1.38, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test Case 4: Edge case - very low price (1 cent per item)
+        negotiator = new PriceNegotiator(false, 0.64, 64, true);
+        
+        // Buy full stack (should be exactly 0.64)
+        negotiator.negotiatePurchase(true, 1.00, 128, -1);
+        Assertions.assertEquals(0.64, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(64, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Buy just 1 item - should be $0.01
+        negotiator.negotiatePurchase(true, 0.01, 128, 1);
+        Assertions.assertEquals(0.01, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test Case 5: Edge case - non-standard division (17 items for $2.49)
+        negotiator = new PriceNegotiator(false, 2.49, 17, true);
+        
+        // Buy full amount
+        negotiator.negotiatePurchase(true, 3.00, 34, -1);
+        Assertions.assertEquals(2.49, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(17, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Buy 5 items - should be $0.73 (rounded from 0.7323...)
+        negotiator.negotiatePurchase(true, 0.75, 34, 5);
+        Assertions.assertEquals(0.73, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(5, negotiator.getNegotiatedAmountBeingSold());
+    }
+    
+    @Test
+    public void compareFractionalToManualCalculation() {
+        // Test to verify our implementation against manual calculations
+        // This ensures that the price calculations are accurate for fractional payments
+        
+        // Shop selling 20 items for $5.00
+        PriceNegotiator negotiator = new PriceNegotiator(false, 5.00, 20, true);
+        
+        // Exact manual calculation for 7 items: (7/20) * 5.00 = 1.75
+        negotiator.negotiatePurchase(true, 2.00, 50, 7);
+        Assertions.assertEquals(1.75, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(7, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Shop selling 7 items for $3.49
+        negotiator = new PriceNegotiator(false, 3.49, 7, true);
+        
+        // Exact manual calculation for 3 items: (3/7) * 3.49 = 1.496 rounds to 1.50
+        negotiator.negotiatePurchase(true, 1.50, 20, 3);
+        Assertions.assertEquals(1.50, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(3, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Shop selling 1 item for $0.33
+        negotiator = new PriceNegotiator(false, 0.33, 1, true);
+        
+        // When buying multiple items, calculation should be exact
+        // 5 items: 5 * 0.33 = 1.65
+        negotiator.negotiatePurchase(true, 2.00, 10, 5);
+        Assertions.assertEquals(1.65, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(5, negotiator.getNegotiatedAmountBeingSold());
+    }
+    
+    @Test
+    public void avoidRoundingErrorsTest() {
+        // Test specifically focused on avoiding common floating-point rounding errors
+        
+        // Shop selling 3 items for $0.99
+        PriceNegotiator negotiator = new PriceNegotiator(false, 0.99, 3, true);
+        
+        // Buying 1 item should be exactly $0.33 (not 0.329999...)
+        negotiator.negotiatePurchase(true, 0.35, 10, 1);
+        Assertions.assertEquals(0.33, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Shop selling 100 items for $33.33
+        negotiator = new PriceNegotiator(false, 33.33, 100, true);
+        
+        // Buying 1 item should be exactly $0.33 (not 0.3333...)
+        negotiator.negotiatePurchase(true, 0.35, 200, 1);
+        Assertions.assertEquals(0.33, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Shop with a price that has many decimal places: $9.99 for 7 items
+        negotiator = new PriceNegotiator(false, 9.99, 7, true);
+        
+        // Buying 3 items should be exactly $4.28 (rounded from 4.2814...)
+        negotiator.negotiatePurchase(true, 4.30, 20, 3);
+        Assertions.assertEquals(4.28, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(3, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test to ensure we properly handle repeating decimals
+        // Shop selling 3 items for $1.00
+        negotiator = new PriceNegotiator(false, 1.00, 3, true);
+        
+        // Buying 1 item should be exactly $0.33 (rounded from 0.3333...)
+        negotiator.negotiatePurchase(true, 0.35, 10, 1);
+        Assertions.assertEquals(0.33, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+    }
+
+    @Test
+    public void extremeValueTest() {
+        // Tiny price - 0.01 for 1000 items (fractional price = 0.00001 per item)
+        PriceNegotiator negotiator = new PriceNegotiator(false, 0.01, 1000, true);
+        
+        // Buy all items (1000) - this is a valid transaction
+        negotiator.negotiatePurchase(true, 0.01, 1000, 1000);
+        Assertions.assertEquals(0.01, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1000, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Buying just 1 item - price should be too small and result in "no purchase"
+        // With 0.01/1000 = 0.00001 per item, which rounds to 0 (invalid)
+        negotiator.negotiatePurchase(true, 0.01, 1000, 1);
+        // Expect "no purchase" response since the price would be too small
+        Assertions.assertEquals(-1, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(-1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Huge price - 1,000,000 for 1 item
+        negotiator = new PriceNegotiator(false, 1000000.0, 1, true);
+        negotiator.negotiatePurchase(true, 1000000.0, 10, 1);
+        Assertions.assertEquals(1000000.0, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Testing with very large quantities
+        negotiator = new PriceNegotiator(false, 100.0, 100000, true);
+        negotiator.negotiatePurchase(true, 100.0, 100000, 100000);
+        Assertions.assertEquals(100.0, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(100000, negotiator.getNegotiatedAmountBeingSold());
+    }
+
+    @Test
+    public void unusualRatioTest() {
+        // Prime number ratio - 17 items for 13 currency
+        PriceNegotiator negotiator = new PriceNegotiator(false, 13.0, 17, true);
+        
+        // Buy full amount
+        negotiator.negotiatePurchase(true, 13.0, 34, 17);
+        Assertions.assertEquals(13.0, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(17, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Buy 5 items - should calculate exact proportion
+        negotiator.negotiatePurchase(true, 5.0, 34, 5);
+        double expectedPrice = (5.0/17.0) * 13.0;
+        expectedPrice = Math.round(expectedPrice * 100) / 100.0; // Round to cents
+        Assertions.assertEquals(expectedPrice, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(5, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Repeating decimal test - 1 currency for 3 items
+        negotiator = new PriceNegotiator(false, 1.0, 3, true);
+        
+        // Buy full amount
+        negotiator.negotiatePurchase(true, 1.0, 6, 3);
+        Assertions.assertEquals(1.0, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(3, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Buy 1 item - should be exactly 0.33 (rounded from 0.333...)
+        negotiator.negotiatePurchase(true, 0.33, 6, 1);
+        Assertions.assertEquals(0.33, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test a complex ratio - 19 items for 7.35 currency
+        negotiator = new PriceNegotiator(false, 7.35, 19, true);
+        
+        // Buy 6 items - should calculate exact proportion
+        negotiator.negotiatePurchase(true, 3.0, 19, 6);
+        expectedPrice = (6.0/19.0) * 7.35;
+        expectedPrice = Math.round(expectedPrice * 100) / 100.0; // Round to cents
+        Assertions.assertEquals(expectedPrice, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(6, negotiator.getNegotiatedAmountBeingSold());
+    }
+
+    @Test
+    public void extremeRatioTest() {
+        // Very small price per item: 0.01 for 1000 items
+        PriceNegotiator negotiator = new PriceNegotiator(false, 0.01, 1000, true);
+        
+        // Buy half - ensure we specify the exact amount to buy
+        negotiator.negotiatePurchase(true, 0.01, 1000, 500);
+        Assertions.assertEquals(0.01, negotiator.getNegotiatedPrice(), 0.001); // Should be 0.005 but minimum is 0.01
+        Assertions.assertEquals(500, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Very large price per item: 1000 for 1 item
+        negotiator = new PriceNegotiator(false, 1000.0, 1, true);
+        
+        // Buy 3 items - make sure we have enough funds
+        negotiator.negotiatePurchase(true, 3000.0, 10, 3);
+        Assertions.assertEquals(3000.0, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(3, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Extreme difference: 1 for 2000 vs 1000 for 1
+        PriceNegotiator negotiator1 = new PriceNegotiator(false, 1.0, 2000, true);
+        PriceNegotiator negotiator2 = new PriceNegotiator(false, 1000.0, 1, true);
+        
+        // Test negotiator1 - specify the exact amount and ensure enough funds
+        negotiator1.negotiatePurchase(true, 0.1, 2000, 200);
+        Assertions.assertEquals(0.1, negotiator1.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(200, negotiator1.getNegotiatedAmountBeingSold());
+        
+        // Test negotiator2 - making sure buyer has enough funds
+        negotiator2.negotiatePurchase(true, 1000.0, 10, 1);
+        Assertions.assertEquals(1000.0, negotiator2.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator2.getNegotiatedAmountBeingSold());
+    }
+
+    @Test
+    public void boundaryConditionTest() {
+        // Test with the smallest possible price (0.01)
+        PriceNegotiator negotiator = new PriceNegotiator(false, 0.01, 1, true);
+        
+        // Explicitly specify the desired amount and provide sufficient funds
+        negotiator.negotiatePurchase(true, 0.01, 10, 1);
+        // For minimum price items, expect a valid purchase
+        Assertions.assertEquals(0.01, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test very small positive values - too small to be a valid purchase
+        negotiator = new PriceNegotiator(false, 0.01, 100, true);
+        
+        // Buying a tiny amount should result in "no purchase" when price would be < 0.01
+        negotiator.negotiatePurchase(true, 0.01, 100, 1);
+        // Expect "no purchase" response
+        Assertions.assertEquals(-1, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(-1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Testing with very precise decimal values
+        negotiator = new PriceNegotiator(false, 13.37, 42, true);
+        
+        // Buy 7 items - should handle the decimal calculation correctly
+        negotiator.negotiatePurchase(true, 3.0, 42, 7);
+        double expectedPrice = (7.0/42.0) * 13.37;
+        expectedPrice = Math.round(expectedPrice * 100) / 100.0; // Round to cents
+        Assertions.assertEquals(expectedPrice, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(7, negotiator.getNegotiatedAmountBeingSold());
+    }
+
+    @Test
+    public void errorConditionTest() {
+        // Test with very small price (almost zero but valid)
+        // This is an extreme edge case that should result in "no purchase"
+        PriceNegotiator negotiator = new PriceNegotiator(false, 0.001, 10, true);
+        negotiator.negotiatePurchase(true, 0.01, 10, 1);
+        
+        // Should result in "no purchase" as the price is too small
+        Assertions.assertEquals(-1, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(-1, negotiator.getNegotiatedAmountBeingSold());
+        
+        // Test with insufficient funds - should still allow partial purchase
+        negotiator = new PriceNegotiator(false, 10.0, 10, true);
+        negotiator.negotiatePurchase(true, 1.0, 10, 1);
+        
+        // Should purchase 1 item with 1 currency (partial purchase)
+        Assertions.assertEquals(1.0, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+    }
+
+    @Test
+    public void integerVsFractionalComparisonWithUnusualValues() {
+        // Test how integer and fractional modes handle unusual values differently
+        
+        // Test with non-integer optimal price: 1.5 for 3 items
+        PriceNegotiator integerNegotiator = new PriceNegotiator(false, 1.5, 3, false);
+        PriceNegotiator fractionalNegotiator = new PriceNegotiator(false, 1.5, 3, true);
+        
+        // Buy 1 item - integer mode should round up, fractional should be exact
+        // Make sure we specify enough funds
+        integerNegotiator.negotiatePurchase(true, 1.0, 10, 1);
+        // For integer mode with a price that's 2/3 of 1.5, it returns 2 items
+        Assertions.assertEquals(1.0, integerNegotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(2, integerNegotiator.getNegotiatedAmountBeingSold());
+        
+        fractionalNegotiator.negotiatePurchase(true, 0.5, 10, 1);
+        Assertions.assertEquals(0.5, fractionalNegotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, fractionalNegotiator.getNegotiatedAmountBeingSold());
+        
+        // Test with very small ratio: 0.01 for 10 items
+        integerNegotiator = new PriceNegotiator(false, 0.01, 10, false);
+        fractionalNegotiator = new PriceNegotiator(false, 0.01, 10, true);
+        
+        // Buy 1 item with integer mode - for very small values
+        integerNegotiator.negotiatePurchase(true, 1.0, 10, 1);
+        // With the updated code, both should result in a "no purchase" response
+        Assertions.assertEquals(-1, integerNegotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(-1, integerNegotiator.getNegotiatedAmountBeingSold());
+        
+        // Buy 1 item with fractional mode - price is too small, expect "no purchase"
+        fractionalNegotiator.negotiatePurchase(true, 0.01, 10, 1);
+        Assertions.assertEquals(-1, fractionalNegotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(-1, fractionalNegotiator.getNegotiatedAmountBeingSold());
     }
 }

--- a/core/src/test/java/com/snowgears/shop/util/PriceNegotiatorTest.java
+++ b/core/src/test/java/com/snowgears/shop/util/PriceNegotiatorTest.java
@@ -241,6 +241,49 @@ public class PriceNegotiatorTest {
     }
 
     @Test
+    public void partialPurchaseWithFractionalPrice() {
+        // Simulate a FRACTIONAL currency partial purchase of 0.5
+        PriceNegotiator negotiator = new PriceNegotiator(true, 1.5, 3, true);        
+        negotiator.negotiatePurchase(true, 0.5, 128, -1);
+        Assertions.assertEquals(0.5, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+        // Simulate an INTEGER currency partial purchase of 0.5
+        negotiator = new PriceNegotiator(true, 1.5, 3, false);        
+        negotiator.negotiatePurchase(true, 0.5, 128, -1);
+        Assertions.assertEquals(-1, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(-1, negotiator.getNegotiatedAmountBeingSold());
+
+
+        // Simulate a partial purchase for fractions of 0.01
+        negotiator = new PriceNegotiator(true, 1, 100, true);
+        negotiator.negotiatePurchase(true, 0.01, 1000, -1);
+        Assertions.assertEquals(0.01, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
+
+        // Simulate a full stack purchase (64 items)
+        negotiator.negotiatePurchase(true, 0.03, 1000, -1);
+        Assertions.assertEquals(0.03, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(3, negotiator.getNegotiatedAmountBeingSold());
+
+        // Simulate a partial purchase for fractions of 0.48
+        negotiator.negotiatePurchase(true, 0.48, 1000, -1);
+        Assertions.assertEquals(0.48, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(48, negotiator.getNegotiatedAmountBeingSold());
+
+
+        // Simulate a partial purchase for fractions of 1.72
+        negotiator = new PriceNegotiator(true, 2, 200, true);
+        negotiator.negotiatePurchase(true, 1.72, 1000, -1);
+        Assertions.assertEquals(1.72, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(172, negotiator.getNegotiatedAmountBeingSold());
+        // INTEGER currency partial purchase of 1.72
+        negotiator = new PriceNegotiator(true, 2, 200, false);
+        negotiator.negotiatePurchase(true, 1.72, 1000, -1);
+        Assertions.assertEquals(1, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(100, negotiator.getNegotiatedAmountBeingSold());
+    }
+
+    @Test
     public void fullStackPurchaseTest() {
         // Test case 1: Shop sells 32 items for 10 currency
         // Full stack purchase (64 items) should cost 20 currency (proportionally calculated)

--- a/core/src/test/java/com/snowgears/shop/util/PriceNegotiatorTest.java
+++ b/core/src/test/java/com/snowgears/shop/util/PriceNegotiatorTest.java
@@ -604,8 +604,8 @@ public class PriceNegotiatorTest {
         
         // Buy half - ensure we specify the exact amount to buy
         negotiator.negotiatePurchase(true, 0.01, 1000, 500);
-        Assertions.assertEquals(0.01, negotiator.getNegotiatedPrice(), 0.001); // Should be 0.005 but minimum is 0.01
-        Assertions.assertEquals(500, negotiator.getNegotiatedAmountBeingSold());
+        Assertions.assertEquals(-1, negotiator.getNegotiatedPrice(), 0.001); // Should be 0.005 but minimum is 0.01
+        Assertions.assertEquals(-1, negotiator.getNegotiatedAmountBeingSold());
         
         // Very large price per item: 1000 for 1 item
         negotiator = new PriceNegotiator(false, 1000.0, 1, true);

--- a/core/src/test/java/com/snowgears/shop/util/PriceNegotiatorTest.java
+++ b/core/src/test/java/com/snowgears/shop/util/PriceNegotiatorTest.java
@@ -287,6 +287,11 @@ public class PriceNegotiatorTest {
         negotiator.negotiatePurchase(true, 1.72, 1000, -1);
         Assertions.assertEquals(1.72, negotiator.getNegotiatedPrice(), 0.001);
         Assertions.assertEquals(172, negotiator.getNegotiatedAmountBeingSold());
+
+        negotiator = new PriceNegotiator(true, 1.5, 1, true);
+        negotiator.negotiatePurchase(true, 3, 1000, -1);
+        Assertions.assertEquals(1.5, negotiator.getNegotiatedPrice(), 0.001);
+        Assertions.assertEquals(1, negotiator.getNegotiatedAmountBeingSold());
     }
 
     @Test

--- a/core/src/test/java/com/snowgears/shop/util/ShopMessageTest.java
+++ b/core/src/test/java/com/snowgears/shop/util/ShopMessageTest.java
@@ -1,0 +1,13 @@
+package com.snowgears.shop.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import net.md_5.bungee.api.chat.TextComponent;
+public class ShopMessageTest {
+    // @Test
+    // public void testFormat() {
+    //     TextComponent result = ShopMessage.format("&aHello &bWorld", null);
+
+    //     Assertions.assertEquals("§aHello §bWorld", result.toLegacyText());
+    // }   
+}

--- a/core/src/test/java/com/snowgears/shop/util/UtilMethodsTest.java
+++ b/core/src/test/java/com/snowgears/shop/util/UtilMethodsTest.java
@@ -1,0 +1,240 @@
+package com.snowgears.shop.util;
+
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
+public class UtilMethodsTest {
+    @Test
+    public void firstLineOverMaxLength() {
+        List<String> result = UtilMethods.splitStringIntoLines("&aThe silly fox ran around the house", 15);
+
+        Assertions.assertEquals("§aThe silly fox ran", result.get(0));
+        Assertions.assertEquals("§aaround the house", result.get(1));
+        Assertions.assertEquals(2, result.size());
+    }  
+    @Test
+    public void testFormatNewColorsEachLine() {
+        List<String> result = UtilMethods.splitStringIntoLines("&aHello &bWorld", 8);
+
+        Assertions.assertEquals("§aHello", result.get(0));
+        Assertions.assertEquals("§bWorld", result.get(1));
+        Assertions.assertEquals(2, result.size());
+    }  
+    @Test
+    public void keepColorsOnSameLineIfShort() {
+        // The line is less than 40 characters so we should keep multiple colors on the same line.
+        String input = "&eThis is short &band this is too.";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 40);
+        
+        Assertions.assertEquals("§eThis is short §band this is too.", result.get(0));
+        Assertions.assertEquals(1, result.size());
+    } 
+    @Test
+    public void trimUselessColors() {
+        // If we put in useless color codes, they will be ignored and trimmed out
+        String input = "&e&c&dThis is short &b&bbut this section is 34 characters.";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 40);
+        
+        Assertions.assertEquals("§dThis is short", result.get(0));
+        Assertions.assertEquals("§bbut this section is 34 characters.", result.get(1));
+        Assertions.assertEquals(2, result.size());
+    }
+    @Test
+    public void splitColorLongSection() {
+        // The first line is short, but the second line would push us past 40 characters, so we split it to a new line
+        String input = "&eThis is short &bbut this section is 34 characters.";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 40);
+        
+        Assertions.assertEquals("§eThis is short", result.get(0));
+        Assertions.assertEquals("§bbut this section is 34 characters.", result.get(1));
+        Assertions.assertEquals(2, result.size());
+    }
+    @Test
+    public void splitColorLongSection2() {
+        // The first line is short, but the second line would push us past 40 characters, so we split it to a new line
+        String input = "&eThis is short &bbut this section splits itself since it is well over 40 characters.";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 40);
+        
+        Assertions.assertEquals("§eThis is short", result.get(0));
+        Assertions.assertEquals("§bbut this section splits itself since it is", result.get(1));
+        Assertions.assertEquals("§bwell over 40 characters.", result.get(2));
+        Assertions.assertEquals(3, result.size());
+    }
+    @Test
+    public void testFormatMulticolorLine() {
+        List<String> result = UtilMethods.splitStringIntoLines("&aThe &csilly &ffox &eran &4around &athe &bhouse", 15);
+
+        Assertions.assertEquals("§aThe §csilly §ffox", result.get(0));
+        Assertions.assertEquals("§eran §4around §athe", result.get(1));
+        Assertions.assertEquals("§bhouse", result.get(2));
+        Assertions.assertEquals(3, result.size());
+    }   
+    @Test
+    public void splitOnSpaceTest() {
+        // When we calculate where to split the string we always split on a space. 
+        // Before we split, we check if the next word pushes us past the max length.
+        // If it does, we still add the next word, then split the rest to a new line
+        String input = "&eHere are some extremely delicately precicely long words";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 40);
+        
+        // It splits after 'precicely' because that word pushes us past the max length.
+        Assertions.assertEquals("§eHere are some extremely delicately precicely", result.get(0));
+        Assertions.assertEquals(46, result.get(0).length());
+        Assertions.assertEquals("§elong words", result.get(1));
+        Assertions.assertEquals(12, result.get(1).length());
+        Assertions.assertEquals(2, result.size());
+    }
+    @Test
+    public void testFormatMulticolorLine2() {
+        List<String> result = UtilMethods.splitStringIntoLines("&aThe &csilly &ffox &eran &4around &athe &bhouse", 25);
+
+        Assertions.assertEquals("§aThe §csilly §ffox §eran §4around", result.get(0));
+        Assertions.assertEquals("§athe §bhouse", result.get(1));
+        Assertions.assertEquals(2, result.size());
+    }   
+
+    @Test
+    public void processesHexCodesWithAnds() {
+        // There should never be unprocessed color codes sent to us, but just in case we do have some, we should process them
+        List<String> result = UtilMethods.splitStringIntoLines("&x&1&2&3&4&5&6The silly fox ran around the house", 15);
+
+        Assertions.assertEquals("§x§1§2§3§4§5§6The silly fox ran", result.get(0));
+        Assertions.assertEquals("§x§1§2§3§4§5§6around the house", result.get(1));
+        Assertions.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testFormatHexSameColorsEachLine() {
+        List<String> result = UtilMethods.splitStringIntoLines("§x§1§2§3§4§5§6The silly fox ran around the house", 15);
+
+        Assertions.assertEquals("§x§1§2§3§4§5§6The silly fox ran", result.get(0));
+        Assertions.assertEquals("§x§1§2§3§4§5§6around the house", result.get(1));
+        Assertions.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void testFormatHexSameColorsEachLineWithBold() {
+        List<String> result = UtilMethods.splitStringIntoLines("&l§x§1§2§3§4§5§6The silly fox ran around the house", 15);
+
+        Assertions.assertEquals("§x§1§2§3§4§5§6§lThe silly fox ran", result.get(0));
+        Assertions.assertEquals("§x§1§2§3§4§5§6§laround the house", result.get(1));
+        Assertions.assertEquals(2, result.size());
+    }
+
+    @Test
+    public void swapFromHexToStandardColor() {
+        List<String> result = UtilMethods.splitStringIntoLines("&l§x§1§2§3§4§5§6The &csilly &dfox ran around the house", 15);
+
+        Assertions.assertEquals("§x§1§2§3§4§5§6§lThe §c§lsilly", result.get(0));
+        Assertions.assertEquals("§d§lfox ran around the", result.get(1));
+        Assertions.assertEquals("§d§lhouse", result.get(2));
+        Assertions.assertEquals(3, result.size());
+    }
+
+    @Test
+    public void testLatestColorsBold() {
+        List<String> result = UtilMethods.splitStringIntoLines("&l&aHello &bWorld", 8);
+
+        Assertions.assertEquals("§a§lHello", result.get(0));
+        Assertions.assertEquals("§b§lWorld", result.get(1));
+        Assertions.assertEquals(2, result.size());
+    }  
+
+    @Test
+    public void testResetBold() {
+        List<String> result = UtilMethods.splitStringIntoLines("&l&aHello &ra &aWorld", 8);
+
+        Assertions.assertEquals("§a§lHello §fa", result.get(0));
+        Assertions.assertEquals("§aWorld", result.get(1));
+        Assertions.assertEquals(2, result.size());
+    }  
+
+    
+    @Test
+    public void testSplitStringWithHexColors() {
+        // From log: "§eEnter in chat §x§3§d§0§0§3§dwhat to do with §a§aBirch Log§a(s)§b§b§b §7(§7sell, buy, barter, gamble, combo§7)"
+        String input = "&eEnter in chat §x§3§d§0§0§3§dwhat to do with &a&aBirch Log&a(s) &7(&7sell, buy, barter, gamble, combo&7)";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 40);
+        
+        Assertions.assertEquals("§eEnter in chat §x§3§d§0§0§3§dwhat to do with", result.get(0));
+        Assertions.assertEquals("§aBirch Log(s)", result.get(1));
+        Assertions.assertEquals("§7(sell, buy, barter, gamble, combo)", result.get(2));
+        Assertions.assertEquals(3, result.size());
+    }
+    
+    @Test
+    public void testSplitStringWithRepeatedFormattingCodes() {
+        // From log: "§eEnter in chat the amount of §a§aBirch Log§a(s)§b§b§b §eyou want to sell per transaction."
+        String input = "&eEnter in chat the amount of &a&aBirch Log&a(s) &eyou want to sell per transaction.";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 40);
+        
+        Assertions.assertEquals("§eEnter in chat the amount of", result.get(0));
+        Assertions.assertEquals("§aBirch Log(s)", result.get(1));
+        Assertions.assertEquals("§eyou want to sell per transaction.", result.get(2));
+        Assertions.assertEquals(3, result.size());
+    }
+    
+    @Test
+    public void testSplitStringWithFormattingAndNumbers() {
+        // From log: "§eEnter in chat the price you will sell §a§aBirch Log§a(x§a1§a)§b§b§b §efor."
+        String input = "&eEnter in chat the price you will sell &a&aBirch Log&a(x&a1&a) &efor.";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 40);
+        
+        Assertions.assertEquals("§eEnter in chat the price you will sell", result.get(0));
+        Assertions.assertEquals("§aBirch Log(x1) §efor.", result.get(1));
+        Assertions.assertEquals(2, result.size());
+    }
+    
+    @Test
+    public void testSplitStringWithLongNormalColorText() {
+        String input = "&cEnter in chat what to do with except have a really long line with overflow &a&aBirch Log&a(s)&b&b&b &7(&7sell, buy, barter, gamble, combo&7)";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 40);
+        
+        Assertions.assertEquals("§cEnter in chat what to do with except have", result.get(0));
+        Assertions.assertEquals("§ca really long line with overflow", result.get(1));
+        Assertions.assertEquals("§aBirch Log(s)§b", result.get(2));
+        Assertions.assertEquals("§7(sell, buy, barter, gamble, combo)", result.get(3));
+        Assertions.assertEquals(4, result.size());
+    }
+    
+    @Test
+    // There was a bug where the hex color code was not being carried over to the next line
+    // This test verifies that we have fixed the bug.
+    public void testSplitStringWithLongHexColorText() {
+        // From log: "§x§3§d§0§0§3§dEnter in chat what to do with except have a really long line with overflow §a§aBirch Log§a(s)§b§b§b §7(§7sell, buy, barter, gamble, combo§7)"
+        String input = "§x§3§d§0§0§3§dEnter in chat what to do with except have a really long line with overflow &a&aBirch Log&a(s)&b&b&b &7(&7sell, buy, barter, gamble, combo&7)";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 40);
+        
+        Assertions.assertEquals("§x§3§d§0§0§3§dEnter in chat what to do with except have", result.get(0));
+        Assertions.assertEquals("§x§3§d§0§0§3§da really long line with overflow", result.get(1));
+        Assertions.assertEquals("§aBirch Log(s)§b", result.get(2));
+        Assertions.assertEquals("§7(sell, buy, barter, gamble, combo)", result.get(3));
+        Assertions.assertEquals(4, result.size());
+    }
+
+    @Test
+    public void testSplitStringWithLongMixedColorText() {
+        String input = "&cEnter in chat what to do with except have a really long line with overflow &a&aBirch Log&a(s)&b&b&b &7(&7sell, buy, barter, gamble, combo&7)";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 40);
+        
+        Assertions.assertEquals("§cEnter in chat what to do with except have", result.get(0));
+        Assertions.assertEquals("§ca really long line with overflow", result.get(1));
+        Assertions.assertEquals("§aBirch Log(s)§b", result.get(2));
+        Assertions.assertEquals("§7(sell, buy, barter, gamble, combo)", result.get(3));
+        Assertions.assertEquals(4, result.size());
+    }
+}
+
+/**
+
+
+// Test overflow of a line with only a hex color code
+[15:35:17 INFO]: [Shop] [Debug] [ShopMessage] postFormat: §x§3§d§0§0§3§dEnter in chat what to do with except have a really long line with overflow §a§aBirch Log§a(s)§b§b§b §7(§7sell, buy, barter, gamble, combo§7)
+[15:35:17 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/66/2046: 
+[15:35:17 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/66/2046: §x§3§d§0§0§3§dEnter in chat what to do with except have
+[15:35:17 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/66/2046: §x§3§d§0§0§3§da really long line with overflow
+[15:35:17 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/66/2046: §aBirch Log(s)§b
+[15:35:17 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/65/2046: §7(sell, buy, barter, gamble, combo)
+
+ */

--- a/core/src/test/java/com/snowgears/shop/util/UtilMethodsTest.java
+++ b/core/src/test/java/com/snowgears/shop/util/UtilMethodsTest.java
@@ -224,17 +224,106 @@ public class UtilMethodsTest {
         Assertions.assertEquals("§7(sell, buy, barter, gamble, combo)", result.get(3));
         Assertions.assertEquals(4, result.size());
     }
+
+    @Test
+    public void testGradientWordIsKeptIntact() {
+        // From log: "§eEnter in chat what to do with §a§ct§x§F§E§5§9§3§Fe§x§F§E§7§3§3§Fs§x§F§E§8§D§3§Et§x§F§E§A§7§3§Fi§x§F§E§C§1§3§Fn§x§F§E§D§B§3§Fg §x§F§E§F§5§3§Fa §x§E§C§F§E§3§Fr§x§D§2§F§E§3§Fa§x§B§8§F§E§3§Fi§x§9§E§F§E§3§Fn§x§8§4§F§E§3§Fb§x§6§A§F§E§3§Fo§x§5§0§F§E§3§Fw §x§3§F§F§5§4§7m§x§3§F§D§B§6§1e§x§3§F§C§1§7§Bs§x§3§F§A§7§9§5s§x§3§F§8§D§A§Fa§x§3§F§7§3§C§9g§x§3§F§5§9§E§3e§9!§a(s)"
+        String input = "&eEnter in chat what to do with &a&ct§x§F§E§5§9§3§Fe§x§F§E§7§3§3§Fs§x§F§E§8§D§3§Et§x§F§E§A§7§3§Fi§x§F§E§C§1§3§Fn§x§F§E§D§B§3§Fg §x§F§E§F§5§3§Fa §x§E§C§F§E§3§Fr§x§D§2§F§E§3§Fa§x§B§8§F§E§3§Fi§x§9§E§F§E§3§Fn§x§8§4§F§E§3§Fb§x§6§A§F§E§3§Fo§x§5§0§F§E§3§Fw §x§3§F§F§5§4§7m§x§3§F§D§B§6§1e§x§3§F§C§1§7§Bs§x§3§F§A§7§9§5s§x§3§F§8§D§A§Fa§x§3§F§7§3§C§9g§x§3§F§5§9§E§3e§9!&a(s)";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 35);
+        
+        // The first line should break after "what to do with"
+        Assertions.assertEquals("§eEnter in chat what to do with", result.get(0));
+        
+        // The gradient word "testing" should be kept intact in one line, not split across lines
+        String secondLine = result.get(1);
+        Assertions.assertTrue(secondLine.contains("§ct§x§F§E§5§9§3§Fe§x§F§E§7§3§3§Fs§x§F§E§8§D§3§Et§x§F§E§A§7§3§Fi§x§F§E§C§1§3§Fn§x§F§E§D§B§3§Fg"));
+        
+        // The gradient word "rainbow" should be kept intact
+        Assertions.assertTrue(secondLine.contains("§x§E§C§F§E§3§Fr§x§D§2§F§E§3§Fa§x§B§8§F§E§3§Fi§x§9§E§F§E§3§Fn§x§8§4§F§E§3§Fb§x§6§A§F§E§3§Fo§x§5§0§F§E§3§Fw"));
+        
+        // The gradient word "message" should be kept intact
+        Assertions.assertTrue(secondLine.contains("§x§3§F§F§5§4§7m§x§3§F§D§B§6§1e§x§3§F§C§1§7§Bs§x§3§F§A§7§9§5s§x§3§F§8§D§A§Fa§x§3§F§7§3§C§9g§x§3§F§5§9§E§3e"));
+        
+    }
+    
+    @Test
+    public void testGradientNonAsciiWordIsKeptIntact() {
+        // From log: "§eEnter in chat what to do with §a§x§F§6§C§9§2§8V§x§F§3§C§3§2§5o§x§F§0§B§C§2§3t§x§E§D§B§6§2§0e§x§E§A§B§0§1§EB§x§E§7§A§A§1§Bo§x§E§4§A§3§1§8x §x§E§1§9§D§1§6k§x§D§E§9§7§1§3ľ§x§D§B§9§0§1§1ú§x§D§8§8§A§0§Eč§a(s)"
+        String input = "&eEnter in chat what to do with &a§x§F§6§C§9§2§8V§x§F§3§C§3§2§5o§x§F§0§B§C§2§3t§x§E§D§B§6§2§0e§x§E§A§B§0§1§EB§x§E§7§A§A§1§Bo§x§E§4§A§3§1§8x §x§E§1§9§D§1§6k§x§D§E§9§7§1§3ľ§x§D§B§9§0§1§1ú§x§D§8§8§A§0§Eč&a(s)";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 35);
+        
+        // The first line should break after "what to do with"
+        Assertions.assertEquals("§eEnter in chat what to do with", result.get(0));
+        
+        // The gradient word "VoteBox" should be kept intact in one line
+        String secondLine = result.get(1);
+        Assertions.assertTrue(secondLine.contains("§x§F§6§C§9§2§8V§x§F§3§C§3§2§5o§x§F§0§B§C§2§3t§x§E§D§B§6§2§0e§x§E§A§B§0§1§EB§x§E§7§A§A§1§Bo§x§E§4§A§3§1§8x"));
+        
+        // The gradient word with non-ASCII chars "klúč" should be kept intact
+        Assertions.assertTrue(secondLine.contains("§x§E§1§9§D§1§6k§x§D§E§9§7§1§3ľ§x§D§B§9§0§1§1ú§x§D§8§8§A§0§Eč"));
+    }
+
+    @Test
+    public void testCompleteGradientMessageSplitting() {
+        // Complete test for the first gradient example
+        String input = "&eEnter in chat what to do with &a&ct§x§F§E§5§9§3§Fe§x§F§E§7§3§3§Fs§x§F§E§8§D§3§Et§x§F§E§A§7§3§Fi§x§F§E§C§1§3§Fn§x§F§E§D§B§3§Fg §x§F§E§F§5§3§Fa §x§E§C§F§E§3§Fr§x§D§2§F§E§3§Fa§x§B§8§F§E§3§Fi§x§9§E§F§E§3§Fn§x§8§4§F§E§3§Fb§x§6§A§F§E§3§Fo§x§5§0§F§E§3§Fw §x§3§F§F§5§4§7m§x§3§F§D§B§6§1e§x§3§F§C§1§7§Bs§x§3§F§A§7§9§5s§x§3§F§8§D§A§Fa§x§3§F§7§3§C§9g§x§3§F§5§9§E§3e§9!&a(s)&b&b&b &7(&7sell, buy, barter, gamble, combo&7)";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 35);
+        
+        // Verify there are 3 lines as shown in the log
+        Assertions.assertEquals(3, result.size());
+        
+        // Verify the content of each line
+        Assertions.assertEquals("§eEnter in chat what to do with", result.get(0));
+        
+        // The second line contains the complex gradient text and should keep all gradient words intact
+        String gradientLine = result.get(1);
+        Assertions.assertTrue(gradientLine.contains("§ct§x§F§E§5§9§3§Fe§x§F§E§7§3§3§Fs§x§F§E§8§D§3§Et§x§F§E§A§7§3§Fi§x§F§E§C§1§3§Fn§x§F§E§D§B§3§Fg"));
+        Assertions.assertTrue(gradientLine.contains("§x§F§E§F§5§3§Fa"));
+        Assertions.assertTrue(gradientLine.contains("§x§E§C§F§E§3§Fr§x§D§2§F§E§3§Fa§x§B§8§F§E§3§Fi§x§9§E§F§E§3§Fn§x§8§4§F§E§3§Fb§x§6§A§F§E§3§Fo§x§5§0§F§E§3§Fw"));
+        Assertions.assertTrue(gradientLine.contains("§x§3§F§F§5§4§7m§x§3§F§D§B§6§1e§x§3§F§C§1§7§Bs§x§3§F§A§7§9§5s§x§3§F§8§D§A§Fa§x§3§F§7§3§C§9g§x§3§F§5§9§E§3e"));
+        Assertions.assertTrue(gradientLine.contains("§a(s)"));
+        
+        // The third line should be the options text
+        Assertions.assertEquals("§7(sell, buy, barter, gamble, combo)", result.get(2));
+    }
+    
+    @Test
+    public void testVoteBoxGradientMessageSplitting() {
+        // Complete test for the second gradient example with VoteBox
+        String input = "&eEnter in chat what to do with &a§x§F§6§C§9§2§8V§x§F§3§C§3§2§5o§x§F§0§B§C§2§3t§x§E§D§B§6§2§0e§x§E§A§B§0§1§EB§x§E§7§A§A§1§Bo§x§E§4§A§3§1§8x §x§E§1§9§D§1§6k§x§D§E§9§7§1§3ľ§x§D§B§9§0§1§1ú§x§D§8§8§A§0§Eč&a(s)&b&b&b &7(&7sell, buy, barter, gamble, combo&7)";
+        List<String> result = UtilMethods.splitStringIntoLines(input, 35);
+        
+        // Verify there are 3 lines as shown in the log
+        Assertions.assertEquals(3, result.size());
+        
+        // Verify the content of each line
+        Assertions.assertEquals("§eEnter in chat what to do with", result.get(0));
+        
+        // The second line contains the complex gradient text for VoteBox klúč
+        String gradientLine = result.get(1);
+        Assertions.assertTrue(gradientLine.contains("§x§F§6§C§9§2§8V§x§F§3§C§3§2§5o§x§F§0§B§C§2§3t§x§E§D§B§6§2§0e§x§E§A§B§0§1§EB§x§E§7§A§A§1§Bo§x§E§4§A§3§1§8x"));
+        Assertions.assertTrue(gradientLine.contains(" §x§E§1§9§D§1§6k§x§D§E§9§7§1§3ľ§x§D§B§9§0§1§1ú§x§D§8§8§A§0§Eč"));
+        Assertions.assertTrue(gradientLine.contains("§a(s)"));
+        
+        // The third line should be the options text
+        Assertions.assertEquals("§7(sell, buy, barter, gamble, combo)", result.get(2));
+    }
 }
 
 /**
 
 
-// Test overflow of a line with only a hex color code
-[15:35:17 INFO]: [Shop] [Debug] [ShopMessage] postFormat: §x§3§d§0§0§3§dEnter in chat what to do with except have a really long line with overflow §a§aBirch Log§a(s)§b§b§b §7(§7sell, buy, barter, gamble, combo§7)
-[15:35:17 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/66/2046: 
-[15:35:17 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/66/2046: §x§3§d§0§0§3§dEnter in chat what to do with except have
-[15:35:17 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/66/2046: §x§3§d§0§0§3§da really long line with overflow
-[15:35:17 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/66/2046: §aBirch Log(s)§b
-[15:35:17 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/65/2046: §7(sell, buy, barter, gamble, combo)
+// Verify we keep gradient words in one piece instead of splitting them in the middle of a word
+[23:47:05 INFO]: [Shop] [Debug] [ShopMessage] postFormat: §eEnter in chat what to do with §a§ct§x§F§E§5§9§3§Fe§x§F§E§7§3§3§Fs§x§F§E§8§D§3§Et§x§F§E§A§7§3§Fi§x§F§E§C§1§3§Fn§x§F§E§D§B§3§Fg §x§F§E§F§5§3§Fa §x§E§C§F§E§3§Fr§x§D§2§F§E§3§Fa§x§B§8§F§E§3§Fi§x§9§E§F§E§3§Fn§x§8§4§F§E§3§Fb§x§6§A§F§E§3§Fo§x§5§0§F§E§3§Fw §x§3§F§F§5§4§7m§x§3§F§D§B§6§1e§x§3§F§C§1§7§Bs§x§3§F§A§7§9§5s§x§3§F§8§D§A§Fa§x§3§F§7§3§C§9g§x§3§F§5§9§E§3e§9!§a(s)§b§b§b §7(§7sell, buy, barter, gamble, combo§7)
+[23:47:05 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2113/68/2026: §eEnter in chat what to do with
+[23:47:05 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2113/68/2026: §ct§x§F§E§5§9§3§Fe§x§F§E§7§3§3§Fs§x§F§E§8§D§3§Et§x§F§E§A§7§3§Fi§x§F§E§C§1§3§Fn§x§F§E§D§B§3§Fg §x§F§E§F§5§3§Fa §x§E§C§F§E§3§Fr§x§D§2§F§E§3§Fa§x§B§8§F§E§3§Fi§x§9§E§F§E§3§Fn§x§8§4§F§E§3§Fb§x§6§A§F§E§3§Fo§x§5§0§F§E§3§Fw §x§3§F§F§5§4§7m§x§3§F§D§B§6§1e§x§3§F§C§1§7§Bs§x§3§F§A§7§9§5s§x§3§F§8§D§A§Fa§x§3§F§7§3§C§9g§x§3§F§5§9§E§3e§9!§a(s)§b
+[23:47:05 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2113/67/2026: §7(sell, buy, barter, gamble, combo)
+
+// Second example
+[23:48:40 INFO]: [Shop] [Debug] [ShopMessage] postFormat: §eEnter in chat what to do with §a§x§F§6§C§9§2§8V§x§F§3§C§3§2§5o§x§F§0§B§C§2§3t§x§E§D§B§6§2§0e§x§E§A§B§0§1§EB§x§E§7§A§A§1§Bo§x§E§4§A§3§1§8x §x§E§1§9§D§1§6k§x§D§E§9§7§1§3ľ§x§D§B§9§0§1§1ú§x§D§8§8§A§0§Eč§a(s)§b§b§b §7(§7sell, buy, barter, gamble, combo§7)
+[23:48:40 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/68/2026: §eEnter in chat what to do with
+[23:48:40 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/68/2026: §x§F§6§C§9§2§8V§x§F§3§C§3§2§5o§x§F§0§B§C§2§3t§x§E§D§B§6§2§0e§x§E§A§B§0§1§EB§x§E§7§A§A§1§Bo§x§E§4§A§3§1§8x §x§E§1§9§D§1§6k§x§D§E§9§7§1§3ľ§x§D§B§9§0§1§1ú§x§D§8§8§A§0§Eč§a(s)§b
+[23:48:40 INFO]: [Shop] [Debug] Spawning hologram for player spaceGurlSky at -2112/67/2026: §7(sell, buy, barter, gamble, combo)
+
 
  */

--- a/mineflayer-tests/ShopBot.js
+++ b/mineflayer-tests/ShopBot.js
@@ -2,151 +2,286 @@ const { Vec3 } = require('vec3')
 const { pathfinder, Movements, goals: { GoalNear } } = require('mineflayer-pathfinder')
 const BlockFaces = require('prismarine-world').iterators.BlockFace
 
+// Constants for better readability
+const TIMING = {
+  SPAWN_DELAY: 2500,
+  SHOP_COOLDOWN: 200,
+  COMMAND_DELAY: 50,
+  MOVEMENT_DELAY: 500,
+  CHEST_INTERACTION_DELAY: 100,
+  SHOP_CREATION_DELAY: 500
+}
+
+const POSITION = {
+  START_X: -100,
+  START_Y: 56,
+  START_Z: 0,
+  SHOP_SPACING: 2, // 1 block space between shops
+  GRID_SIZE: 32,   // 32x32 grid of shops
+  SIGN_OFFSET: 1,
+  PLAYER_OFFSET: 1.5
+}
+
+// Shop types and items
+const SHOP_TYPES = ["buy", "sell"]
+const SHOP_ITEMS = [
+  "stone",
+  "gold_ingot",
+  "diamond",
+  "emerald",
+  "lapis_lazuli",
+  "redstone",
+  "coal",
+  "iron_ingot",
+  "copper_ingot",
+  "wheat",
+  "carrot",
+  "potato"
+]
+
+const TOOLS = {
+  AXE: "netherite_axe[enchantments={levels:{efficiency:255}}]",
+  CHEST: "chest"
+}
+
 async function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 class ShopBot {
-    constructor(bot) {
-        this.bot = bot
-        this.defaultMove
+  constructor(bot) {
+    this.bot = bot
+    this.defaultMove = null
+    this.shopCount = 0
+    this.maxShops = POSITION.GRID_SIZE * POSITION.GRID_SIZE
 
-        this.bot.loadPlugin(pathfinder)
-        this.bot.once('spawn', async () => {
-            await sleep(2500)
-            await this.start()
-        })
+    this.bot.loadPlugin(pathfinder)
+    this.bot.once('spawn', async () => {
+      await sleep(TIMING.SPAWN_DELAY)
+      await this.start()
+    })
 
-        this.bot.on('kicked', console.log)
-        this.bot.on('error', console.log)
+    this.setupEventListeners()
+  }
 
-        this.bot.on('message', (message) => {
-            // console.log(message)
-        })
-    }
+  setupEventListeners() {
+    this.bot.on('kicked', console.log)
+    this.bot.on('error', console.log)
+    // Commented code left for potential future use
+    this.bot.on('message', (message) => {
+      // console.log(message)
+    })
+  }
 
-    async start() {
-        let x = 10
-        let y = 56
-        let z = 10
-        await this.createShopRoutine("stone", "sell", 1, 1, x, y, z)
-        x += 2
-        await this.createShopRoutine("gold_ingot", "buy", 1, 1, x, y, z)
-        x += 2
-        await this.createShopRoutine("diamond", "sell", 1, 1, x, y, z)
-        x += 2
-        await this.createShopRoutine("emerald", "buy", 1, 1, x, y, z)
-        x += 2
-        await this.createShopRoutine("lapis_lazuli", "sell", 1, 1, x, y, z)
-        x += 2
-        await this.createShopRoutine("redstone", "buy", 1, 1, x, y, z)
-        x += 2
-        await this.createShopRoutine("coal", "sell", 1, 1, x, y, z)
+  /**
+   * Creates a shop field in a grid pattern
+   */
+  async start() {
+    const baseX = POSITION.START_X
+    const y = POSITION.START_Y
+    const baseZ = POSITION.START_Z
+
+    // Create shops in a grid pattern
+    for (let gridZ = 0; gridZ < POSITION.GRID_SIZE; gridZ++) {
+      for (let gridX = 0; gridX < POSITION.GRID_SIZE; gridX++) {
+        // Calculate actual position with proper spacing
+        const x = baseX + (gridX * POSITION.SHOP_SPACING)
+        const z = baseZ + (gridZ * POSITION.SHOP_SPACING)
         
-    }
-
-    async createShopRoutine(item, type, quantity, price, x, y, z) {
-        await this.clearInventory()
-        await this.moveToLocation(x, y, z - 1.5)
-        await this.giveItem("netherite_axe[enchantments={levels:{efficiency:255}}]")
-        await this.removeBlockIfExists(x, y, z - 1, BlockFaces.WEST) // Remove sign
-        await this.removeBlockIfExists(x, y, z, BlockFaces.WEST) // Remove chest
-        await this.placeChest(x, y - 1, z) // Place chest
-        await this.giveItem(item)
-        await this.createShop(type, quantity, price, x, y, z) // Create shop
-        await this.doesSignExist(x, y, z - 1) // Check if shop was created
-        await sleep(3500) // 5 second cooldown between creating shops
-    }
-
-    async clearInventory() {
-        this.bot.chat("/clear")
-        await sleep(50)
-    }
-
-    async giveItem(item) {
-        await this.clearInventory()
-        this.bot.chat(`/give Bot minecraft:${item} 1`)
-        await sleep(50)
-    }
-
-    async moveToLocation(x, y, z) {
-        this.bot.chat(`/tp ${x} ${y} ${z}`)
-        await sleep(500)
-        // if (!this.defaultMove) {
-        //     this.defaultMove = new Movements(this.bot)
-        // }
-        // this.bot.chat("currently: moving")
-        // this.bot.pathfinder.setMovements(this.defaultMove)
-        // this.bot.chat("on my way!")
-        // await this.bot.pathfinder.goto(new GoalNear(x, y, z, 0.25))
-        // await sleep(1500)
-    }
-
-    async removeBlockIfExists(x, y, z, face) {
-        // remove previous chest if it exists
-        const blockToCleanup = this.bot.blockAt(new Vec3(x, y, z))
-        if (this.bot.canDigBlock(blockToCleanup)){
-            this.bot.chat(`starting to dig ${blockToCleanup.name}`)
-            await this.bot.dig(blockToCleanup, true, face)
-            this.bot.chat("removed existing block...")
-            await sleep(50)
+        // Determine shop type and item based on position
+        const shopType = this.getShopTypeForPosition(gridX, gridZ)
+        const shopItem = this.getShopItemForPosition(gridX, gridZ)
+        const quantity = 1
+        const price = 1
+        
+        // Create shop and update progress
+        await this.createShopRoutine(shopItem, shopType, quantity, price, x, y, z)
+        this.shopCount++
+        
+        // Log progress
+        if (this.shopCount % 10 === 0) {
+          console.log(`Progress: ${this.shopCount}/${this.maxShops} shops created (${Math.floor(this.shopCount/this.maxShops*100)}%)`)
         }
-    }
-
-    async placeChest(x, y, z) {
-        await this.giveItem("chest")
-        const referenceBlock = this.bot.blockAt(new Vec3(x, y, z))
-        await this.bot.placeBlock(referenceBlock, new Vec3(0, 1, 0))
-        await sleep(50)
-    }
-
-    async createShop(type, quantity, price, x, y, z) {
-        const chest = this.bot.blockAt(new Vec3(x, y, z))
-        this.bot.setControlState('sneak', true)
-        await sleep(50)
-        await this.clickOnChest(chest)
-        await sleep(50)
-        this.bot.setControlState('sneak', false)
-        await sleep(50)
-        this.bot.chat(type)
-        await sleep(50)
-        this.bot.chat(`${quantity}`)
-        await sleep(50)
-        this.bot.chat(`${price}`)
-        await sleep(500)
-    }
-
-    async doesSignExist(x, y, z) {
-        const sign = this.bot.blockAt(new Vec3(x, y, z))
-        if (sign.name.includes("sign")) {
-            this.bot.chat("teh sign is there")
-            const signText = sign.getSignText()
-            console.log(signText[0])
-            if (signText[0].includes("[shop]")){
-                this.bot.chat("i did its! shop created :3")
-                console.log("Successfully created sell shop")
-                return true
-            }
-        } else {
-            this.bot.chat("i failed my task :c")
-            return false
-        }
-    }
-
-    // Left clicks on a block
-    async clickOnChest(block) {
-        this.bot._client.write('block_dig', {
-          status: 0, // start digging
-          location: block.position,
-          face: 1
-        })
-        await sleep(100)
-        this.bot._client.write('block_dig', {
-          status: 1, // cancel digging
-          location: block.position,
-          face: 1
-        })
       }
+    }
+    
+    console.log(`Completed: Created ${this.shopCount} shops in a ${POSITION.GRID_SIZE}x${POSITION.GRID_SIZE} grid`)
+  }
+
+  /**
+   * Determines shop type (buy/sell) based on position
+   */
+  getShopTypeForPosition(x, z) {
+    // Alternate between buy and sell in a checkerboard pattern
+    return SHOP_TYPES[(x + z) % 2]
+  }
+  
+  /**
+   * Determines shop item based on position
+   */
+  getShopItemForPosition(x, z) {
+    // Create a pattern of items
+    const itemIndex = (x + z * POSITION.GRID_SIZE) % SHOP_ITEMS.length
+    return SHOP_ITEMS[itemIndex]
+  }
+
+  async createShopRoutine(item, type, quantity, price, x, y, z) {
+    await this.clearInventory()
+    await this.moveToLocation(x, y, z - POSITION.PLAYER_OFFSET)
+    await this.giveItem(TOOLS.AXE)
+    
+    // Make sure the bot has loaded the area
+    await sleep(TIMING.COMMAND_DELAY * 2)
+    
+    // Clear existing blocks
+    await this.removeBlockIfExists(x, y, z - POSITION.SIGN_OFFSET, BlockFaces.WEST) // Remove sign
+    await this.removeBlockIfExists(x, y, z, BlockFaces.WEST) // Remove chest
+    
+    // Set up and create the shop
+    await this.placeChest(x, y - 1, z)
+    await this.giveItem(item)
+    await this.createShop(type, quantity, price, x, y, z)
+    await this.verifyShopCreation(x, y, z - POSITION.SIGN_OFFSET)
+    
+    // Wait for shop cooldown
+    await sleep(TIMING.SHOP_COOLDOWN)
+  }
+
+  async clearInventory() {
+    this.bot.chat("/clear")
+    await sleep(TIMING.COMMAND_DELAY)
+  }
+
+  async giveItem(item) {
+    await this.clearInventory()
+    this.bot.chat(`/give Bot minecraft:${item} 1`)
+    await sleep(TIMING.COMMAND_DELAY)
+  }
+
+  async moveToLocation(x, y, z) {
+    this.bot.chat(`/tp ${x} ${y} ${z}`)
+    await sleep(TIMING.MOVEMENT_DELAY)
+    
+    // Pathfinding implementation kept for potential future use
+    /*
+    if (!this.defaultMove) {
+      this.defaultMove = new Movements(this.bot)
+    }
+    this.bot.pathfinder.setMovements(this.defaultMove)
+    await this.bot.pathfinder.goto(new GoalNear(x, y, z, 0.25))
+    await sleep(1500)
+    */
+  }
+
+  async removeBlockIfExists(x, y, z, face) {
+    const blockToCleanup = this.bot.blockAt(new Vec3(x, y, z))
+    if (this.bot.canDigBlock(blockToCleanup)) {
+      this.bot.chat(`starting to dig ${blockToCleanup.name}`)
+      await this.bot.dig(blockToCleanup, true, face)
+      this.bot.chat("removed existing block...")
+      await sleep(TIMING.COMMAND_DELAY)
+    }
+  }
+
+  async placeChest(x, y, z) {
+    await this.giveItem(TOOLS.CHEST)
+    
+    // Ensure there's a reference block by placing a temporary block if needed
+    const blockPos = new Vec3(x, y, z)
+    let referenceBlock = this.bot.blockAt(blockPos)
+    
+    if (!referenceBlock || referenceBlock.name === 'air') {
+      // First, we need to check if we're in a loaded chunk
+      if (!this.bot.world.getColumnAt(blockPos)) {
+        console.log(`Chunk at (${x}, ${z}) not loaded, waiting...`)
+        await sleep(1000) // Wait for chunk to load
+        
+        // If still not loaded, we can force load it with a teleport nearby
+        if (!this.bot.world.getColumnAt(blockPos)) {
+          this.bot.chat(`/tp ${x} ${y} ${z}`)
+          await sleep(1000)
+        }
+      }
+      
+      // Try to place a temporary block below
+      this.bot.chat(`/setblock ${x} ${y-1} ${z} stone`)
+      await sleep(TIMING.COMMAND_DELAY * 2)
+      
+      // Update reference block
+      referenceBlock = this.bot.blockAt(blockPos)
+      if (!referenceBlock || referenceBlock.name === 'air') {
+        console.log(`Failed to get reference block at (${x}, ${y}, ${z}), chest placement may fail`)
+        // Last resort - try to use a different placement method
+        this.bot.chat(`/setblock ${x} ${y} ${z} chest`)
+        await sleep(TIMING.COMMAND_DELAY)
+        return
+      }
+    }
+    
+    // Now place the chest using the reference block
+    try {
+      await this.bot.placeBlock(referenceBlock, new Vec3(0, 1, 0))
+    } catch (err) {
+      console.log(`Error placing chest: ${err.message}`)
+      // Fallback to setblock command
+      this.bot.chat(`/setblock ${x} ${y} ${z} chest`)
+    }
+    
+    await sleep(TIMING.COMMAND_DELAY)
+  }
+
+  async createShop(type, quantity, price, x, y, z) {
+    const chest = this.bot.blockAt(new Vec3(x, y, z))
+    
+    // Interact with chest while sneaking
+    this.bot.setControlState('sneak', true)
+    await sleep(TIMING.COMMAND_DELAY)
+    await this.clickOnChest(chest)
+    await sleep(TIMING.COMMAND_DELAY)
+    this.bot.setControlState('sneak', false)
+    await sleep(TIMING.COMMAND_DELAY)
+    
+    // Input shop parameters
+    this.bot.chat(type)
+    await sleep(TIMING.COMMAND_DELAY)
+    this.bot.chat(`${quantity}`)
+    await sleep(TIMING.COMMAND_DELAY)
+    this.bot.chat(`${price}`)
+    await sleep(TIMING.SHOP_CREATION_DELAY)
+  }
+
+  async verifyShopCreation(x, y, z) {
+    const sign = this.bot.blockAt(new Vec3(x, y, z))
+    if (sign.name.includes("sign")) {
+      this.bot.chat("The sign is there")
+      const signText = sign.getSignText()
+      console.log(signText[0])
+      
+      if (signText[0].includes("[shop]")) {
+        this.bot.chat("Shop created successfully")
+        console.log("Successfully created shop")
+        return true
+      }
+    } else {
+      this.bot.chat("Shop creation failed")
+      return false
+    }
+  }
+
+  // Left clicks on a block
+  async clickOnChest(block) {
+    this.bot._client.write('block_dig', {
+      status: 0, // start digging
+      location: block.position,
+      face: 1
+    })
+    await sleep(TIMING.CHEST_INTERACTION_DELAY)
+    this.bot._client.write('block_dig', {
+      status: 1, // cancel digging
+      location: block.position,
+      face: 1
+    })
+  }
 }
 
 module.exports = ShopBot;

--- a/mineflayer-tests/index.js
+++ b/mineflayer-tests/index.js
@@ -1,12 +1,10 @@
 const mineflayer = require('mineflayer')
-const { pathfinder, Movements, goals: { GoalNear } } = require('mineflayer-pathfinder')
-const { Vec3 } = require('vec3')
 const ShopBot = require('./ShopBot')
 const bot = mineflayer.createBot({
   host: 'localhost', // minecraft server ip
   username: 'Bot', // username to join as if auth is `offline`, else a unique identifier for this account. Switch if you want to change accounts
-  auth: 'offline' // for offline mode servers, you can set this to 'offline'
-  // port: 25565,              // set if you need a port that isn't 25565
+  auth: 'offline', // for offline mode servers, you can set this to 'offline'
+  // port: 25595,              // set if you need a port that isn't 25565
   // version: false,           // only set if you need a specific version or snapshot (ie: "1.8.9" or "1.16.5"), otherwise it's set automatically
   // password: '12345678'      // set if you want to use password-based auth (may be unreliable). If specified, the `username` must be an email
 })

--- a/pom.xml
+++ b/pom.xml
@@ -33,12 +33,27 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
+        
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <properties>
         <revision>1.10.1</revision>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/runDev.sh
+++ b/runDev.sh
@@ -24,7 +24,7 @@ function resetVersion() {
 updateVersion
 # Build the plugin
 export MAVEN_OPTS="-Xms8g -Xmx16g"
-mvn clean compile package -T 8C -o
+mvn clean compile package -T 8C #-o
 # Reset the version in pom.xml
 resetVersion
 

--- a/wiki/config.md
+++ b/wiki/config.md
@@ -259,7 +259,7 @@ The partial sales system is particularly useful for servers with item-based econ
 ### Technical Details
 - For partial purchases, the price per item is calculated as: `originalPrice ÷ originalAmount`
 - For items selling below 1 currency unit each (like 64 items for 10 emeralds), the system calculates `itemsPerPrice = 1 ÷ pricePerItem`
-- The system always rounds in favor of the item seller, so they never lose value in partial transactions
+- The system always rounds slightly in favor of the item seller
 
 ## checkItemDurability
 This will make it so shops will only complete transactions if the item durabilities are the same.

--- a/wiki/config.md
+++ b/wiki/config.md
@@ -1,0 +1,1606 @@
+**`config.yml`**
+* **General Settings**
+    * [usePermissions](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#usePermissions)
+    * [checkUpdates](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#checkUpdates)
+    * [enableGUI](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#enableGUI)
+    * [commandAlias](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#commandAlias)
+    * [deletePlayerShopsAfterXHoursOffline](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#deletePlayerShopsAfterXHoursOffline)
+* **Currency and Economy**
+    * [currency](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#currency)
+    * [allowPartialSales](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#allowPartialSales)
+    * [checkItemDurability](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#checkItemDurability)
+    * [ignoreItemRepairCost](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#ignoreItemRepairCost)
+    * [creationCost](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#creationCost)
+    * [destructionCost](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#destructionCost)
+    * [teleportCost](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#teleportCost)
+    * [teleportCooldown](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#teleportCooldown)
+    * [returnCreationCost](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#returnCreationCost)
+    * [priceSuffixes](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#priceSuffixes)
+* **Shop Display**
+    * [displayType](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#displayType)
+    * [displayNameTags](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#displayNameTags)
+    * [displayCycle](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#displayCycle)
+    * [forceDisplayToNoneIfBlocked](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#forceDisplayToNoneIfBlocked)
+    * [displayLightLevel](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#displayLightLevel)
+    * [setGlowingItemFrame](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#setGlowingItemFrame)
+    * [setGlowingSignText](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#setGlowingSignText)
+* **Shop Interactions**
+    * [actionMappings](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#action-mappings)
+    * [creationMethod](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#creationMethod)
+    * [displayFloatingCreateText](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#displayFloatingCreateText)
+    * [allowCreativeSelection](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#allowCreativeSelection)
+    * [destroyShopRequiresSneak](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#destroyShopRequiresSneak)
+    * [playSounds](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#playSounds)
+    * [playEffects](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#playEffects)
+    * [inverseComboShops](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#inverseComboShops)
+    * [itemList](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#itemList)
+    * [worldBlacklist](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#worldBlacklist)
+    * [enabledContainers](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#enabledContainers)
+* **Database Logging & Notifications**
+    * [logging](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#logging)
+    * [offlinePurchaseNotifications](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#offlinePurchaseNotifications)
+* **Integrations**
+    * [hookWorldGuard](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#hookWorldGuard)
+    * [hookTowny](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#hookTowny)
+    * [dynmap-marker](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#dynmap-marker)
+    * [bluemap-marker](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#bluemap-marker)
+* **Shop Performance Optimizations**
+    * [displayProcessInterval](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#displayProcessInterval)
+    * [displayMovementThreshold](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#displayMovementThreshold)
+    * [maxShopDisplayDistance](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#maxShopDisplayDistance)
+    * [shopSearchRadius](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#shopSearchRadius)
+* **Debug Tools**
+    * [logLevel](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#logLevel)
+    * [enableLogColor](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#enableLogColor)
+    * [debug](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#debug)
+
+# General Settings
+
+## usePermissions
+This setting determines whether the plugin uses the permission system to control access to features.
+```yaml
+usePermissions: true
+```
+
+This setting governs how Shop handles player permissions throughout the plugin, affecting almost every aspect of shop creation, management, and usage.
+
+When set to `true`:
+- The plugin will check for specific permissions before allowing players to perform actions
+- Players will by default have NO permissions to create or use shops
+- Permissions must be explicitly granted using a permissions plugin (like LuckPerms)
+- Shop owners need appropriate permissions (e.g., `shop.create.buy`, `shop.create.sell`)
+- Shop customers need appropriate permissions (e.g., `shop.use.buy`, `shop.use.sell`)
+- Build limits can be set using permissions like `shop.buildlimit.10` (limits to 10 shops)
+- Using `shop.operator` permission grants full access to all plugin features
+
+When set to `false`:
+- All players can create and use any type of shop without permission checks
+- Only gamble shop creation remains restricted to operators
+- Admin commands (like setcurrency, itemrefresh, reload) remain restricted to operators
+- WorldGuard and Towny hooks still respect operator status
+
+This setting is particularly important for server administrators who want granular control over shop privileges. For example, you might want to restrict certain shop types to VIP players, or limit how many shops each player can create based on their rank.
+
+## checkUpdates
+This setting enables or disables update notifications for server operators when they log in.
+```yaml
+checkUpdates: true
+```
+
+This setting controls whether the plugin checks for and notifies about available updates. When enabled, Shop will connect to SpigotMC.org to check if a newer version is available.
+
+When set to `true`:
+- The plugin will check SpigotMC.org for updates at regular intervals
+- If a newer version is found, a notification will be sent to the console
+- Server operators (OPs) will receive a clickable notification when they log in, with a link to download the update
+- If you're running a development or pre-release version (higher version number than the latest stable release), a different notification will indicate you're using a development build
+
+When set to `false`:
+- No update checks will be performed
+- No notifications will be sent to operators or the console
+
+This feature is useful for staying informed about new versions that may include bug fixes, performance improvements, or new features. The update check is performed asynchronously so it doesn't impact server performance. Please leave this enabled.
+
+## enableGUI 
+This enables a graphical user interface to use all shop features without typing commands.
+```yaml
+enableGUI: true
+```
+
+This setting controls whether players can access and use the plugin's graphical user interface. The GUI provides an intuitive, menu-based approach to using all shop features without needing to remember commands.
+
+When set to `true`:
+- Typing `/shop` (or your custom command alias) without any arguments opens the GUI
+- Players can browse all shops, search for specific items, manage their own shops, and access settings through interactive menus
+- Features are organized in tabs for easy navigation
+- The GUI makes the plugin more accessible to players who are unfamiliar with commands
+- All shop types and management functions are available through the interface
+
+When set to `false`:
+- The GUI is completely disabled
+
+The GUI is designed to be intuitive and user-friendly, making it easier for players to discover and use shop features. Most server owners will want to keep this enabled as it significantly improves the player experience.
+
+## commandAlias
+This is the command alias that will be used as the base for all shop commands.
+```yaml
+commandAlias: shop
+```
+
+This setting determines the primary command that players will use to interact with the Shop plugin. It defines the base command that all other subcommands will extend from.
+
+When you set this value:
+- Players will use `/<your_alias>` as the main command (e.g., `/shop list`, `/shop currency`)
+- The GUI will be accessible via `/<your_alias>` if the GUI is enabled
+- Tab completion will work with your custom alias
+
+Common examples of alternative values:
+- `market` (players would use `/market` instead of `/shop`)
+- `trade` (players would use `/trade` instead of `/shop`)
+- `store` (players would use `/store` instead of `/shop`)
+
+Changing this can be useful to:
+- Avoid command conflicts with other plugins
+- Create more intuitive commands that match your server's theme
+- Provide language-specific commands for international servers
+
+Remember that changing this value affects all documentation and guides for your players, so you may need to update any server guides or tutorials accordingly.
+
+## deletePlayerShopsAfterXHoursOffline
+This will permanently delete a player's shops if they have not logged onto the server after X hours. Set this to 0 to never auto-delete a player's shops.
+```yaml
+deletePlayerShopsAfterXHoursOffline: 0
+```
+
+This setting enables automatic cleanup of shops belonging to players who haven't logged into your server for an extended period. It can help keep your server tidy by removing inactive shops and potentially improve performance by reducing the number of shops that need to be processed.
+
+When set to a value greater than 0:
+- The plugin checks each player's last login time whenever any player joins the server
+- For each shop owner, it calculates how many hours have passed since they last played
+- If the calculated time exceeds the configured threshold, all of their shops are deleted
+- A log message is generated for each deleted shop
+- Shop files for that player are cleaned up if all shops are removed
+
+When set to `0` (default):
+- The auto-deletion feature is completely disabled
+- Shops will remain indefinitely, regardless of how long players are inactive
+- You'll need to manually remove shops from inactive players if desired
+
+Common usage examples:
+- `720` (30 days) - Reasonable for high-traffic servers with many temporary players
+- `2160` (90 days) - More lenient setting for established communities
+- `0` - No automatic deletion, ideal for servers where shop persistence is critical
+
+This feature runs specifically when players join the server, making it a gradual cleanup process rather than a scheduled task that might cause server lag. It's a "set it and forget it" way to maintain server tidiness over time.
+
+# Currency and Economy Settings
+
+## currency
+The type of currency used for shops.
+```yaml
+currency:
+  type: 'ITEM'
+  name: 'Emerald(s)'
+  format: '[price] [name]'
+```
+
+This is one of the most important configurations in the Shop plugin as it determines how players will pay for transactions. The currency system has three components that work together:
+
+### type
+Defines which currency system the plugin will use:
+
+- `ITEM`: Uses physical Minecraft items as currency (default is Emerald)
+  - Players must have the specified item in their inventory to make purchases
+  - Shop owners receive the actual items when their shops make sales
+  - The currency item can be changed in-game using `/shop setcurrency` while holding the desired item
+  - Ideal for servers that want to create an item-based economy
+  - Can use any item, including custom/modded items with NBT data
+
+- `VAULT`: Integrates with your economy plugin through the Vault API
+  - Requires the Vault plugin and a compatible economy plugin (like Essentials, CMI, etc.)
+  - Uses virtual currency from your economy plugin
+  - Automatically withdraws/deposits from player balances
+  - Best for servers with an established economy plugin
+  - If Vault setup fails, the plugin will disable itself with an error message
+
+- `EXPERIENCE`: Uses player experience points as currency
+  - Players spend and earn actual XP when buying/selling
+  - For offline players, XP data is stored in files to ensure transactions still work
+  - Creates an interesting economy option without additional plugins
+  - Note: This uses total experience points, not just levels
+
+### name
+This is the display name for the currency that appears on signs and in messages:
+
+- For `ITEM`: Should describe the item (e.g., "Emerald(s)", "Diamond(s)")
+- For `VAULT`: Typically a currency symbol (e.g., "$", "€", "£")
+- For `EXPERIENCE`: Usually "Experience" or "XP"
+
+The name is purely cosmetic and doesn't affect functionality, but should match your currency type for clarity.
+
+### format
+Controls how prices are displayed on signs and in messages:
+
+- `[price] [name]`: Shows "5 Emerald(s)" or "5 Experience" (default format)
+- `[name][price]`: Shows "Emerald(s)5" or "$5" (better for currency symbols)
+- `[name] [price]`: Shows "Emerald(s) 5" or "$ 5" (with space)
+- `[price][name]`: Shows "5Emerald(s)" or "5$" (no space)
+
+For large numbers, the plugin can apply suffixes based on your `priceSuffixes` configuration (like 5k for 5,000).
+
+The currency system is integral to all shop transactions, determining how players interact with the economy of your server. Most servers will want to align this with their overall economy approach - either item-based (common for survival/RPG servers) or Vault-based (common for established economy servers).
+
+## allowPartialSales
+This allows shops to sell partial stacks for a calculated partial rate if the shop is low on stock, or if the player only has partial funds. By default only the defined amount/price is allowed for a transaction, to allow partial sales you must changes this to `true`
+```yaml
+allowPartialSales: false
+```
+
+This important setting determines how flexible shop transactions can be when a player doesn't have enough currency to buy a full stack, or when a shop doesn't have enough items to sell a full stack.
+
+When set to `true`:
+- Players can buy fewer items than the shop's full stack amount if they don't have enough currency
+- The price is automatically calculated based on the per-item rate (price ÷ amount)
+- Players can buy from shops that don't have enough items for a full transaction
+- Shop stock display is more accurate, showing "in stock" even if there's only partial inventory
+- The price calculation rounds in favor of the item seller (not the currency spender)
+- For sell shops with low stock: if a shop is selling 64 items for 16 emeralds but only has 32 items left, a player can buy those 32 items for 8 emeralds
+- For buy shops with low funds: if a shop buys 64 items for 16 emeralds but only has 8 emeralds left, a player can sell 32 items for those 8 emeralds
+
+When set to `false` (default):
+- Only full transactions at exact price and amount are allowed
+- Shops without enough stock for a complete transaction will show as "out of stock"
+- Players without enough currency for a complete purchase cannot buy anything
+- Shop owners without enough funds can't buy any items from players
+- This creates a more rigid economy where prices are fixed and non-negotiable
+
+The partial sales system is particularly useful for servers with item-based economies, where players might not always have exact amounts of currency. It also helps keep shops functional even when inventory is low.
+
+### Technical Details
+- For partial purchases, the price per item is calculated as: `originalPrice ÷ originalAmount`
+- For items selling below 1 currency unit each (like 64 items for 10 emeralds), the system calculates `itemsPerPrice = 1 ÷ pricePerItem`
+- The system always rounds in favor of the item seller, so they never lose value in partial transactions
+
+## checkItemDurability
+This will make it so shops will only complete transactions if the item durabilities are the same.
+```yaml
+checkItemDurability: true
+```
+
+This setting controls whether shops should take item durability (damage) into account when matching items for transactions. It's particularly important for tools, weapons, and armor that can be damaged through normal use.
+
+When set to `true` (default):
+- Shops will only accept items with the exact same durability as the sample item
+- Players cannot sell damaged items to shops that are buying undamaged items
+- Shops selling damaged items (like half-durability swords) will only sell at that specific durability
+- This prevents players from selling near-broken items to shops and buying pristine ones
+- The durability percentage is displayed in shop information and GUIs
+- Useful for servers that want to enforce quality control in the economy
+
+When set to `false`:
+- Shops will ignore durability differences when matching items
+- A player can sell a barely broken or nearly broken tool to a shop buying that tool type
+- A shop selling tools will accept tools of any durability when restocking
+- The plugin automatically handles durability metadata in the background to prevent NBT data issues
+- This makes trading more flexible but can potentially be exploited
+
+This setting mainly affects tools, weapons, and armor - items that have a durability bar. Regular items without durability (like blocks and most materials) are unaffected by this setting.
+
+For servers focused on fair trading, keeping this enabled prevents durability-based exploits. For more casual servers, disabling it can make shop usage more convenient.
+
+## ignoreItemRepairCost
+This setting determines whether shops will complete transactions if the item "repair cost" is different, like with enchanted books or armor. The "repair cost" defines how many times an item has been combined in an anvil.
+```yaml
+ignoreItemRepairCost: true
+```
+
+This setting controls whether shops should take into account an item's "repair cost" when matching items for transactions. The repair cost is a hidden value that increases each time an item is worked on in an anvil, affecting the XP cost for future anvil work.
+
+When set to `true` (default):
+- Shops will ignore differences in repair cost when comparing items
+- Players can sell items that have been previously repaired or combined in an anvil
+- This is more player-friendly as most players aren't aware of the repair cost mechanic
+- Particularly important for enchanted items, which often have repair costs from combining enchantments
+- Useful for armor and tool shops where repair history shouldn't affect trading
+
+When set to `false`:
+- Shops will require items to have the exact same repair cost to be considered a match
+- Players cannot sell items that have been worked on in an anvil if the shop is selling/buying "fresh" items
+- This creates a more strict economy where item history matters
+- Can prevent certain exploits but can be frustrating for players who don't understand why their items aren't accepted
+
+This setting works by modifying how items are compared during shop transactions. When enabled, the plugin temporarily sets the repair cost to zero on both items during comparison, effectively making them match regardless of actual repair history.
+
+Most servers should keep this enabled for a better player experience, as repair costs are usually not visibly apparent to players and can cause confusion when items don't seem to match for no obvious reason.
+
+## creationCost
+The amount of currency a player is charged to create a shop. By default there is no cost to create a shop, so if you would like to charge a fee, you can define it here.
+```yaml
+creationCost: 0
+```
+
+This setting allows server administrators to impose an economy-based restriction on shop creation by charging players a fee when they set up a shop. This can be useful for controlling shop proliferation and adding an economic cost to commerce on your server.
+
+When set to a value greater than `0`:
+- Players must pay the specified amount of currency when creating a shop
+- The fee is charged in whatever currency type you've configured (items, Vault money, or experience)
+- The payment is taken when the shop is initialized (when the item to be sold/bought is selected)
+- For barter shops, the fee is only charged once the second item is selected
+- If a player doesn't have enough funds, the shop creation process is canceled with an error message
+- Players with the `shop.operator` permission bypass this cost
+
+When set to `0` (default):
+- No cost is associated with shop creation
+- Any player with appropriate permissions can create shops without economic restriction
+
+This setting can be used in conjunction with `returnCreationCost` to create a refundable deposit system, where players get their creation fee back when they properly close their shop.
+
+Special considerations:
+- For Vault-based economies, the fee is withdrawn directly from the player's balance
+- For item-based economies, the required number of the currency item is removed from the player's inventory
+- For experience-based economies, the player's XP is reduced accordingly
+- The fee applies to each individual shop a player creates
+- Operators and players with the `shop.operator` permission are exempt from this fee
+
+For new servers, it's often best to start with a low value or zero to encourage economic activity, then adjust it upward if shop spam becomes an issue.
+
+## destructionCost
+The amount of currency a player is charged to destroy a shop.
+```yaml
+destructionCost: 0
+```
+
+This setting enables server administrators to impose a fee when players destroy their own shops. It works as a counterpart to the `creationCost` setting, creating economic controls around the entire shop lifecycle.
+
+When set to a value greater than `0`:
+- Players must pay the specified amount of currency to destroy a shop they own
+- The fee is charged in whatever currency type you've configured (items, Vault money, or experience)
+- If a player tries to destroy their shop without sufficient funds, the action is canceled with an error message
+- The transaction only applies when destroying your own shops, not when removing other players' shops (with permissions)
+- The cost is charged before the shop is actually destroyed
+
+When set to `0` (default):
+- No cost is associated with destroying shops
+- Players can freely remove their shops without economic penalty
+
+This setting can serve several purposes:
+- Discouraging players from creating temporary shops that they quickly remove
+- Encouraging more permanent shop placements and economic planning
+- Creating a more thoughtful economy where shop placement has lasting consequences
+- Generating a small "tax" that sinks currency out of the economy
+
+Special considerations:
+- Unlike the creation cost, there is no built-in way to return this cost to players
+- Server operators and players with `shop.operator` permission can still destroy shops without paying this fee
+- WorldGuard region owners can still destroy any shop in their region without cost
+- Players with the `shop.destroy.other` permission can remove others' shops without paying this fee
+
+Most servers will want to leave this at 0 unless you're specifically trying to discourage shop turnover.
+
+## teleportCost
+The amount of currency a player is charged to teleport to a shop (via the GUI)
+```yaml
+teleportCost: 0
+```
+
+This setting allows administrators to place an economic cost on the shop teleportation feature available through the GUI. By charging for teleportation, you can balance the convenience of instant shop access with economic gameplay.
+
+When set to a value greater than `0`:
+- Players must pay the specified amount each time they use the teleport feature in the GUI
+- The fee is charged in whatever currency type you've configured (items, Vault money, or experience)
+- If a player doesn't have enough funds, the teleport is canceled and an error message is displayed
+- The cost is checked and charged before the teleport occurs
+- The teleportation positions the player in front of the shop's sign, facing the shop
+- Only players with appropriate permissions (`shop.gui.teleport` or `shop.operator`) can teleport, even if they can pay
+
+When set to `0` (default):
+- No cost is associated with shop teleportation
+- Players with teleport permission can freely teleport to any shop through the GUI
+
+This setting is particularly useful for:
+- Balancing the convenience of teleportation against walking/traveling to shops
+- Encouraging players to establish central shopping districts
+- Preventing players from using shop teleports as free transportation across the map
+- Creating another currency sink for the server economy
+
+Special considerations:
+- The teleport feature requires the GUI to be enabled (`enableGUI: true`)
+- Players need the `shop.gui.teleport` permission to use this feature, regardless of cost
+- This setting works well in combination with `teleportCooldown` to further regulate teleportation
+- For item-based economies, players must have the currency items in their inventory
+
+Most servers use this as a "convenience fee" if enabled, with the value typically set to represent a moderate but not prohibitive cost in your economy.
+
+## teleportCooldown
+The amount of time (in seconds) a player must wait between shop teleports
+```yaml
+teleportCooldown: 0
+```
+
+This setting implements a cooling-off period between shop teleportations, limiting how frequently players can use the teleport feature in the GUI. It works together with the `teleportCost` setting to regulate the shop teleportation system.
+
+When set to a value greater than `0`:
+- After teleporting to a shop, players must wait the specified number of seconds before teleporting again
+- If a player attempts to teleport during the cooldown period, they'll receive a message showing how many seconds remain
+- The cooldown is tracked per player, so each player has their own independent cooldown timer
+- The teleport attempt is completely canceled if the player is still on cooldown
+- Cooldown timers persist until they expire or the server restarts
+
+When set to `0` (default):
+- No cooldown restrictions are applied to shop teleportation
+- Players with teleport permission can teleport to shops as frequently as they wish
+- Only the `teleportCost` setting (if enabled) would limit teleportation frequency
+
+This setting is useful for:
+- Preventing players from rapidly teleporting across the server using shops
+- Encouraging more deliberate and meaningful shop visits
+- Reducing potential strain on the server from frequent teleportations
+- Creating a more balanced teleportation system without making it prohibitively expensive
+
+Common values include:
+- `30` - A short cooldown that prevents rapid teleportation but doesn't significantly inconvenience players
+- `60` - A moderate cooldown that encourages players to spend some time at each shop
+- `300` (5 minutes) - A longer cooldown that makes teleportation a more significant decision
+- `0` - No cooldown, suitable for servers with a teleport cost or other teleportation plugins
+
+For the smoothest player experience, this setting should be balanced against your server's general philosophy on teleportation and travel. Lower values create convenience, while higher values promote more immersive gameplay.
+
+## returnCreationCost
+Should the player be refunded the creation cost when they destroy their own shop. By default players are not refunded their cost to create the shop. If you would like to refund players the creation cost, you can set this to true. This will either drop the item on the chest location if using `ITEM` currency, or deposit virtual funds if using `VAULT` currency.
+```yaml
+returnCreationCost: false
+```
+
+This setting determines whether players should receive a refund of their shop creation fee when they destroy their own shops. It creates a "deposit" system where the initial cost to establish a shop can be recovered when the player properly dismantles it.
+
+When set to `true`:
+- Players receive back the exact amount they paid as `creationCost` when they destroy their shop
+- For Vault-based currencies, the refund is directly added to the player's economy balance
+- For item-based currencies, the items are dropped at the shop's chest location
+- The refund only applies to regular player-owned shops, not admin shops
+- The refund is processed automatically during the shop destruction process
+- The refund only happens if the `creationCost` setting is greater than 0
+
+When set to `false` (default):
+- No refund is given when shops are destroyed
+- The creation fee is treated as a permanent economic cost
+- This creates a stronger "sink" for your server's economy
+
+This setting can serve several purposes:
+- Encouraging players to properly destroy their shops rather than abandoning them
+- Reducing the economic burden of shop relocation (destroy and rebuild elsewhere)
+- Creating a system where shop space is "rented" rather than permanently purchased
+- Allowing for more flexible economies where players frequently change shop types
+
+Special considerations:
+- This setting only has an effect if `creationCost` is set to a value greater than 0
+- The refund is only given when players destroy their own shops, not when operators or others destroy them
+- For item-based currencies, players should ensure they have inventory space or the items will drop on the ground
+- This feature is completely independent from the `destructionCost` setting
+
+Many servers find this useful to implement a "deposit" system where players get their initial investment back, making shop creation more of a temporary commitment of funds rather than a permanent expense.
+
+## priceSuffixes
+This setting controls how large numbers are formatted with suffixes on shop signs and in messages.
+```yaml
+priceSuffixes:
+   minimumValue: 10000
+   k:
+      enabled: true
+      value: 1000
+   M:
+      enabled: true
+      value: 1000000
+   B:
+      enabled: true
+      value: 1000000000
+   T:
+      enabled: true
+      value: 1000000000000
+   P:
+      enabled: true
+      value: 1000000000000000
+   E:
+      enabled: true
+      value: 1000000000000000000
+```
+
+The `priceSuffixes` configuration offers an elegant solution for displaying large prices in a more readable format. Instead of showing "1000000" on signs and in messages, the plugin can display "1M" for improved readability and space efficiency.
+
+### minimumValue
+- Defines the threshold at which the plugin starts applying suffixes
+- Prices below this value will be displayed normally (e.g., "9999")
+- Prices at or above this value will use the appropriate suffix (e.g., "10k")
+- Default is `10000`, meaning suffixes only apply to values of 10,000 or higher
+
+### Suffix Entries
+Each suffix entry (k, M, B, etc.) has two components:
+- `enabled`: When `true`, this suffix will be used; when `false`, the suffix is ignored
+- `value`: The numeric value this suffix represents (e.g., k = 1000, M = 1000000)
+
+The plugin automatically selects the most appropriate suffix based on the price magnitude:
+- A price of 15,000 would display as "15k"
+- A price of 2,500,000 would display as "2.5M"
+- A price of 3,250,000,000 would display as "3.25B"
+
+### Decimal Precision
+- For suffixed values, the plugin intelligently determines whether to show decimals
+- Values are truncated to two decimal places maximum
+- The plugin omits unnecessary decimal places (e.g., "5M" instead of "5.00M")
+- Small fractional values maintain precision (e.g., "1.25k" for 1,250)
+
+### Technical Details
+- The system uses a NavigableMap to efficiently find the appropriate suffix for each value
+- The formatting is applied consistently across all price displays including signs, GUI, and chat messages
+- Players can also use these suffixes when manually entering prices (e.g., typing "5k" for 5,000)
+- This feature works with all currency types (ITEM, VAULT, EXPERIENCE)
+
+### Custom Configuration
+Server owners can:
+- Add or remove suffixes by modifying this section
+- Change the value each suffix represents
+- Adjust the minimum value threshold to control when suffixes appear
+- Disable specific suffixes by setting `enabled: false`
+
+This feature significantly improves user experience by making large numbers more readable and shop signs more compact, especially important on servers with inflated economies or high-value items.
+
+# Shop Display
+
+## displayType
+The type of display that appears above shops.
+```yaml
+displayType: ITEM
+```
+
+This setting controls the default visual display that appears above shop containers (chests, barrels, etc.) to showcase the items being sold. The display helps players easily identify what items are being sold without needing to interact with the shop.
+
+Available display types:
+- `NONE`: No display is shown above the shop
+- `ITEM`: A small floating item appears above the shop (default)
+- `LARGE_ITEM`: A larger version of the item displayed via an armor stand
+- `GLASS_CASE`: Item shown inside a glass case
+- `ITEM_FRAME`: Item displayed in an item frame attached to the block above the shop
+
+This setting defines the initial display style for all newly created shops. Players with the `shop.setdisplay` permission can later cycle through different display types using the action defined in `actionMappings.cycleShopDisplay` (default: Shift+Right-click on the shop chest).
+
+For barter shops that exchange two different items, the display will show both items side by side.
+
+Technical notes:
+- Some display types require an empty block above the shop container
+- The `ITEM_FRAME` type is not available for barter shops
+- If a block above the shop is occupied, the plugin will either force the display to `NONE` (if `forceDisplayToNoneIfBlocked` is true) or prevent shop creation
+
+## displayNameTags
+This setting controls when floating text tags are shown above shops.
+```yaml
+displayNameTags: VIEW_SIGN
+```
+
+This setting determines how and when the shop's information hovers above the shop as floating text. These tags typically show details like item name, price, and stock status.
+
+Available options:
+- `NONE`: Never show floating text tags above shops
+- `RIGHT_CLICK_CHEST`: Display tags temporarily when a player right-clicks the shop container
+- `VIEW_SIGN`: Display tags temporarily when a player looks directly at the shop sign (default)
+
+The tag information comes from the `displayConfig.yml` file, which can be customized with various placeholders like `[item]`, `[price]`, `[stock]`, and more.
+
+The tags are shown only temporarily and will disappear after a short period or when the player looks away.
+
+## displayCycle
+This setting controls which display types are available when cycling through displays.
+```yaml
+displayCycle:
+   - NONE
+   - ITEM
+   - GLASS_CASE
+   - LARGE_ITEM
+   - ITEM_FRAME
+```
+
+This setting defines the sequence of display types that players can cycle through when using the display cycle action (by default: Shift+Right-click on the shop chest). You can remove options from this list to limit which display types are available to players.
+
+The order in the list determines the cycling sequence. For example, with the default configuration, if a shop currently has the `ITEM` display, cycling it would change to `GLASS_CASE`, then to `LARGE_ITEM`, and so on.
+
+Special considerations:
+- Players need the `shop.setdisplay` permission to cycle display types
+- Operators can cycle displays on any shop, regular players only on their own shops
+- The `ITEM_FRAME` type will be skipped for barter shops due to technical limitations
+- If a shop has a block above it that prevents certain display types, the plugin will intelligently skip to compatible options
+
+## forceDisplayToNoneIfBlocked
+This setting controls whether shops can be created if the display is blocked.
+```yaml
+forceDisplayToNoneIfBlocked: true
+```
+
+When enabled, this setting allows shop creation even when there's a block above the shop container that would normally prevent displays from appearing.
+
+When set to `true` (default):
+- Shops can be created even if the space above the container is obstructed
+- The display type is automatically set to `NONE` in these cases
+- The shop will function normally but won't have a visual item display
+- Players can still interact with the shop sign and container
+
+When set to `false`:
+- The plugin will prevent shop creation if the display would be blocked
+- Players will receive an error message indicating that the display is blocked
+- This enforces that all shops must have the ability to show a proper item display
+
+This setting is particularly useful for underground shops or shops in tight spaces where visual displays may not be possible or desired.
+
+## displayLightLevel
+This setting controls the light level emitted by shop displays.
+```yaml
+displayLightLevel: 0
+```
+
+This setting determines the amount of light (0-15) emitted by shop displays, allowing shops to illuminate their surroundings. This feature is only available in Minecraft 1.17 and later versions.
+
+- Range: 0-15 (0 = no light, 15 = maximum brightness like glowstone)
+- Default: 0 (no light emission)
+- Higher values make shops more visible in dark areas
+- Light emits from the display itself, not the shop container
+
+Setting this to values above 0 can be useful for underground shopping areas or night-time marketplaces, as it creates a visual highlight effect around shops.
+
+## setGlowingItemFrame
+This setting controls whether item frames used for shop displays are glowing.
+```yaml
+setGlowingItemFrame: false
+```
+
+When enabled, this setting applies a glowing effect to item frames used by the `ITEM_FRAME` display type, making them appear highlighted with an outline. This feature is only available in Minecraft 1.17 and later versions.
+
+When set to `true`:
+- Item frames used for shop displays will have a glowing outline effect
+- This helps shops stand out visually, especially in busy areas
+- The glow effect applies only to the frame, not the item inside
+
+When set to `false` (default):
+- Item frames appear normal without any special effects
+
+This setting has no effect if you don't use the `ITEM_FRAME` display type or if your server is running on a version prior to Minecraft 1.17.
+
+## setGlowingSignText
+This setting controls whether shop sign text glows.
+```yaml
+setGlowingSignText: false
+```
+
+When enabled, this setting makes the text on shop signs appear to glow, providing better visibility. This feature is only available in Minecraft 1.17 and later versions.
+
+When set to `true`:
+- Text on shop signs will have a luminescent quality
+- This improves readability in dark locations
+- The glow applies to all text on the sign
+
+When set to `false` (default):
+- Sign text appears with normal brightness
+
+Technical note: On Bedrock Edition clients, non-glowing sign text might appear dimmer rather than brighter due to rendering differences between Java and Bedrock editions.
+
+# Shop Interactions
+
+## actionMappings
+This setting allows you to customize how players interact with shops by mapping specific actions to different click patterns.
+```yaml
+actionMappings:
+  transactWithShop: 'RIGHT_CLICK_SIGN'
+  transactWithShopFullStack: 'SHIFT_RIGHT_CLICK_SIGN'
+  viewShopDetails: 'LEFT_CLICK_CHEST'
+  cycleShopDisplay: 'SHIFT_RIGHT_CLICK_CHEST'
+```
+
+This powerful configuration option gives you complete control over the player interactions with shops. You can customize how players buy, sell, view details, and change the display type of shops.
+
+The following actions can be mapped:
+- `transactWithShop`: The primary interaction for buying/selling a single transaction worth of items
+- `transactWithShopFullStack`: Buy/sell a full stack (64) of items at once for bulk transactions
+- `viewShopDetails`: View detailed information about the shop (owner, stock, price per item)
+- `cycleShopDisplay`: Change the visual display type that appears above the shop
+
+Each action can be assigned to any of these click types:
+```yaml
+# Sign interactions
+LEFT_CLICK_SIGN
+SHIFT_LEFT_CLICK_SIGN
+RIGHT_CLICK_SIGN
+SHIFT_RIGHT_CLICK_SIGN
+
+# Container interactions
+LEFT_CLICK_CHEST
+SHIFT_LEFT_CLICK_CHEST
+RIGHT_CLICK_CHEST
+SHIFT_RIGHT_CLICK_CHEST
+
+# Special
+NONE  # Disables the action completely
+```
+
+Setting any action to `NONE` will completely disable that functionality. For example, if you set `cycleShopDisplay: 'NONE'`, players and adminswon't be able to change shop displays at all, even with the correct permissions.
+
+Technical details:
+- For combo shops, the `transactWithShop` action works differently based on which side of the sign is clicked (buy or sell)
+- The "chest" click types work on any container type (barrels, shulker boxes, etc.), not just chests
+- Permissions still apply to restricted actions like `cycleShopDisplay` (requires `shop.setdisplay`)
+
+## creationMethod
+This setting determines the methods players can use to create shops.
+```yaml
+creationMethod:
+   placeSign: true
+   hitChest: true
+```
+
+Control how players can create shops with these two distinct creation methods:
+
+### placeSign
+When enabled (`true`), players can create shops by:
+1. Placing a sign directly on a container (chest, barrel, etc.)
+2. Writing `[Shop]` on the first line of the sign
+3. Specifying the amount of items on the second line
+4. Specifying the price on the third line
+5. Specifying the shop type on the fourth line (buy, sell, barter, combo)
+6. Punching the sign/container while holding the item they want to sell/buy
+
+This is the traditional method of shop creation and is intuitive for experienced Minecraft shop plugin users.
+
+### hitChest
+When enabled (`true`), players can create shops by:
+1. Shift+Left-clicking (punching) a container while holding an item
+2. Following a step-by-step chat process that prompts for:
+   - Shop type (buy, sell, barter, combo)
+   - Item amount
+   - Price
+3. The plugin automatically creates a sign on the container
+
+This guided approach is more beginner-friendly and ensures shops are created correctly.
+
+Most servers enable both methods to accommodate player preferences, but you can disable either method if you prefer a consistent shop creation experience.
+
+## displayFloatingCreateText
+This setting controls whether floating instructions appear during shop creation.
+```yaml
+displayFloatingCreateText: true
+```
+
+When enabled, this setting shows helpful floating text guides above containers during the shop creation process.
+
+When set to `true` (default):
+- Temporary hologram-style text appears above containers during shop creation
+- Step-by-step instructions guide players through the creation process
+- Text changes based on the current step (selecting shop type, setting price, etc.)
+- Instructions automatically disappear when the shop is created or the process is canceled
+
+When set to `false`:
+- No floating instructions appear during shop creation
+- Players must rely on chat messages only for guidance
+
+This feature is particularly useful for new players who are unfamiliar with the shop creation process. The floating text provides clear, contextual instructions exactly where they're needed.
+
+## allowCreativeSelection
+This setting allows players to select items from a creative-style menu when creating shops.
+```yaml
+allowCreativeSelection: true
+```
+
+This feature provides a creative inventory interface for selecting items when creating buy shops and combo shops, even in survival mode.
+
+When set to `true` (default):
+- Players can Shift+Left-click a container with an empty hand to access a creative inventory
+- They can select any item from the creative inventory to use in their shop
+- The selection only applies to the shop creation process and doesn't give actual creative mode
+- For buy shops and combo shops, this allows players to create shops for items they don't currently possess
+- Players' original inventory, gamemode, and location are restored after selection
+
+When set to `false`:
+- Players must physically possess the item they want to sell or buy
+- No creative interface is available for item selection
+
+This feature balances convenience with gameplay, making it easier to create buy shops without needing to obtain the item first. It's particularly useful for server admins setting up community shops.
+
+## destroyShopRequiresSneak
+This setting adds an extra safety measure when destroying shops.
+```yaml
+destroyShopRequiresSneak: false
+```
+
+This safety feature helps prevent accidental shop destruction by requiring players to sneak (hold the shift key) while breaking shop signs.
+
+When set to `true`:
+- Players must be sneaking (holding shift) to break a shop sign
+- If a player tries to break a shop sign without sneaking, the action is canceled
+- The sign remains intact, preventing accidental shop removal
+- Applies to both owner and admin shop removal (if they have permissions)
+
+When set to `false` (default):
+- Shop signs can be broken normally without sneaking
+- No additional protection against accidental shop destruction
+
+This setting is recommended for servers where shop spaces are valuable or where players have reported accidentally destroying their shops while trying to interact with them.
+
+## playSounds
+This setting controls whether shops play sound effects during interactions.
+```yaml
+playSounds: true
+```
+
+This setting enables auditory feedback for shop interactions, enhancing the shopping experience with appropriate sound effects.
+
+When set to `true` (default):
+- Different sounds play based on shop interactions:
+  - Creation: A positive "success" sound
+  - Destruction: A breaking sound
+  - Successful transaction: A cash register/exchange sound
+  - Failed transaction: A negative "error" sound
+- Sounds are only played to players involved in the interaction
+- Sound selection is thematically appropriate to the action
+
+When set to `false`:
+- No sounds are played during any shop interaction
+- Shop actions happen silently
+
+Sound effects provide important feedback to players about the success or failure of their shop interactions. For servers running Minecraft versions before 1.9, this setting should be set to `false` as the sound API changed significantly in that version.
+
+## playEffects
+This setting controls whether shops display particle effects during interactions.
+```yaml
+playEffects: true
+```
+
+This setting enables visual particle effects for shop interactions, providing clear visual feedback.
+
+When set to `true` (default):
+- Different particle effects display based on shop interactions:
+  - Creation: Positive green particles
+  - Destruction: Red "angry" particles
+  - Successful transaction: Green sparkles and smoke
+  - Failed transaction: Red/dark particles
+- Effects appear at the shop location
+
+When set to `false`:
+- No particle effects are shown during any shop interaction
+- Shop actions happen without visual feedback
+
+Visual effects help players quickly understand if their shop interaction was successful or not, especially in busy areas where chat messages might be missed. For servers running Minecraft versions before 1.9, this setting should be set to `false` as the particle API changed significantly in that version.
+
+## inverseComboShops
+This setting controls the layout of combo shop signs.
+```yaml
+inverseComboShops: false
+```
+
+Combo shops allow both buying and selling of the same item on a single sign, with different sides of the sign handling different transaction types. This setting determines which side of the sign corresponds to buy or sell functionality.
+
+When set to `true`:
+- The LEFT side of the sign is for BUYING items from players (shop buys)
+- The RIGHT side of the sign is for SELLING items to players (shop sells)
+
+When set to `false` (default):
+- The LEFT side of the sign is for SELLING items to players (shop sells)
+- The RIGHT side of the sign is for BUYING items from players (shop buys)
+
+This setting affects both the physical clicking areas on the sign and the arrangement of information displayed on the sign. Most servers keep this as `false` for consistency with traditional shop plugins, but some servers may prefer the inverted arrangement.
+
+## itemList
+This setting restricts which items can be sold in shops.
+```yaml
+itemList: NONE
+```
+
+This powerful control option lets you limit which items players can sell in their shops, with three distinct modes:
+
+Available options:
+- `NONE`: No restrictions - all items can be listed in shops (default)
+- `DENY_LIST`: All items except those specified in `itemList.yml` can be listed in shops
+- `ALLOW_LIST`: Only items specified in `itemList.yml` can be listed in shops
+
+Server owners can create and customize the `itemList.yml` file to define specific items that should be allowed or denied, depending on the selected mode.
+
+This feature is useful for:
+- Preventing economy exploits with certain items
+- Reserving special/rare items for other game mechanics
+- Creating a more balanced economy by restricting certain items
+- Preventing problematic items (like bedrock, command blocks) from being traded
+
+Note that operators and players with the `shop.operator` permission can bypass these restrictions and create shops with any item.
+
+## worldBlacklist
+This setting prevents shop creation in specified worlds.
+```yaml
+worldBlacklist:
+  - 'world_nether'
+  - 'world_the_end'
+```
+
+This setting allows you to completely disable shop creation in specific worlds. Players will not be able to create any type of shop in worlds listed here.
+
+When a world is added to this list:
+- Players cannot create shops in that world (sign placement will be canceled)
+- Existing shops may still function if they were created before the world was blacklisted
+- Players with the `shop.operator` permission can still create shops in blacklisted worlds
+
+Common uses include:
+- Preventing shops in PvP or survival challenge worlds
+- Restricting economic activity to designated shopping worlds
+- Keeping utility worlds (like resource worlds) free from permanent structures
+- Preventing shops in worlds that may be reset periodically
+
+Simply add the exact world name to the list to blacklist it. World names are case-sensitive and must match exactly.
+
+## enabledContainers
+This setting defines which block types can be used as shop containers.
+```yaml
+enabledContainers:
+   - BARREL
+   - CHEST
+   - ENDER_CHEST
+   - TRAPPED_CHEST
+   - SHULKER_BOX
+   - BLACK_SHULKER_BOX
+   - BLUE_SHULKER_BOX
+   - BROWN_SHULKER_BOX
+   - CYAN_SHULKER_BOX
+   - GRAY_SHULKER_BOX
+   - GREEN_SHULKER_BOX
+   - LIGHT_BLUE_SHULKER_BOX
+   - LIGHT_GRAY_SHULKER_BOX
+   - LIME_SHULKER_BOX
+   - MAGENTA_SHULKER_BOX
+   - ORANGE_SHULKER_BOX
+   - PINK_SHULKER_BOX
+   - PURPLE_SHULKER_BOX
+   - RED_SHULKER_BOX
+   - WHITE_SHULKER_BOX
+   - YELLOW_SHULKER_BOX
+```
+
+This setting gives you fine-grained control over which container blocks can be used to create shops. You can add or remove container types from this list to control exactly which blocks can hold shop inventories.
+
+By default, the following container types are enabled:
+- `CHEST`: Standard chest blocks
+- `TRAPPED_CHEST`: Trapped chests (generates redstone signal when opened)
+- `BARREL`: Barrel blocks (added in 1.14)
+- `ENDER_CHEST`: Ender chests for personal shops
+- All 16 colored `SHULKER_BOX` variants plus the standard `SHULKER_BOX`
+
+Key considerations for container types:
+- **Chests**: The most common choice, unlimited storage
+- **Trapped Chests**: Allow for redstone integration
+- **Barrels**: Don't require space above them to open
+- **Ender Chests**: Enable personal shop access from anywhere (inventory is tied to player)
+- **Shulker Boxes**: Can be placed in any orientation
+
+Changing this setting affects:
+- Which blocks players can create shops on
+- The plugin's internal container detection system
+- Shop-finding algorithms
+
+Removing a container type from this list will prevent new shops from being created on that block type, but existing shops may continue to function until they're broken.
+
+# Database Logging & Notifications
+
+## logging
+Database logging for player Shop Actions & Transactions. Required for Offline Purchase Notifications to be sent, enabled by default with FILE database. Also helpful if you want to keep an eye out for potential issues or monitor shop activity.
+```yaml
+logging:
+   type: "FILE"
+   serverName: "127.0.0.1"
+   databaseName: "shopdb"
+   port: 3306
+   user: "shop"
+   password: "mysecurepassword"
+   properties:
+      - "useSSL=false"
+```
+
+This powerful feature allows server administrators to track, monitor, and analyze all shop activities and transactions on the server. It serves multiple purposes, including enabling offline purchase notifications, providing data for player notifications, and offering insights into the server's economy.
+
+### type
+Defines which database system the plugin should use for logging shop activity:
+
+- `OFF`: Completely disables database logging and all features that depend on it, including offline purchase notifications
+- `FILE`: (Default) Uses a lightweight embedded H2 database stored as files within the plugin directory
+  - Requires no additional setup or external database
+  - Perfect for small to medium-sized servers
+  - Automatically manages data with minimal performance impact
+  - Files are stored in the `plugins/Shop/database/` directory
+
+- `MYSQL`: Uses a remote MySQL database for logging
+  - Requires an existing MySQL server and database
+  - Ideal for larger servers or server networks that want centralized logging
+  - Allows for external access to shop data through standard database tools
+  - Requires proper credentials and connection settings
+
+- `MARIADB`: Uses a remote MariaDB database (MySQL fork) for logging
+  - Functionally similar to MySQL but works with MariaDB servers
+  - Configuration is identical to MySQL option
+
+For servers using the default `FILE` option, no additional configuration is needed. The plugin will automatically create and manage the necessary database files.
+
+For servers using `MYSQL` or `MARIADB`, you'll need to configure the following additional settings:
+
+### serverName
+The hostname or IP address of your MySQL/MariaDB server. Default is `127.0.0.1` (localhost).
+
+### databaseName
+The name of the database to use for shop data. The database must exist before the plugin starts. Default is `shopdb`.
+
+### port
+The port number the database server is listening on. Default MySQL/MariaDB port is `3306`.
+
+### user
+The username for authenticating with the database server.
+
+### password
+The password for authenticating with the database server.
+
+### properties
+A list of additional JDBC connection properties for fine-tuning the database connection. The default `useSSL=false` is sufficient for most setups, but you can add additional properties as needed.
+
+### Data Collection
+When enabled, the logging system collects the following data:
+- Every shop action performed by players (timestamps, player info, action type)
+- All transaction details (items, amounts, prices, locations)
+- Shop creation, modification, and deletion events
+- Player interactions with shops
+
+This data is used to:
+- Power the offline purchase notification system
+- Track shop usage statistics
+- Provide detailed transaction history for troubleshooting
+- Enable server admins to monitor economic activity
+
+The database implementation automatically manages connection pools efficiently and has minimal performance impact, even on busy servers.
+
+## offlinePurchaseNotifications
+Controls whether players will receive notifications about purchases that happened while they were offline.
+```yaml
+offlinePurchaseNotifications:
+   enabled: true
+```
+
+This feature enhances the player experience by providing a detailed summary of all shop transactions that occurred while they were away from the server. When a player logs in, they'll receive an informative message showing profits, purchases, and shop status updates.
+
+When set to `true` (default):
+- Players receive a comprehensive notification upon login showing:
+  - Number of transactions that occurred during their absence
+  - Total profit earned from their shops
+  - Total amount spent at other shops
+  - Detailed breakdown of items sold and purchased (with quantities)
+  - Notifications about any shops that ran out of stock
+- The notification includes hover effects that show additional transaction details
+- All information is calculated asynchronously to prevent login delays
+
+When set to `false`:
+- No offline transaction notifications are shown
+- Players will need to check their shops manually to see if any transactions occurred
+
+### Requirements
+For offline purchase notifications to work:
+- Database logging must be enabled (`logging.type` must be `FILE`, `MYSQL`, or `MARIADB`)
+- If database logging is set to `OFF`, offline purchase notifications will be automatically disabled with a warning in the console
+
+### Technical Details
+The offline notification system:
+- Collects data from the database when a player logs in
+- Calculates totals and summaries asynchronously
+- Formats messages based on templates in `chatConfig.yml`
+- Uses hover-enabled text components for a rich user experience
+- Processes notifications in the background without affecting server performance
+
+This feature is particularly valuable for players who run shops on your server, as it gives them immediate feedback about their economic activity without requiring them to manually check each shop.
+
+# Integrations
+
+The Shop plugin offers several powerful integrations with popular Minecraft plugins to enhance functionality, improve protection, and provide visual representation of shops on map plugins.
+
+## hookWorldGuard
+Controls whether the Shop plugin integrates with WorldGuard for enhanced region-based shop protection.
+```yaml
+hookWorldGuard: false
+```
+
+This integration adds an extra layer of shop security by respecting WorldGuard regions and their protection flags:
+
+- When `false` (default): The Shop plugin will respect WorldGuard's basic region protection flags (`passthrough`, `build`, and `chest-access`) but won't use the custom `allow-shop` flag. This means players can create shops anywhere they have permission to build and access chests according to WorldGuard's standard protection system.
+
+- When `true`: In addition to respecting the basic protection flags, the plugin will also check for a custom WorldGuard flag called `allow-shop`. This gives server administrators more granular control over where shops can be created within protected regions.
+
+### Technical Details
+- When enabled, the plugin registers a custom WorldGuard flag called `allow-shop`
+- Shop creation is checked against multiple protection mechanisms:
+  - The player must have permission to build in the region
+  - The player must have chest access in the region
+  - The region must have the `allow-shop` flag set to allow (if set to `true`)
+- Operators and players with the `shop.operator` permission can bypass these restrictions
+
+This integration is particularly useful for servers with complex region management where you want to restrict commerce to specific areas
+
+### Requirements
+- WorldGuard plugin must be installed on your server
+- The setting has no effect if WorldGuard is not present
+
+## hookTowny
+Controls whether the Shop plugin integrates with Towny for town-based shop protection.
+```yaml
+hookTowny: false
+```
+
+This integration ensures that shops can only be created in appropriate locations within the Towny town system:
+
+- When `false` (default): No special Towny integration is enabled. Players can create shops according to standard permission systems and other enabled protections.
+
+- When `true`: The plugin enforces Towny's commercial plot system. Players can only create shops in:
+  - Plots where they have explicit building permissions
+  - Commercial plots within towns where they are residents
+  - Their own residential plots
+
+### Technical Details
+- Shop creation checks use the Towny API's `ShopPlotUtil.doesPlayerHaveAbilityToEditShopPlot()` method
+- This ensures compatibility with Towny's commercial plot system
+- Operators and players with the `shop.operator` permission can bypass these restrictions
+- Prevents players from creating shops in towns where they aren't residents
+
+### Requirements
+- Towny plugin must be installed on your server
+- The setting has no effect if Towny is not present
+
+## dynmap-marker
+Controls the integration with the Dynmap plugin to display shops as markers on your server's dynamic map.
+```yaml
+dynmap-marker:
+   enabled: false
+   name: Shop
+   preview: "[item](x[item amount]) - [shop type] - [price]"
+   description: "Item: [item](x[item amount])<br />Owner: [owner]<br />Type: [shop type]<br />Price: [price]<br />Stock: [stock]<br />---------------<br />[location]<br />"
+```
+
+This integration allows players to see all shops on your server's Dynmap, making it easier for them to find what they're looking for:
+
+- `enabled`: When set to `true`, shop markers will appear on your Dynmap
+- `name`: The label shown for the marker set in Dynmap's layer control (default: "Shop")
+- `preview`: The text shown when hovering over a shop marker on the map
+- `description`: The HTML-formatted text shown when clicking on a shop marker
+
+Both `preview` and `description` support the following placeholder variables:
+- `[item]` - The item being sold/bought
+- `[item amount]` - The quantity per transaction
+- `[owner]` - The shop owner's name
+- `[shop type]` - The shop type (BUY or SELL)
+- `[price]` - The price per transaction
+- `[stock]` - Current stock level
+- `[location]` - The shop's location (world, x, y, z)
+
+### Technical Details
+- The plugin automatically updates markers when shops are created or destroyed
+- Markers use the built-in "chest" icon from Dynmap
+- Markers are grouped in a dedicated layer that can be toggled on/off in the Dynmap interface
+- The integration has minimal performance impact as it updates markers asynchronously
+
+### Requirements
+- Dynmap plugin must be installed on your server
+- The setting has no effect if Dynmap is not present
+
+## bluemap-marker
+Controls the integration with the BlueMap plugin to display shops as markers on your server's 3D map.
+```yaml
+bluemap-marker:
+   enabled: false
+   icon: "https://i.imgur.com/oCI3XJC.png"
+   label: |
+      <div style='background: rgba(0,0,0,0.7); color: #fff; font-size: 16px; padding: 5px; width: 200px; height: 140px;'>
+        <div style='font-weight: bold; color: #fff; font-size: 20px;'>[item] x[item amount]</div>
+        <div style='mt:80px;'>Owner: [owner]</div>
+        <div style='mt:80px;'>Type: [shop type]</div>
+        <div style='mt:80px; color: #7fca8c;'>Price: [price]</div>
+        <div style='mt:80px;'>Stock: [stock]</div>
+        <div style='mt:80px; color: #aaa; font-size: 20px;'>[location]</div>
+      </div>
+   minDistance: 0
+   maxDistance: 500
+```
+
+This integration allows players to see all shops on your server's BlueMap, providing a beautiful 3D visualization:
+
+- `enabled`: When set to `true`, shop markers will appear on your BlueMap
+- `icon`: The URL to the icon image used for shop markers
+- `label`: HTML-formatted content displayed when clicking a shop marker
+- `minDistance`: Minimum distance (in blocks) at which markers become visible (0 = always visible)
+- `maxDistance`: Maximum distance (in blocks) at which markers are visible
+
+The `label` field supports the same placeholder variables as the dynmap integration:
+- `[item]` - The item being sold/bought
+- `[item amount]` - The quantity per transaction
+- `[owner]` - The shop owner's name
+- `[shop type]` - The shop type (BUY or SELL)
+- `[price]` - The price per transaction
+- `[stock]` - Current stock level
+- `[location]` - The shop's location (world, x, y, z)
+
+### Technical Details
+- The plugin automatically updates BlueMap markers when shops are created or destroyed
+- Markers are positioned precisely over the shop location
+- The default icon is a chest image, but you can customize it with any web-accessible image
+- Markers are organized in a dedicated layer per world called "Shops"
+- The HTML label can be fully customized with CSS styling for a unique look
+- The integration has minimal performance impact as it updates markers asynchronously
+
+### Requirements
+- BlueMap plugin must be installed on your server
+- The setting has no effect if BlueMap is not present
+
+## Automatic Integrations
+
+The following plugins are automatically integrated when detected (no configuration needed):
+
+- **LWC**: Protects shops from being broken into by non-owners & allows purchases to be made through protected chests
+- **BentoBox**: Handles shop deletion when islands are reset or deleted
+- **AdvancedRegionMarket (ARM)**: Handles shop deletion when regions are reset
+- **PlotSquared**: Handles shop deletion when plots are reset or deleted
+- **Vault**: Provides economy support for currency-based shops (required for VAULT currency type)
+
+These integrations ensure that the Shop plugin works seamlessly with other popular server plugins without requiring additional configuration.
+
+# Shop Performance Optimizations
+
+This section contains settings that can be adjusted to optimize the plugin's performance on your server. These settings primarily affect how shop displays are processed and how the plugin searches for shops in the world.
+
+## displayProcessInterval
+How often (in seconds) to check for shop displays that need to be shown to players. Lower values make shop displays appear faster. You can increase this if you are experiencing performance issues to reduce the number of checks.
+```yaml
+displayProcessInterval: 1
+```
+
+This setting controls the frequency (in seconds) at which the plugin checks for and processes shop displays that should be shown to players. It directly affects how responsive the shop display system is and its impact on server performance.
+
+When set to a lower value (like `1`, the default):
+- Shop displays appear more quickly when a player moves near a shop
+- More frequent checks are performed, which can be slightly more demanding on the server
+- Players experience minimal delay when viewing/interacting with shops
+- Optimal for most servers with a moderate number of shops
+
+When set to a higher value (like `2` or `3`):
+- Shop displays may take slightly longer to appear when players approach them
+- Fewer checks are performed, reducing the CPU load on the server
+- May reduce "micro-stutters" on servers with many shops
+- Better for larger servers with hundreds of active shops
+
+### Technical Details
+- The plugin uses a scheduled task that runs every `displayProcessInterval` seconds
+- During each run, it determines which shops should be visible to which players
+- This task runs asynchronously to minimize impact on the main server thread
+- The processing cost scales with the number of online players and active shops
+
+### Recommendations
+- For small servers (< 20 players, < 500 shops): `1` second is ideal
+- For medium servers (20-50 players, 500-2000 shops): `1-2` seconds works well
+- For large servers (50+ players, 2000+ shops): Consider `2-3` seconds
+- If you notice server TPS drops when many players are near shops, try increasing this value
+
+## displayMovementThreshold
+How far a player needs to move (in blocks) before shop display checks should be processed. This prevents unnecessary processing when players are standing still.
+```yaml
+displayMovementThreshold: 1.0
+```
+
+This setting defines how far (in blocks) a player must move before the plugin recalculates which shop displays they should see. This optimization prevents the plugin from constantly rechecking displays when players are relatively stationary.
+
+When set to a lower value (like `1.0`, the default):
+- Shop displays are updated more responsively as players move
+- More movement checks are performed, which can be slightly more CPU-intensive
+- Better for servers where shop discovery is important
+- Players see new shop displays after moving just a short distance
+
+When set to a higher value (like `2.0` or `3.0`):
+- Shop displays update less frequently as players move
+- Fewer movement checks reduce CPU usage
+- Better for servers with performance concerns
+- Players may need to move a bit further before seeing new shop displays
+
+### Technical Details
+- The plugin tracks each player's last position where displays were processed
+- When a player moves more than `displayMovementThreshold` blocks (in any direction) from that position, display calculations are triggered
+- The check efficiently uses 3D Euclidean distance (X, Y, and Z coordinates)
+- This works in conjunction with `displayProcessInterval` – movement is only checked at the interval frequency
+
+### Recommendations
+- For general gameplay: `1.0-2.0` blocks provides a good balance
+- For performance-sensitive servers: `2.0-4.0` blocks reduces processing overhead
+- For shop-focused servers (like markets/malls): Keep at `1.0` for responsive displays
+- If players report shops appearing/disappearing abruptly, lower this value
+- If your server experiences lag spikes when many players are moving around shops, increase this value
+
+## maxShopDisplayDistance
+Maximum distance (in blocks) at which shop displays will be shown to players. Mainly affects player performance, not server performance.
+```yaml
+maxShopDisplayDistance: 16.0
+```
+
+This setting controls the maximum distance at which a player can see shop displays (floating items, item frames, etc.). It primarily affects the client-side rendering load and visual experience rather than server performance.
+
+When set to a lower value (like `12.0` or `16.0`, the default):
+- Fewer shop displays are visible at once, reducing client-side rendering load
+- Better performance for players with lower-end computers
+- Shop displays "pop in" at closer distances
+- Reduces visual clutter in dense shop areas
+
+When set to a higher value (like `24.0` or `32.0`):
+- Shop displays are visible from further away, helping players locate shops
+- Players can see more shops at once, improving shop discovery
+- May reduce the "pop-in" effect as players move through the world
+- Can increase client-side rendering load in areas with many shops
+
+### Technical Details
+- This value is used to filter out shop displays that are too far away from a player
+- The distance calculation is performed on the server, so distant displays are never sent to clients
+- Entity culling is still applied by the client based on their render distance settings
+- The Minecraft client's default entity render distance is approximately 20 blocks
+- Setting values higher than the client's entity render distance will still "prepare" displays that come into range
+
+### Recommendations
+- For general gameplay: `16.0` blocks provides a good balance (default)
+- For performance-focused servers: `10.0-12.0` blocks improves client performance
+- For shopping district emphasis: `24.0-32.0` blocks improves shop visibility and discovery
+- Consider your server's shop density – higher values have more impact in densely packed shop areas
+- Note that custom resource packs or client mods might affect how this setting performs
+
+## shopSearchRadius
+Radius (in chunks) around a player to search for shops. Each increment searches exponentially more chunks (1=3x3 area, 2=5x5 area, etc).
+```yaml
+shopSearchRadius: 1
+```
+
+This setting determines how far (in chunks) the plugin searches for shops around a player. This is a critical performance setting that directly affects how many chunks are scanned when looking for nearby shops, with each increment significantly increasing the search area.
+
+When set to `1` (default):
+- Searches a 3×3 chunk area centered on the player (9 chunks total)
+- Very efficient, even on servers with many shops
+- Works well for most gameplay scenarios
+- Players need to be relatively close to shops to interact with them
+
+When set to `2`:
+- Searches a 5×5 chunk area centered on the player (25 chunks total)
+- Somewhat higher CPU usage, especially with many shops
+- Players can interact with shops from further away
+- Useful for larger shop buildings that might span multiple chunks
+
+When set to `3` or higher:
+- Searches a 7×7 chunk area or larger (49+ chunks total)
+- Moderately higher CPU usage
+- Generally not recommended unless absolutely necessary
+- May be useful in very specific server configurations (i.e. YouTube/Streamer servers)
+
+### Technical Details
+- Search area grows as (2×radius+1)² in chunks
+- The search is performed very efficiently using spatial hash maps
+- Chunk radius calculation starts from the chunk the player is currently in
+- Search is performed when players move, every `displayProcessInterval` seconds
+- This setting does not affect display visibility, only shop interaction distance
+
+### Search Area by Radius Value
+| Radius | Chunk Area | Approx. Block Area |
+|--------|------------|-------------------|
+| 1      | 3×3 (9)    | 48×48 blocks      |
+| 2      | 5×5 (25)   | 80×80 blocks      |
+| 3      | 7×7 (49)   | 112×112 blocks    |
+| 4      | 9×9 (81)   | 144×144 blocks    |
+
+### Recommendations
+- For most servers: Keep at the default value of `1`
+- For servers with very large shop structures: Consider `2`
+- Never set higher than `3` without careful testing
+- If players report inability to interact with distant parts of their shop, increase to `2`
+- If you experience server lag when players use shop commands or interact with shops, decrease to `1`
+
+### Performance Impact
+The shop search process is one of the most resource-intensive operations in the plugin, particularly on servers with thousands of shops. Each increment in radius exponentially increases the number of chunks that must be searched, which can significantly impact performance during shop interactions.
+
+The plugin uses highly optimized data structures to minimize this impact, but setting an appropriate `shopSearchRadius` is still crucial for maintaining server performance.
+
+# Debug Tools
+
+This section contains settings that help server administrators troubleshoot issues, optimize performance, and enable special functionality for testing or specific use cases. Most servers should keep these settings at their default values unless actively diagnosing problems.
+
+## logLevel
+Controls the amount of information logged by the plugin. Useful for troubleshooting.
+```yaml
+logLevel: HELPFUL
+```
+
+This setting determines how verbose the plugin's logging will be in the server console and log files. Higher log levels provide more detailed information but can generate significantly larger log files and potentially impact performance when set to the highest levels.
+
+The available log levels, from least to most verbose:
+
+- `INFO`: Basic logging that only shows critical information
+  - Plugin startup and shutdown messages
+  - Error messages and warnings
+  - Configuration problems
+  - Essential server notifications
+  - Best for normal operation on production servers
+
+- `NOTICE`: Adds logging for significant system events
+  - Shop creation and deletion events
+  - Player-triggered admin actions
+  - Database connections and disconnections
+  - Useful for monitoring general plugin activity
+
+- `HELPFUL` (Default): Adds logging for important player interactions
+  - Shop transactions (purchases and sales)
+  - Helpful information about settings
+
+- `DEBUG`: Adds detailed troubleshooting information
+  - Logs messages sent/displayed to players (in color!)
+  - Shop processing logic
+  - Display handling
+  - Performance metrics
+  - Useful when diagnosing specific issues
+
+- `TRACE`: Adds step-by-step operation logging
+  - Method entry and exit points
+  - Variable state changes
+  - Detailed execution flow
+  - For advanced debugging only
+  - Can significantly increase log size
+
+- `SPAM`: Extremely verbose diagnostics
+  - Internal calculations
+  - Every player movement check
+  - All shop processing events
+  - Will rapidly generate lots of log files
+
+- `HYPER`: Maximum possible logging detail
+  - Lots of logs for some function calls related to the plugin
+  - Raw data processing
+  - For developer use only
+  - Only use briefly when requested by support
+
+### Recommendations
+- For normal server operation: Use `HELPFUL`
+- When troubleshooting specific issues: Use `DEBUG`
+- When working with plugin developers on a bug: Use `TRACE` or higher as directed
+- After resolving issues: Return to `HELPFUL` to avoid performance impacts and large log files
+
+## enableLogColor
+Enables or disables colored output in the console log. Cuz it looks cool.
+```yaml
+enableLogColor: false
+```
+
+This setting controls whether the plugin uses ANSI color codes to highlight different types of log messages in the server console. When enabled, log messages will be color-coded based on their severity and type, making it easier to identify warnings, errors, and important information at a glance.
+
+When set to `true`:
+- Log messages are color-coded in the console
+- Errors appear in red
+- Warnings appear in yellow
+- Information messages appear in different shades of white/gray
+- Debug messages and lower appear in shades of grey
+- Makes it easier to visually scan logs for issues
+
+When set to `false` (default):
+- All log messages appear in the console's default text color
+- No special formatting is applied
+- Better compatibility with console environments that don't support ANSI color codes
+- Prevents potential display issues in some server management panels
+
+### Technical Details
+- Color codes are implemented using standard ANSI escape sequences
+- Some server hosting panels may not properly display colored logs
+- Console colors have no effect on log files, only the live console display
+- No performance impact either way
+
+### Recommendations
+- If you're running the server directly in a terminal: Enable this for better readability
+- If you're using a hosting panel: Test to see if colors display correctly
+- If you're experiencing odd characters in your console: Disable this feature
+
+## debug
+Advanced debug settings for troubleshooting or special use cases.
+```yaml
+debug:
+   allowUseOwnShop: false
+   transactionDebugLogs: false
+   shopCreateCooldown: 5000
+   forceResaveAll: false
+```
+
+This section contains specialized settings used for testing, debugging, and special situations. Most of these settings should remain at their defaults unless you have a specific reason to change them.
+
+### allowUseOwnShop
+Controls whether players can use their own shops.
+
+When set to `true`:
+- Shop owners can buy from their own sell shops and sell to their own buy shops
+- This bypasses the normal restriction preventing self-transactions
+- Useful for testing shop functionality without requiring a second player
+- Can potentially be used to exploit certain game mechanics (e.g., quick item transfers)
+- May enable inventory manipulation that circumvents normal gameplay limitations
+
+When set to `false` (default):
+- Players cannot buy from or sell to their own shops
+- Enforces proper shop usage through legitimate player-to-player trading
+- Prevents potential economy exploits
+- Ensures shops function as intended for commerce between different players
+
+This setting is primarily designed for testing and development environments. On production servers, enabling this setting could potentially lead to weird things.
+
+### transactionDebugLogs
+Controls whether detailed transaction information is logged during shop transactions.
+
+When set to `true`:
+- Detailed price calculation information is logged for every shop transaction
+- Shows exactly how prices are calculated for partial transactions
+- Displays item matching data and durability checks
+- Useful for troubleshooting issues with specific items or shops
+- Can generate a large volume of logs if many transactions occur
+
+When set to `false` (default):
+- Only standard transaction information is logged (based on the `logLevel` setting)
+- Price calculation details are omitted
+- Reduces log verbosity for normal operation
+
+This setting is particularly useful when:
+- Troubleshooting issues with specific transaction types
+- Verifying price calculations for partial sales
+- Diagnosing problems with custom items or NBT data
+- Investigating player reports about incorrect pricing
+
+The logs produced when this option is enabled are highly technical and intended for administrators who need to diagnose specific transaction problems.
+
+### shopCreateCooldown
+Controls the minimum time (in milliseconds) between shop creation attempts by a player.
+
+```yaml
+shopCreateCooldown: 5000
+```
+
+This setting prevents players from spamming shop creation commands or accidentally triggering multiple shop creation processes simultaneously. It defines how many milliseconds must pass before a player can initiate another shop creation process.
+
+- Default value: `5000` (5 seconds)
+- Lower values allow more rapid shop creation
+- Higher values enforce a longer waiting period between shop creations
+- Doesn't affect shop interactions, only the initiation of new shop creation
+
+This setting helps prevent:
+- Accidental double shop creation
+- Server load from rapid creation attempts
+- Potential shop placement exploits
+- Chat spam from shop creation messages
+
+For most servers, the default value provides a good balance between preventing spam and allowing convenient shop setup. If players report issues with shop creation being unresponsive, ensure this value isn't set too high. Only lowered mainly in our testing scripts.
+
+### forceResaveAll
+Controls whether all shops should be forcibly resaved during server startup.
+
+When set to `true`:
+- Every shop is loaded and immediately resaved when the server starts
+- Forces the conversion of old item formats to the current format
+- Can fix shops with corrupted or outdated NBT data
+- Updates item storage format for compatibility with newer Minecraft versions
+- May significantly increase server startup time on servers with many shops
+
+When set to `false` (default):
+- Shops are loaded normally during server startup
+- No forced resaving occurs
+- Server startup proceeds at normal speed
+
+**⚠️ IMPORTANT: ALWAYS CREATE A FULL BACKUP BEFORE ENABLING THIS OPTION**
+
+This setting should only be enabled when:
+- Updating from a very old version of the plugin
+- After a major Minecraft version update that changed item formats
+- When instructed by plugin support staff
+- If you're experiencing widespread issues with shop items not displaying correctly
+
+After enabling this option and restarting once, you should immediately set it back to `false` to prevent unnecessary processing on subsequent restarts.
+
+### Technical Details
+The force resave process:
+- Loads every shop from storage
+- Re-serializes all items with current NBT formats
+- Updates any legacy item data structures
+- Overwrites existing shop files with newly formatted versions
+- Logs each conversion for verification
+
+This is a powerful maintenance tool that should be used with caution, as it makes permanent changes to your shop data files. In rare cases, if the conversion process encounters severely corrupted data, it might result in item data loss.

--- a/wiki/config.md
+++ b/wiki/config.md
@@ -1122,6 +1122,47 @@ This integration is particularly useful for servers with complex region manageme
 - WorldGuard plugin must be installed on your server
 - The setting has no effect if WorldGuard is not present
 
+### Example WorldGuard Commands
+
+Here are practical examples of WorldGuard commands for configuring regions with different shop permissions:
+
+```bash
+# Create a default region (by default, has no passthrough permission)
+# (Shop creation will be denied)
+/rg define default_region
+
+# Create a region with passthrough permission
+# (Shop creation will be allowed if using default `hookWorldGuard: false`)
+/rg define region_with_passthrough
+/rg flag region_with_passthrough passthrough allow
+
+# Create a region with both build and chest access
+# (Shop creation will be allowed if using default `hookWorldGuard: false`)
+/rg define region_with_build_and_chest_access
+/rg flag region_with_build_and_chest_access build allow
+/rg flag region_with_build_and_chest_access chest-access allow
+
+# Create a region with the custom allow-shop flag
+# (Shop creation will be allowed if `hookWorldGuard: true` is configured)
+/rg define my_shop_region
+/rg flag my_shop_region build allow
+/rg flag my_shop_region chest-access allow
+/rg flag my_shop_region allow-shop allow
+
+# Create a region with chest access but no build access
+# (Shop creation will be denied always - both permissions are required)
+/rg define region_with_chest_access
+/rg flag region_with_chest_access build deny
+/rg flag region_with_chest_access chest-access allow
+
+# Create a region with build access but no chest access
+# (Shop creation will be denied always - both permissions are required)
+/rg define region_with_build_access
+/rg flag region_with_build_access build allow
+/rg flag region_with_build_access chest-access deny
+
+```
+
 ## hookTowny
 Controls whether the Shop plugin integrates with Towny for town-based shop protection.
 ```yaml

--- a/wiki/config.md
+++ b/wiki/config.md
@@ -7,6 +7,7 @@
     * [deletePlayerShopsAfterXHoursOffline](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#deletePlayerShopsAfterXHoursOffline)
 * **Currency and Economy**
     * [currency](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#currency)
+    * [allowFractionalCurrency](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#allowFractionalCurrency)
     * [allowPartialSales](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#allowPartialSales)
     * [checkItemDurability](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#checkItemDurability)
     * [ignoreItemRepairCost](https://github.com/snowgears/shopbugs/wiki/Configuration-(config.yml)#ignoreItemRepairCost)
@@ -229,6 +230,35 @@ Controls how prices are displayed on signs and in messages:
 For large numbers, the plugin can apply suffixes based on your `priceSuffixes` configuration (like 5k for 5,000).
 
 The currency system is integral to all shop transactions, determining how players interact with the economy of your server. Most servers will want to align this with their overall economy approach - either item-based (common for survival/RPG servers) or Vault-based (common for established economy servers).
+
+## allowFractionalCurrency
+This setting determines whether your currency supports fractional (decimal) units instead of only whole numbers.
+```yaml
+allowFractionalCurrency: false
+```
+
+This setting controls whether shops can process transactions with fractional (decimal) currency values, enabling more precise pricing and partial purchases.
+
+When set to `true`:
+- Currency values can use decimals (down to 0.01 precision)
+- Shop prices can be set with cent-level precision (e.g., 1.50, 0.75, 3.99)
+- Players can make partial purchases even when they have less than a full unit of currency
+- Perfect for servers using Vault economy plugins that support fractional currency
+- Prices are automatically rounded to the nearest cent (0.01) for display and calculations
+- Allows for more nuanced economy with fine-grained price differentiation
+- **Note: This feature requires Vault and an economy plugin that supports decimal currencies!**
+
+When set to `false` (default):
+- Currency values are always whole numbers (integers only)
+- All prices are rounded HALF_UP to the nearest whole number (preference to seller)
+- Partial purchases requiring fractional currency are rejected
+- Compatible with item-based economies where splitting items isn't possible
+- Simplifies the economy by enforcing whole-number transactions
+- Better for traditional Minecraft servers using physical items as currency
+
+This setting is particularly important for servers using Vault with economy plugins that support decimal currency (like EssentialsX Economy, CMI, etc.). It enables more realistic pricing models similar to real-world economies.
+
+For most servers using Vault economies, enabling this option provides a better player experience with more flexible purchasing options.
 
 ## allowPartialSales
 This allows shops to sell partial stacks for a calculated partial rate if the shop is low on stock, or if the player only has partial funds. By default only the defined amount/price is allowed for a transaction, to allow partial sales you must changes this to `true`

--- a/wiki/home.md
+++ b/wiki/home.md
@@ -1,0 +1,89 @@
+![520ef725efdc8caad836d0370a17d58ce8ee99b2](https://github.com/user-attachments/assets/075aaff3-2328-4672-89af-32bc86ec3fcd)
+
+<p align="center">Allows players to quickly create shops to buy, sell, barter, or gamble items seamlessly!</p>
+
+<p align="center">By focusing on ease of use, players of any skill level can create in-game shops in a way that feels like a native feature.</p>
+
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://github.com/user-attachments/assets/1fe15aee-b29f-47ef-b13d-79e493aef08c" alt="Buy Shop" width="400"/>
+      <br>Buy Shop
+    </td>
+    <td align="center">
+      <img src="https://github.com/user-attachments/assets/ef525ef0-5452-43dd-93f9-2ee2368127d8" alt="Sell Shop" width="400"/>
+      <br>Sell Shop
+    </td>
+    <td align="center">
+      <img src="https://github.com/user-attachments/assets/dfa4cad8-1da7-4523-9912-77650efc3b8e" alt="Combo Shop" width="400"/>
+      <br>Combo Shop
+    </td>
+    <td align="center">
+      <img src="https://github.com/user-attachments/assets/8617a81c-2902-4417-aeac-ad69024c755d" alt="Barter Shop" width="400"/>
+      <br>Barter Shop
+    </td>
+  </tr>
+</table>
+
+<div align="center">
+  <img src="https://github.com/user-attachments/assets/4a949cd7-e63f-4c4a-bb5c-b85c8e3f6551" alt="Gamble Shop" width="50%"/>
+  <br/>Gamble/Random Item Shops!
+  <br/>
+</div>
+
+## Features
+Change * currency to a custom item, virtual currency (Vault), or experience points seamlessly.
+* [Create shops in multiple ways. Either fill out a sign or hit a chest with an item and fill out info in chat (both configurable)](https://github.com/snowgears/shopbugs/wiki/Creating-Shops)
+* Fully customizable.
+* No commands required.
+* No permissions required. (But are supported)
+* Easily handles items with custom display names, descriptions, and enchantments. (and custom player heads)
+* All shop displays use client side packets so there is no lag on the server or chances of duping the items
+* Full logging support for MySQL and MariaDB
+* Create admin shops that don't need to be stocked
+* All sign text is translatable and customizable. (along with text colors)
+* All chat messages are translatable and customizable. (along with text colors)
+* Control what types of shops individual players are able to create and use.
+* Control the amount of shops individual players are able to create and use
+* Blacklist certain worlds from having shops created in them.
+* Ability to set an optional price players must pay to create and/or destroy shops
+* Integrates with WorldGuard, Towny, AdvancedRegionMarket, and more!
+* Integrates with DynMap to [show shops on the map](https://proxy.spigotmc.org/03ee898c967e8983196a73b85a3a267226dc3e04?url=https%3A%2F%2Fi.imgur.com%2FbkzTlOz.png)
+* Integrates with BlueMap to [show shops on the map](https://user-images.githubusercontent.com/4141199/194400062-2dbdbad4-a2c5-4097-b1fd-9ab0b3d1a801.png)
+* Works with chests, barrels, shulker boxes, even ender chests!
+* Plug and Play.
+
+## Display Types
+<table>
+  <tr>
+    <td align="center">
+      <img src="https://github.com/user-attachments/assets/3095bd19-cfd1-47f8-8e5c-36be324c1a28" alt="Item Display" width="400"/>
+      <br>Item Display
+    </td>
+    <td align="center">
+      <img src="https://github.com/user-attachments/assets/c6bec141-efb4-4550-b7b3-6f93ec170290" alt="Glass Case Display" width="400"/>
+      <br>Glass Case Display
+    </td>
+    <td align="center">
+      <img src="https://github.com/user-attachments/assets/1af00832-3128-44c1-8e7c-f01d44a23f47" alt="Large Item Display" width="400"/>
+      <br>Large Item Display
+    </td>
+    <td align="center">
+      <img src="https://github.com/user-attachments/assets/58c3d422-75ba-4c52-b4c3-edcb74f8285f" alt="Item Frame Display" width="400"/>
+      <br>Item Frame Display
+    </td>
+    <td align="center">
+      <img src="https://github.com/user-attachments/assets/a4a7ca82-ce55-4dce-83b5-7dcce401b329" alt="No Display" width="400"/>
+      <br>No Display
+    </td>
+  </tr>
+</table>
+
+
+
+
+
+
+
+## How it works
+

--- a/wiki/languageConfigs.md
+++ b/wiki/languageConfigs.md
@@ -1,0 +1,131 @@
+# Language Configuration Files
+
+The Shop plugin features a customizable text system that allows server administrators to modify messages, sign formats, and display elements. This enables localization to different languages and custom styling to match server themes.
+
+## Overview
+
+The plugin uses three main configuration files:
+
+1. **chatConfig.yml** - Chat messages sent to players
+2. **signConfig.yml** - Text displayed on shop signs
+3. **displayConfig.yml** - Floating text tags above shops
+
+## Color Codes and Formatting
+
+All configuration files support both legacy color codes (using &) and hex color codes:
+
+### Legacy Color Codes
+Common codes: `&a` (green), `&b` (aqua), `&c` (red), `&e` (yellow), `&f` (white)  
+Formatting: `&l` (bold), `&o` (italic), `&n` (underline), `&m` (strikethrough)
+
+### Hex Color Codes
+Format: `#RRGGBB` (e.g., `#FF00FF` for pink)
+
+### Combining Formatting
+You can combine codes: `&l&c` creates bold red text.
+
+### Formatting Persistence and Reset
+Minecraft's formatting codes persist until explicitly reset. When you apply a formatting code like `&l` (bold), all text that follows will remain bold until you use the reset code `&r`.
+
+```yaml
+# Without reset - all text is bold and red
+message: '&l&cThis entire message stays bold and red'
+
+# With reset - formatting stops after reset code
+message: '&l&cThis part is bold and red.&r This part is normal.'
+```
+
+Always use `&r` when you want to return to normal text after applying formatting codes.
+
+## Placeholder System
+
+Placeholders dynamically insert content into messages. They're surrounded by square brackets like `[item]` or `[price]`.
+
+### How Placeholders Work
+When displayed, placeholders are replaced with real-time data from shops, transactions, or players. For example, `[price]` will show the actual price of an item.
+
+### Common Placeholders
+
+- **Item-related**: `[item]`, `[item amount]`, `[item type]`, `[item enchants]`
+- **Price-related**: `[price]`, `[price per item]`
+- **Player-related**: `[user]`, `[owner]`
+- **Shop-related**: `[stock]`, `[shop type]`, `[location]`
+
+For barter shops: `[barter item]`, `[barter item amount]`
+
+## Message Organization
+
+Messages follow a structured pattern to make finding and customizing them easier:
+
+- **Transaction messages**: `{shopType}_{recipient}` (e.g., `SELL_user`)
+- **Error messages**: `{shopType}_{errorType}` (e.g., `SELL_shopNoStock`)
+
+Many placeholders create interactive features automatically:
+- `[location]` - Clickable coordinates
+- `[item]` - Includes hover text with details
+- `[offline transactions]` - Hoverable transaction details
+
+## Configuration Files
+
+### chatConfig.yml
+
+Controls chat messages for transactions, errors, and shop interactions.
+
+**Key Sections:**
+- `transaction:` - Success messages
+- `transaction_issue:` - Error messages
+- `interaction:` - Shop creation/management messages
+- `description:` - Shop information panels
+- `OFFLINE_TRANSACTIONS_NOTIFICATION:` - Summary of offline activity
+
+### signConfig.yml
+
+Controls shop sign text and formats.
+
+**Key Sections:**
+- `sign_creation:` - Keywords for creating shops
+- `sign_text:` - Text layout with variations for shop types and display options
+- Special settings: `zeroPrice` ("FREE"), `adminStock` ("unlimited")
+
+### displayConfig.yml
+
+Controls floating text tags above shops.
+
+**Key Sections:**
+- `display_tag_text:` - Text displayed by shop type
+- Special positioning: `[lshift]` and `[rshift]` for side-by-side formatting
+
+## Customization Tips
+
+### Translating to Other Languages
+1. Translate text outside placeholder brackets
+2. Keep placeholders intact with original names
+3. Test thoroughly after changes
+
+### Style Consistency
+- Use the same color scheme across files
+- Keep sign text concise due to space limitations
+
+## Advanced Tips
+
+- **Unicode Symbols**: Use symbols like ✦, ❖, or • for visual distinction
+- **Multi-column Layouts**: Use shift markers for complex displays
+- **Multi-line Messages**: Use the `|-` syntax in YAML for cleaner formatting
+
+## Implementation Guide
+
+### Performance Considerations
+- Complex messages with many placeholders may increase processing time
+- Dense shop areas benefit from shorter display texts
+- Excessive formatting affects client-side performance
+
+### Applying Changes
+1. Save the file
+2. Restart your server (safest) or run `/shop reload` 
+3. Test your changes
+
+### Troubleshooting
+- Check YAML syntax (indentation matters)
+- Verify placeholders are intact with correct names
+- Ensure color codes are properly formatted
+- Confirm you've properly reloaded after changes

--- a/wiki/permissions.md
+++ b/wiki/permissions.md
@@ -1,0 +1,68 @@
+To enable permission usage you must set `usePermissions` to `true` inside `config.yml`!
+
+If you have permissions enabled, then by default players have NO permissions, and permissions are only granted to OP's.
+
+**Available Permissions**
+``` yaml
+permissions:
+    shop.use:
+        description: Allows player to use all shops.
+        default: op
+    shop.use.sell:
+        description: Allows player to use selling shops.
+        default: op
+    shop.use.buy:
+        description: Allows player to use buying shops.
+        default: op
+    shop.use.barter:
+        description: Allows player to use barter shops.
+        default: op
+    shop.use.combo:
+        description: Allows player to use combo buy/sell shops.
+        default: op
+    shop.use.gamble:
+        description: Allows player to use gambling shops.
+        default: op
+
+    shop.create:
+        description: Allows player to create all shops.
+        default: op
+    shop.create.sell:
+        description: Allows player to create selling shops.
+        default: op
+    shop.create.buy:
+        description: Allows player to create buying shops.
+        default: op
+    shop.create.barter:
+        description: Allows player to create barter shops.
+        default: op
+    shop.create.combo:
+        description: Allows player to create combo shops that both buy and sell.
+        default: op
+    shop.create.gamble:
+        description: Allows player to create admin gamble shops. Only give this permission to Operators!
+        default: op
+
+    shop.destroy:
+        description: Allows player to destroy their own shops.
+        default: op
+    shop.destroy.other:
+        description: Allows player to destroy other player's shops.
+        default: op
+
+    shop.buildlimit.#:
+         description: Restricts the number of shops a player can create. For example shop.buildlimit.10 would limit players to creating 10 shops maximum.
+         default: op
+
+    shop.setdisplay:
+         description: Allows player to set the display type on their shop (allows shop display cycling, see actionMappings in config.yml).
+         default: op
+
+    shop.gui.teleport:
+         description: Allows player to use teleport to shops by using the gui.
+         default: op
+
+    shop.operator:
+        description: Allows access to operator actions like setting currency, setting the gamble item, reloading configs, creating gamble/admin shops, etc.
+        default: op
+```

--- a/wiki/player-instructions.md
+++ b/wiki/player-instructions.md
@@ -1,0 +1,77 @@
+There are multiple ways you can create a shop! You can alter configuration to disable creation modes if desired.
+
+1. Shift+Punch a chest with your desired item in hand
+2. Shift+Punch with an empty hand, select item from creative menu
+3. Place a sign on a chest with your shop details, punch chest with desired item
+
+# Simple Create
+## Create using item
+
+1. Shift+Punch a chest with the item you want to buy/sell in your hand
+2. Enter the Shop type you are creating into chat and send it
+3. Enter the amount of the item you want to buy/sell
+4. Enter the price you want to buy/sell the item for
+
+**`config.yml` Defaults:**
+
+```yaml
+creationMethod:
+  hitChest: true # Allow shops to be created by punching the chest
+```
+
+## Create using Creative Selection
+
+1. Shift+Punch a chest with an empty hand
+2. Select the item you want to buy/sell from the creative menu and drop it outside the creative window
+3. Enter the Shop type you are creating into chat and send it
+4. Enter the amount of the item you want to buy/sell
+5. Enter the price you want to buy/sell the item for
+
+**`config.yml` Defaults:**
+
+```yaml
+creationMethod:
+  hitChest: true # Allow shops to be created by punching the chest
+
+allowCreativeSelection: true # This will allow players to use the limited creative selection tool to choose shop items
+```
+
+# Sign Create
+## Create using a Sign & Item in hand
+
+1. Place a sign onto the chest/in front of it and enter the following details
+```
+[Shop]
+amount of item
+price of item
+buy/sell/barter
+```
+2. Punch the shop with the item you want to buy/sell
+
+**`config.yml` Defaults:**
+
+```yaml
+creationMethod:
+  placeSign: true # Allow shops to be created by placing a sign down
+```
+
+## Create using a Sign & Creative Selection
+
+1. Place a sign onto the chest/in front of it and enter the following details
+```
+[Shop]
+amount of item
+price of item
+buy/sell/barter
+```
+2. Punch the shop with an empty hand to enter creative selection
+3. Select the item from the creative menu and drop it outside the creative menu
+
+**`config.yml` Defaults:**
+
+```yaml
+creationMethod:
+  placeSign: true # Allow shops to be created by placing a sign down
+
+allowCreativeSelection: true # This will allow players to use the limited creative selection tool to choose shop items
+```


### PR DESCRIPTION
# Changelog
## Added
* Support for Folia! (https://github.com/snowgears/shopbugs/issues/473)
* PlotSquared integration
  * https://github.com/snowgears/shopbugs/issues/129
  * https://github.com/snowgears/shopbugs/issues/471
  * TODO https://github.com/snowgears/shopbugs/issues/309
* Graceful error handling, so that even if errors occur, Shop will still attempt to continue functioning.
* If Display class fails to load, a fake display class will be loaded instead, disabling the feature instead of breaking the plugin.
* Support for fractional currencies!  (https://github.com/snowgears/shopbugs/issues/469)
    * New config.yml flag `allowFractionalCurrency`
* Added `[split]` placeholder to complement the reimplemented `[lshift]` and `[rshift]` placeholders
* Enhanced item detail display for many item types:
  * Beehives (shows honey level and bee count)
  * Goat Horns (displays horn type)
  * Music Discs (shows disc name)
  * Smithing templates (displays template type)
  * Ominous Bottles (display bad omen level)
  * Firework effects (shows all rocket details/effects)
  * Potions with improved details

## Changed
* Extend sign text to be full width (uses the Minecraft font character widths to calculate length)
* Add proper support for all formatting codes (bold, italic, underline, strikethrough, magic, and reset) to mirror Vanilla 
* Added support for Gradient Item Names & config values in all displays, signs, and messages.
* Handle `shop.buildlimit.#` permission changing instantly. (Players previously had to relog)
* Improved security for locked creative mode selection

## Fixed
* Issues preventing versions older than 1.20 to work.
* Combo Shops not using proper buy/sell transaction types
* https://github.com/snowgears/shopbugs/issues/470
  * Reimplement `[lshift]` and `[rshift]` placeholders
  * Properly handle formatting when users pass color codes inside of square brackets
  * Issue where "Armor Stand" hologram text would be displayed if string passed was empty/null
  * Issue where Hex color codes were not properly being copied to the next line
* Fixed fractional payments
* Fixed display of hex gradient items in Offline Purchase History
* Properly load stock on shop creation
* Fixed WorldGuard integration

## Technical Improvements
* Refactored price negotiation system for better maintenance
* Improved plugin enabling/disabling process for more stability
* Render shop displays in batches for efficiency
  * Optimizes the number of Item Display packets sent to clients, prevents sending duplicate item display packets (packets used to be sent for all shops within range every 5 seconds). Also speeds up the time it takes to display nearby shop displays from 5s to 1s.
  * Completely configurable via `config.yml`
* Canceled break event if shop cannot be created
* Gracefully handle NBTAPI errors & disable if broken
* Keep gradient words intact to maintain visual quality
* Improved handling of hex formatting codes

## Screenshots
![1a-gradient-item-names](https://github.com/user-attachments/assets/e1d309c3-812f-4c51-b7f7-9f5dd1e17b79)
![1b-enchanted-item](https://github.com/user-attachments/assets/7723f051-04bc-413e-a0b5-1a147fe9bfc7)
![1c-player-heads](https://github.com/user-attachments/assets/7ed76b14-4584-4dc0-abef-26208343ca1f)
![2a-potion-detail-improved](https://github.com/user-attachments/assets/6aa09343-eff6-45bb-9fd1-bc1185046aed)
![2b-tipped-arrow-detail](https://github.com/user-attachments/assets/12591cf9-3acd-42ce-a390-df3c2530ff13)
![3a-smithing-templates](https://github.com/user-attachments/assets/55d93e0b-240c-40da-8683-572cf55beb1a)
![3b-armor-with-trim](https://github.com/user-attachments/assets/9a61bef8-64d8-4732-b6ee-3b80494a441a)
![4a-firework-rockets-duration](https://github.com/user-attachments/assets/6a8bd50f-7f2d-4f45-aa25-d95c16b518c0)
![4b-firework-star](https://github.com/user-attachments/assets/d9b70a9f-c77e-4c55-a6e9-fde5b97210a2)
![4c-firework-effects](https://github.com/user-attachments/assets/97922cb6-a2e1-4021-b8c2-c6b0d41c022c)
![5-beehive-details](https://github.com/user-attachments/assets/99506991-aa74-44c0-94d5-4fb2616b0c22)
![6-goat-horns](https://github.com/user-attachments/assets/6e1a4dcc-2bd2-441d-8563-fc3eb3a27d04)
![7-music-discs](https://github.com/user-attachments/assets/302fbd6e-1617-426b-b0b8-bfff6b50b817)
