### PR TITLE
Nit: Fix hex item names

### DIFF
--- a/core/src/main/java/com/snowgears/shop/util/ItemNameUtil.java
+++ b/core/src/main/java/com/snowgears/shop/util/ItemNameUtil.java
@@ -32,7 +32,7 @@ public class ItemNameUtil {
 
         // Check if there is a name embedded in the item, aka named by an anvil or command
         if(item.getItemMeta() != null && item.getItemMeta().getDisplayName() != null && !item.getItemMeta().getDisplayName().isEmpty()){
-            return new TextComponent(item.getItemMeta().getDisplayName());
+            return (TextComponent) TextComponent.fromLegacy(item.getItemMeta().getDisplayName());
         }
 
         // Add custom formatting for player heads

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -7,7 +7,7 @@ import com.snowgears.shop.shop.AbstractShop;
 import com.snowgears.shop.shop.ComboShop;
 import com.snowgears.shop.shop.ShopType;
 import net.md_5.bungee.api.chat.*;
-import net.md_5.bungee.api.chat.hover.content.Item;
+// import net.md_5.bungee.chat.ComponentSerializer;
 
 import org.bukkit.Bukkit;
 import net.md_5.bungee.api.ChatColor;
@@ -592,7 +592,8 @@ public class ShopMessage {
                 // Add new lines between text
                 hoverText.addExtra(format(line + (i == hoverLines.size() ? "" : "\n"), context));
             }
-            return new HoverEvent(HoverEvent.Action.SHOW_TEXT, new BaseComponent[]{hoverText});
+            BaseComponent flatText = TextComponent.fromLegacy(hoverText.toLegacyText());
+            return new HoverEvent(HoverEvent.Action.SHOW_TEXT, new BaseComponent[]{flatText});
         } catch (Exception e) {}
         return null;
     }

--- a/runDev.sh
+++ b/runDev.sh
@@ -29,10 +29,10 @@ mvn clean compile package -T 8C #-o
 resetVersion
 
 # Copy latest plugin in
-rm ../paper-test-1.21.4/plugins/Shop-*.jar 
+rm ../paper-test-1.21.6/plugins/Shop-*.jar 
 # rm -r ../paper-test-1.21.4/plugins/.paper-remapped
-cp target/Shop-*.jar ../paper-test-1.21.4/plugins
+cp target/Shop-*.jar ../paper-test-1.21.6/plugins
 
-cd ../paper-test-1.21.4/
+cd ../paper-test-1.21.6/
 # rm -r plugins/.paper-remapped
-java -Xms4G -Xmx8G -jar paper-1.21.4*.jar --nogui
+java -Xms4G -Xmx8G -jar paper-1.21.6*.jar --nogui


### PR DESCRIPTION
Fixes item hex name display in PaperMC 1.21.6