### PR TITLE
Add Player Name Caching

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -285,7 +285,7 @@
     </build>
 
     <properties>
-        <spigot.version>1.21-R0.1-SNAPSHOT</spigot.version>
+        <spigot.version>1.21.1-R0.1-SNAPSHOT</spigot.version>
     </properties>
 
 </project>

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -798,6 +798,9 @@ public class Shop extends JavaPlugin {
         //save any remaining shops (usually not required but just in case)
         if (shopHandler != null) shopHandler.saveAllShops();
 
+        // Save player name cache to ensure no data loss
+        PlayerNameCache.saveToFile();
+
         this.getLogger().info("Disabled Shop " + this.getDescription().getVersion());
     }
 

--- a/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
@@ -8,6 +8,7 @@ import com.snowgears.shop.shop.ComboShop;
 import com.snowgears.shop.shop.ShopType;
 import com.snowgears.shop.util.DisplayUtil;
 import com.snowgears.shop.util.ItemListType;
+import com.snowgears.shop.util.PlayerNameCache;
 import com.snowgears.shop.util.ShopLogger;
 import com.snowgears.shop.util.UtilMethods;
 import org.bukkit.*;
@@ -936,8 +937,12 @@ public class ShopHandler {
             public int compare(AbstractShop o1, AbstractShop o2) {
                 if(o1 == null || o2 == null)
                     return 0;
-                //could have something to do with switching between online and offline mode
-                return o1.getOwnerName().toLowerCase().compareTo(o2.getOwnerName().toLowerCase());
+                
+                // Cache owner names to avoid calling getOwnerName() twice per comparison
+                String owner1Name = o1.getOwnerName();
+                String owner2Name = o2.getOwnerName();
+                
+                return owner1Name.toLowerCase().compareTo(owner2Name.toLowerCase());
             }
         });
         return list;
