### PR TITLE
MC 1.21.7: update item-nbt-api v2.15.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -182,13 +182,13 @@
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api-plugin</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.1</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>de.tr7zw</groupId>
             <artifactId>item-nbt-api</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.1</version>
         </dependency>
         <dependency>
             <groupId>com.intellectualsites.plotsquared</groupId>


### PR DESCRIPTION
Update `item-nbt-api` to v2.15.1 to pull in support for new MC versions