### PR TITLE
Nit: Elytra & Mace large item display tweaks

### DIFF
--- a/core/src/main/java/com/snowgears/shop/util/DisplayUtil.java
+++ b/core/src/main/java/com/snowgears/shop/util/DisplayUtil.java
@@ -94,6 +94,8 @@ public class DisplayUtil {
             case LEGS:
             case FEET:
                 armorStandData.setSmall(true);
+                if (itemStack.getType() == Material.ELYTRA)
+                    standLocation.setY(standLocation.getY() + 0.7);
                 break;
             case HAND:
                 armorStandData.setRightArmPose(getArmAngle(itemStack));

--- a/core/src/main/java/com/snowgears/shop/util/DisplayUtil.java
+++ b/core/src/main/java/com/snowgears/shop/util/DisplayUtil.java
@@ -405,8 +405,9 @@ public class DisplayUtil {
 
     public static boolean isTool(Material material){
         String sMaterial = material.toString().toUpperCase();
-        return (sMaterial.contains("_AXE") || sMaterial.contains("_HOE") || sMaterial.contains("_PICKAXE")
-                || sMaterial.contains("_SPADE") || sMaterial.contains("_SWORD")
+        return (sMaterial.contains("_AXE") || sMaterial.contains("_HOE") 
+                || sMaterial.contains("_PICKAXE") || sMaterial.contains("_SPADE") 
+                || sMaterial.contains("_SWORD") || sMaterial.contains("MACE")
                 || material == Material.BONE || material == Material.STICK  || material == Material.BLAZE_ROD
                 || material == Material.CARROT_ON_A_STICK || material == Material.FISHING_ROD);
     }


### PR DESCRIPTION
## Elytra
The Elytra display is a bit broken when you set it to "Large Item" mode. 

Before
![elytra-before](https://github.com/user-attachments/assets/0869dec6-116b-4cc4-95a8-d40590843596)
After
![elytra-after](https://github.com/user-attachments/assets/983ccff6-9b2a-4924-a377-3fc3ca6f3fcc)

## Mace
Additionally, the Mace displays with an incorrect rotation in Large Item Display mode 

Before
![mace-before](https://github.com/user-attachments/assets/f3099292-6971-4c74-91da-dc46544b903c)
After
![mace-after](https://github.com/user-attachments/assets/c1e241e9-fa65-4d89-9783-1866d6049146)