@@ -1220,6 +1225,9 @@ public class ShopHandler {
             File fileDirectory = new File(plugin.getDataFolder(), "Data");
             if (!fileDirectory.exists())
                 return;
+
+            // Initialize player name cache (simple check for existing cache file)
+            PlayerNameCache.initialize();
 
             // load all the yml files from the data directory
             for (File file : fileDirectory.listFiles()) {

--- a/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
@@ -1237,7 +1237,8 @@ public class ShopHandler {
                         if (file.getName().endsWith(".yml")
                                 && !file.getName().contains("enderchests")
                                 && !file.getName().contains("itemCurrency")
-                                && !file.getName().contains("gambleDisplay")) {
+                                && !file.getName().contains("gambleDisplay")
+                                && !file.getName().contains("playerNameCache")) {
                             YamlConfiguration config = YamlConfiguration.loadConfiguration(file);
                             boolean isLegacyConfig = false;
                             UUID playerUUID = null;

--- a/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
@@ -46,6 +46,10 @@ public class ShopListener implements Listener {
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event){
         plugin.getFoliaLib().getScheduler().runLater(() -> {
+            // Cache player name for performance optimization
+            PlayerNameCache.cacheName(event.getPlayer().getUniqueId(), event.getPlayer().getName());
+            
+            // Check if the players permissions have changed
             recalculateShopPerms(event.getPlayer());
         }, 5);
     }

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -36,6 +36,7 @@ public abstract class AbstractShop {
 
     protected UUID id = UUID.randomUUID();
     protected boolean needsSave = false;
+    protected boolean playerFileError = false;
     protected Location signLocation;
     protected Location chestLocation;
     protected BlockFace facing;
@@ -296,8 +297,10 @@ public abstract class AbstractShop {
         if (this.getOwner() != null){
             // If we can load the owner name, just use that
             try {
-                if (this.getOwner().getName() != null) return this.getOwner().getName();
+                if (!playerFileError) // Prevent trying to load it multiple times if we already failed once
+                    if (this.getOwner().getName() != null) return this.getOwner().getName();
             } catch (Error | Exception e) {
+                playerFileError = true;
                 Shop.getPlugin().getLogger().severe(
                     "Error loading Player File for Owner (uuid: " + this.getOwnerUUID() 
                     + ")!!! This could mean that the player file is corrupt or missing!!! "

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -295,7 +295,15 @@ public abstract class AbstractShop {
             return "admin";
         if (this.getOwner() != null){
             // If we can load the owner name, just use that
-            if (this.getOwner().getName() != null) return this.getOwner().getName();
+            try {
+                if (this.getOwner().getName() != null) return this.getOwner().getName();
+            } catch (Error | Exception e) {
+                Shop.getPlugin().getLogger().severe(
+                    "Error loading Player File for Owner (uuid: " + this.getOwnerUUID() 
+                    + ")!!! This could mean that the player file is corrupt or missing!!! "
+                    + "Falling back to UUID only for Owner Name! Shop: " + this.toString()
+                );
+            }
             // Return unknown player text
             String shortId = this.getOwnerUUID().toString();
             shortId = shortId.substring(0,3) + "..." + shortId.substring(shortId.length()-3);

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -36,7 +36,6 @@ public abstract class AbstractShop {
 
     protected UUID id = UUID.randomUUID();
     protected boolean needsSave = false;
-    protected boolean playerFileError = false;
     protected Location signLocation;
     protected Location chestLocation;
     protected BlockFace facing;
@@ -294,24 +293,12 @@ public abstract class AbstractShop {
     public String getOwnerName() {
         if(this.isAdmin())
             return "admin";
-        if (this.getOwner() != null){
-            // If we can load the owner name, just use that
-            try {
-                if (!playerFileError) // Prevent trying to load it multiple times if we already failed once
-                    if (this.getOwner().getName() != null) return this.getOwner().getName();
-            } catch (Error | Exception e) {
-                playerFileError = true;
-                Shop.getPlugin().getLogger().severe(
-                    "Error loading Player File for Owner (uuid: " + this.getOwnerUUID() 
-                    + ")!!! This could mean that the player file is corrupt or missing!!! "
-                    + "Falling back to UUID only for Owner Name! Shop: " + this.toString()
-                );
-            }
-            // Return unknown player text
-            String shortId = this.getOwnerUUID().toString();
-            shortId = shortId.substring(0,3) + "..." + shortId.substring(shortId.length()-3);
-            return "Unknown Player (" + shortId + ")";
+        
+        if (this.getOwnerUUID() != null) {
+            // Use cache first - this avoids expensive disk I/O
+            return PlayerNameCache.getName(this.getOwnerUUID());
         }
+        
         return ChatColor.RED + "CLOSED";
     }
 

--- a/core/src/main/java/com/snowgears/shop/util/PlayerNameCache.java
+++ b/core/src/main/java/com/snowgears/shop/util/PlayerNameCache.java
@@ -1,0 +1,130 @@
+package com.snowgears.shop.util;
+
+import org.bukkit.Bukkit;
+import org.bukkit.configuration.file.YamlConfiguration;
+import com.snowgears.shop.Shop;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Lightweight cache for player names to avoid expensive OfflinePlayer.getName() calls.
+ * Thread-safe with lazy loading during initial cache build phase.
+ */
+public class PlayerNameCache {
+    
+    private static final ConcurrentHashMap<UUID, String> cache = new ConcurrentHashMap<>();
+    private static final String CACHE_FILENAME = "playerNameCache.yml";
+    
+    /**
+     * Initialize cache on startup - checks if cache file exists
+     */
+    public static void initialize() {
+        File cacheFile = new File(Shop.getPlugin().getDataFolder(), CACHE_FILENAME);
+        
+        if (cacheFile.exists()) {
+            loadFromFile(cacheFile);
+        }
+    }
+    
+    /**
+     * Gets a player name from cache, with lazy loading during initial build
+     * @param uuid Player UUID
+     * @return Player name or formatted UUID fallback
+     */
+    public static String getName(UUID uuid) {
+        String cachedName = cache.get(uuid);
+        if (cachedName != null) {
+            return cachedName;
+        }
+
+        // If the player is not in the cache, add a placeholder name before attempting to load from OfflinePlayer
+        // This is to avoid issues with Bukkit.getOfflinePlayer(uuid).getName() causing a recursive error loop in 1.21.5
+        // if we run into the recursive loop issue, then we'll just return the placeholder name in the future instead of lagging the server
+        String shortId = uuid.toString();
+        String unknownPlayerString = "Unknown Player (" + shortId.substring(0, 3) + "..." + shortId.substring(shortId.length() - 3) + ")";
+        cache.put(uuid, unknownPlayerString);
+
+        // Try loading from OfflinePlayer once, otherwise we'll just return the placeholder name
+        try {
+            String name = Bukkit.getOfflinePlayer(uuid).getName();
+            if (name != null) {
+                cache.put(uuid, name);
+                return name;
+            }
+        } catch (Error | Exception e) {
+            Shop.getPlugin().getLogger().warning("Error while getting player name for " + uuid + " from OfflinePlayer.getName()! " + e.getMessage());
+        }
+
+        // Return placeholder name as fallback
+        return unknownPlayerString;
+    }
+    
+    /**
+     * Caches a player name and switches off initial build mode
+     * @param uuid Player UUID  
+     * @param name Player name
+     */
+    public static void cacheName(UUID uuid, String name) {
+        if (uuid != null && name != null && !name.trim().isEmpty()) {
+            cache.put(uuid, name);
+        }
+    }
+    
+    /**
+     * Removes a player from cache
+     * @param uuid Player UUID
+     */
+    public static void removeName(UUID uuid) {
+        cache.remove(uuid);
+    }
+    
+    /**
+     * Saves cache to file
+     * @param dataFolder Plugin data folder
+     */
+    public static void saveToFile() {
+        File cacheFile = new File(Shop.getPlugin().getDataFolder(), CACHE_FILENAME);
+        try {
+            YamlConfiguration config = new YamlConfiguration();
+            for (ConcurrentHashMap.Entry<UUID, String> entry : cache.entrySet()) {
+                config.set(entry.getKey().toString(), entry.getValue());
+            }
+            config.save(cacheFile);
+        } catch (IOException e) {
+            Shop.getPlugin().getLogger().warning("Error while saving player name cache to file! " + e.getMessage());
+        }
+    }
+    
+    /**
+     * Loads cache from file
+     */
+    private static void loadFromFile(File cacheFile) {
+        try {
+            YamlConfiguration config = YamlConfiguration.loadConfiguration(cacheFile);
+            for (String key : config.getKeys(false)) {
+                try {
+                    UUID uuid = UUID.fromString(key);
+                    String name = config.getString(key);
+                    if (name != null) {
+                        cache.put(uuid, name);
+                    }
+                } catch (IllegalArgumentException e) {
+                    // Skip invalid UUID entries
+                }
+            }
+        } catch (Exception e) {
+            Shop.getPlugin().getLogger().warning("Error while loading player name cache from file! " + e.getMessage());
+        }
+    }
+    
+    /**
+     * Gets current cache size for monitoring
+     * @return Number of cached entries
+     */
+    public static int getCacheSize() {
+        return cache.size();
+    }
+} 

--- a/core/src/main/java/com/snowgears/shop/util/PlayerNameCache.java
+++ b/core/src/main/java/com/snowgears/shop/util/PlayerNameCache.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class PlayerNameCache {
     
     private static final ConcurrentHashMap<UUID, String> cache = new ConcurrentHashMap<>();
-    private static final String CACHE_FILENAME = "playerNameCache.yml";
+    private static final String CACHE_FILENAME = "Data/playerNameCache.yml";
     
     /**
      * Initialize cache on startup - checks if cache file exists

--- a/core/src/main/java/com/snowgears/shop/util/PlayerNameCache.java
+++ b/core/src/main/java/com/snowgears/shop/util/PlayerNameCache.java
@@ -1,6 +1,7 @@
 package com.snowgears.shop.util;
 
 import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.YamlConfiguration;
 import com.snowgears.shop.Shop;
 
@@ -49,10 +50,15 @@ public class PlayerNameCache {
 
         // Try loading from OfflinePlayer once, otherwise we'll just return the placeholder name
         try {
-            String name = Bukkit.getOfflinePlayer(uuid).getName();
-            if (name != null) {
-                cache.put(uuid, name);
-                return name;
+            OfflinePlayer player = Bukkit.getOfflinePlayer(uuid);
+            if (player.hasPlayedBefore()) {
+                String name = player.getName();
+                if (name != null) {
+                    cache.put(uuid, name);
+                    return name;
+                }
+            } else {
+                Shop.getPlugin().getLogger().warning("Player " + uuid + " has not played on this server and/or their player data file does not exist! Unable to load the player name from OfflinePlayer!");
             }
         } catch (Error | Exception e) {
             Shop.getPlugin().getLogger().warning("Error while getting player name for " + uuid + " from OfflinePlayer.getName()! " + e.getMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     </build>
 
     <properties>
-        <revision>1.10.1</revision>
+        <revision>1.10.2</revision>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The function `CraftOfflinePlayer.getName()` forces the player file to load from the disk which can lead to inefficiencies as well as some issues.

In the PaperMC 1.21.5 experimental builds there is a bug where recursive logic is called with the MojangDataFixers if there is a corrupt/outdated/missing (or something) player file. 

This MR introduces the `PlayerNameCache` class which will maintain a history of player names to prevent the data from being repeatedly loaded from the disk. This should also fix issues with sorting shops by player names was causing tons of lag from all the player name lookups/comparisons.

This makes the code much more efficient and also effectively handles issues when loading a player file from the disk is impossible.

PaperMC 1.21.5 experimental build error log:
```
591 | [08:24:11 ERROR]:               net.minecraft.world.level.storage.PlayerDataStorage.load(PlayerDataStorage.java:114)
592 | [08:24:11 ERROR]:               org.bukkit.craftbukkit.CraftOfflinePlayer.getData(CraftOfflinePlayer.java:199)
593 | [08:24:11 ERROR]:               org.bukkit.craftbukkit.CraftOfflinePlayer.getBukkitData(CraftOfflinePlayer.java:203)
594 | [08:24:11 ERROR]:               org.bukkit.craftbukkit.CraftOfflinePlayer.getName(CraftOfflinePlayer.java:70)
595 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.shop.AbstractShop.getOwnerName(AbstractShop.java:298)
596 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.util.ShopMessage.lambda$loadPlaceholders$6(ShopMessage.java:376)
597 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.util.ShopMessage$$Lambda/0x00007b361ebd2a38.apply(Unknown Source)
598 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.util.ShopMessage.replacePlaceholder(ShopMessage.java:107)
599 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.util.ShopMessage.format(ShopMessage.java:209)
600 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.util.ShopMessage.formatMessage(ShopMessage.java:807)
601 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.util.ShopMessage.getSignLines(ShopMessage.java:849)
602 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.shop.AbstractShop.updateSign(AbstractShop.java:516)
603 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.shop.AbstractShop.updateStock(AbstractShop.java:227)
604 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.shop.AbstractShop.load(AbstractShop.java:150)
605 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.handler.ShopHandler.lambda$loadShopsFromConfig$10(ShopHandler.java:1363)
606 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.handler.ShopHandler$$Lambda/0x00007b361f3ddd58.accept(Unknown Source)
607 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.artifact.folialib.impl.SpigotImplementation.lambda$runNextTick$0(SpigotImplementation.java:82)
608 | [08:24:11 ERROR]:               Shop-1.10.1-ef7bf41.jar//com.snowgears.shop.artifact.folialib.impl.SpigotImplementation$$Lambda/0x00007b361f3dd090.accept(Unknown Source)
609 | [08:24:11 ERROR]:               org.bukkit.craftbukkit.scheduler.CraftTask.run(CraftTask.java:80)
610 | [08:24:11 ERROR]:               org.bukkit.craftbukkit.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:474)
611 | [08:24:11 ERROR]:               net.minecraft.server.MinecraftServer.tickChildren(MinecraftServer.java:1657)
612 | [08:24:11 ERROR]:               net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1527)
613 | [08:24:11 ERROR]:               net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1249)
```