### PR TITLE
Re-implement `shop.buildlimitextra.#` feature!

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -74,12 +74,27 @@
     </dependencyManagement>
 
     <dependencies>
+        <!-- Unit Testing -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Core Dependencies -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>

--- a/core/src/main/java/com/snowgears/shop/handler/CommandHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/CommandHandler.java
@@ -45,8 +45,6 @@ public class CommandHandler extends BukkitCommand {
             if (sender instanceof Player) {
                 Player player = (Player) sender;
 
-                plugin.getShopListener().recalculateShopPerms(player);
-
                 if(plugin.useGUI()) {
                     ShopGuiWindow window = plugin.getGuiHandler().getWindow(player);
                     window.open();

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -50,14 +50,17 @@ permissions:
         description: Allows player to destroy other player's shops.
         default: op
     shop.buildlimit.#:
-         description: Restricts the number of shops a player can create. For example shop.buildlimit.10 would limit players to creating 10 shops maximum.
-         default: op
+        description: Restricts the number of shops a player can create. For example shop.buildlimit.10 would limit players to creating 10 shops maximum. If multiple buildlimit permissions exist, ONLY the highest will be used.
+        default: op
+    shop.buildlimitextra.#:
+        description: Add an additional number of shops to the players build limit. For example shop.buildlimitextra.5 would grant players an additional 5 shops to their limit. If mulitple buildlimitextra permissions exist they will ALL be used and added together.
+        default: op
     shop.setdisplay:
-         description: Allows player to set the display type on their shop (allows shop display cycling, see actionMappings in config.yml).
-         default: op
+        description: Allows player to set the display type on their shop (allows shop display cycling, see actionMappings in config.yml).
+        default: op
     shop.gui.teleport:
-         description: Allows player to use teleport to shops by using the gui.
-         default: op
+        description: Allows player to use teleport to shops by using the gui.
+        default: op
     shop.operator:
         description: Allows access to operator actions like setting currency, setting the gamble item, reloading configs, creating gamble/admin shops, etc.
         default: op

--- a/core/src/test/java/com/snowgears/shop/listener/ShopListenerTest.java
+++ b/core/src/test/java/com/snowgears/shop/listener/ShopListenerTest.java
@@ -1,0 +1,99 @@
+package com.snowgears.shop.listener;
+
+import com.snowgears.shop.Shop;
+import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.mockito.Mockito;
+
+/**
+ * Very small unit-tests that exercise the build-limit calculation logic inside
+ * {@link ShopListener#getBuildLimit(org.bukkit.entity.Player)}.
+ *
+ * Because these tests only need to validate the numeric result, we mock the
+ * Bukkit/Spigot types with Mockito. Mockito-inline is declared as a test
+ * dependency in the module POM to allow mocking of the final
+ * {@link PermissionAttachmentInfo} class.
+ */
+class ShopListenerTest {
+
+    private static PermissionAttachmentInfo mockPermission(String node) {
+        PermissionAttachmentInfo info = Mockito.mock(PermissionAttachmentInfo.class);
+        Mockito.when(info.getPermission()).thenReturn(node);
+        return info;
+    }
+
+    private static ShopListener listenerWithPerms(boolean usePerms) {
+        Shop plugin = Mockito.mock(Shop.class);
+        Mockito.when(plugin.usePerms()).thenReturn(usePerms);
+        return new ShopListener(plugin);
+    }
+
+    @Test
+    @DisplayName("Use highest base limit")
+    void useHighestBaseLimit() {
+        ShopListener listener = listenerWithPerms(true);
+
+        Player player = Mockito.mock(Player.class);
+        Set<PermissionAttachmentInfo> perms = new HashSet<>();
+        perms.add(mockPermission("shop.buildlimit.2"));
+        perms.add(mockPermission("shop.buildlimit.5"));
+        perms.add(mockPermission("shop.other.permission")); // malformed permission, ignored
+        perms.add(mockPermission("shop.buildlimit.#"));     // malformed permission, ignored
+        perms.add(mockPermission("shop.buildlimit.rawr"));  // malformed permission, ignored
+        perms.add(mockPermission("shop.buildlimit.10"));
+        perms.add(mockPermission("shop.buildlimit.7"));
+        Mockito.when(player.getEffectivePermissions()).thenReturn(perms);
+
+        assertEquals(10, listener.getBuildLimit(player));
+    }
+
+    @Test
+    @DisplayName("Base 10 with extras 2+3 results in 15")
+    void baseAndExtrasAreAdded() {
+        ShopListener listener = listenerWithPerms(true);
+
+        Player player = Mockito.mock(Player.class);
+        Set<PermissionAttachmentInfo> perms = new HashSet<>();
+        perms.add(mockPermission("shop.buildlimitextra.2"));
+        perms.add(mockPermission("shop.buildlimit.10"));
+        perms.add(mockPermission("shop.buildlimitextra.3"));
+        Mockito.when(player.getEffectivePermissions()).thenReturn(perms);
+
+        assertEquals(15, listener.getBuildLimit(player));
+    }
+
+    @Test
+    @DisplayName("Extras without base falls back to default base 10 000")
+    void extrasOnlyGetsDefaultBase() {
+        ShopListener listener = listenerWithPerms(true);
+
+        Player player = Mockito.mock(Player.class);
+        Set<PermissionAttachmentInfo> perms = new HashSet<>();
+        perms.add(mockPermission("shop.buildlimitextra.5"));
+        Mockito.when(player.getEffectivePermissions()).thenReturn(perms);
+
+        // default (10000) without extras
+        assertEquals(10000, listener.getBuildLimit(player));
+    }
+
+    @Test
+    @DisplayName("Permissions disabled returns hard-coded limit")
+    void permissionsDisabledReturnsDefault() {
+        ShopListener listener = listenerWithPerms(false);
+
+        Player player = Mockito.mock(Player.class);
+        // Even if some permission nodes exist, they are ignored when perms are off
+        Set<PermissionAttachmentInfo> perms = new HashSet<>();
+        perms.add(mockPermission("shop.buildlimit.1"));
+        Mockito.when(player.getEffectivePermissions()).thenReturn(perms);
+
+        assertEquals(10000, listener.getBuildLimit(player));
+    }
+}

--- a/wiki/permissions.md
+++ b/wiki/permissions.md
@@ -51,8 +51,9 @@ permissions:
         default: op
 
     shop.buildlimit.#:
-         description: Restricts the number of shops a player can create. For example shop.buildlimit.10 would limit players to creating 10 shops maximum.
-         default: op
+         description: Restricts the number of shops a player can create. For example shop.buildlimit.10 would limit players to creating 10 shops maximum. If multiple buildlimit permissions exist, ONLY the highest will be used.
+    shop.buildlimitextra.#:
+         description: Add an additional number of shops to the players build limit. For example shop.buildlimitextra.5 would grant players an additional 5 shops to their limit. If mulitple buildlimitextra permissions exist they will ALL be used and added together.
 
     shop.setdisplay:
          description: Allows player to set the display type on their shop (allows shop display cycling, see actionMappings in config.yml).


### PR DESCRIPTION
Changes a few things:
1. Removes caching for player permissions because it was just unnecessary and left in from 10 years ago when the feature was first added.
2. Adds the `buildlimitextra` permission feature back into the plugin, it was removed recently since it was undocumented
3. Documents the `buildlimitextra` feature

We also add Mockito and have proper unit tests that mock Bukkit classes!!