### PR TITLE
Shop Deletion Bugs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
         NEW_VERSION="${CURRENT_VERSION}-${COMMIT_HASH}"
 
         echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV
+        echo "JAR_FILENAME=shop-${NEW_VERSION}.jar" >> $GITHUB_ENV
         
     - name: Generate Maven toolchains.xml (JDK 21)
       run: |
@@ -101,34 +102,22 @@ jobs:
         title: Coverage Report
         update-comment: true
 
-    - name: Upload JaCoCo XML
-      uses: actions/upload-artifact@v4
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      continue-on-error: true
       with:
-        name: jacoco-xml
-        path: '**/target/site/jacoco/jacoco.xml'
-        if-no-files-found: warn
-
-    - name: Coverage Summary (Job Summary)
-      uses: irongut/CodeCoverageSummary@v1.3.0
-      with:
-        filename: '**/target/site/jacoco/jacoco.xml'
-        badge: true
-        format: markdown
-        output: both
+        files: '**/target/site/jacoco/jacoco.xml'
+        flags: java
+        fail_ci_if_error: false
+        verbose: true
+        # no need for token, it's not required for our use case
       
     - name: Upload Artifact
-      id: upload-artifact
+      id: upload-shop-jar
       uses: actions/upload-artifact@v4
       with:
-        name: shop-plugin
+        name: ${{ env.JAR_FILENAME }}
         path: target/Shop-*.jar
-        
-    - name: Find JAR filename
-      id: find-jar
-      run: |
-        JAR_FILE=$(find target -name "Shop-*.jar" -not -name "original-Shop-*.jar" | head -n 1)
-        JAR_FILENAME=$(basename "$JAR_FILE")
-        echo "JAR_FILENAME=$JAR_FILENAME" >> $GITHUB_ENV
         
     - name: Create workflow summary
       run: |
@@ -138,9 +127,9 @@ jobs:
         echo "**Version:** ${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Direct Download Link" >> $GITHUB_STEP_SUMMARY
-        echo "⬇️ [Download ${{ env.JAR_FILENAME }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+        echo "⬇️ [Download Bleeding Edge build: ${{ env.JAR_FILENAME }}](${{ steps.upload-shop-jar.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "To download, click the link above, then click on the 'Artifacts' dropdown and select 'shop-plugin'." >> $GITHUB_STEP_SUMMARY
+        echo "To download, click the link above, then click on the 'Artifacts' dropdown and select '${{ env.JAR_FILENAME }}'." >> $GITHUB_STEP_SUMMARY
         
     - name: Create Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,10 +84,10 @@ jobs:
     
     - name: Pre-fetch Maven dependencies (go-offline)
       run: |
-        mvn -B -Pcoverage -nsu -Drevision=${{ env.VERSION }} -DskipTests dependency:go-offline
+        mvn -B -nsu -Drevision=${{ env.VERSION }} -DskipTests dependency:go-offline
       
-    - name: Build with Maven
-      run: mvn -B -Pcoverage -nsu -T 1C -Drevision=${{ env.VERSION }} clean verify
+    - name: Build
+      run: mvn -B -nsu -T 1C -Drevision=${{ env.VERSION }} clean package
 
     - name: Publish Test Results
       if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,26 +145,24 @@ jobs:
         name: diff-cover-report.html
         path: scripts/diff-cover.html
 
-    - name: HTML Preview
-      if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-      id: html_preview
-      uses: pavi2410/html-preview-action@v4
-      with:
-        html_file: 'scripts/diff-cover.html'
-        job_summary: true
-
     - name: Create workflow summary
       run: |
         echo "# Build Completed Successfully! 🎉" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Version:** ${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
         if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
-          echo "**Diff Cover:** [View report](${{ steps.html_preview.outputs.url }})" >> $GITHUB_STEP_SUMMARY
+          echo "**Diff Cover:** [View report](${{ steps.upload-diff-cover-report.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
         fi
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Download Build" >> $GITHUB_STEP_SUMMARY
         echo "⬇️ [${{ env.JAR_FILENAME }}](${{ steps.upload-shop-jar.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
+        echo $GITHUB_STEP_SUMMARY > build-summary.md
+
+    - name: Build Summary
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        path: build-summary.md
       
     - name: Create Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,28 +100,15 @@ jobs:
         fail-on-error: false
         fail-on-empty: false
 
-    - name: Comment PR with JaCoCo Coverage Report
-      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
-      uses: madrapps/jacoco-report@v1.6.1
-      continue-on-error: true
-      with:
-        paths: |
-          **/target/site/jacoco/jacoco.xml
-        token: ${{ secrets.GITHUB_TOKEN }}
-        min-coverage-overall: 0
-        min-coverage-changed-files: 0
-        title: Coverage Report
-        update-comment: true
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
-      continue-on-error: true
-      with:
-        files: '**/target/site/jacoco/jacoco.xml'
-        flags: java
-        fail_ci_if_error: false
-        verbose: true
-        # no need for token, it's not required for our use case
+    # - name: Upload coverage to Codecov
+    #   uses: codecov/codecov-action@v4
+    #   continue-on-error: true
+    #   with:
+    #     files: '**/target/site/jacoco/jacoco.xml'
+    #     flags: java
+    #     fail_ci_if_error: false
+    #     verbose: true
+    #     # no need for token, it's not required for our use case
       
     - name: Generate diff-cover report
       if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
@@ -157,12 +144,24 @@ jobs:
         echo "### Download Build" >> $GITHUB_STEP_SUMMARY
         echo "⬇️ [${{ env.JAR_FILENAME }}](${{ steps.upload-shop-jar.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo $GITHUB_STEP_SUMMARY > build-summary.md
 
     - name: Build Summary
       uses: marocchino/sticky-pull-request-comment@v2
       with:
-        path: build-summary.md
+        path: $GITHUB_STEP_SUMMARY
+
+    - name: Comment PR with JaCoCo Coverage Report
+      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      uses: madrapps/jacoco-report@v1.6.1
+      continue-on-error: true
+      with:
+        paths: |
+          **/target/site/jacoco/jacoco.xml
+        token: ${{ secrets.GITHUB_TOKEN }}
+        min-coverage-overall: 0
+        min-coverage-changed-files: 0
+        title: Coverage Report
+        update-comment: true
       
     - name: Create Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,13 +134,11 @@ jobs:
       run: |
         echo "# Build Completed Successfully! 🎉" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "## Download" >> $GITHUB_STEP_SUMMARY
         echo "**Version:** ${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### Direct Download Link" >> $GITHUB_STEP_SUMMARY
-        echo "⬇️ [Download Bleeding Edge build: ${{ env.JAR_FILENAME }}](${{ steps.upload-shop-jar.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
+        echo "### Download Build" >> $GITHUB_STEP_SUMMARY
+        echo "⬇️ [${{ env.JAR_FILENAME }}](${{ steps.upload-shop-jar.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "To download, click the link above, then click on the 'Artifacts' dropdown and select '${{ env.JAR_FILENAME }}'." >> $GITHUB_STEP_SUMMARY
         
     - name: Create Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,13 @@ jobs:
         ./scripts/run-diff-cover.sh "origin/${{ github.base_ref }}" ./scripts/diff-cover.md ./scripts/diff-cover.html
       continue-on-error: true
 
+    - name: Upload Artifact
+      id: upload-shop-jar
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.JAR_FILENAME }}
+        path: target/Shop-*.jar
+        
     - name: Upload diff-cover HTML artifact
       if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
       id: upload-diff-cover-report
@@ -138,20 +145,21 @@ jobs:
         name: diff-cover-report.html
         path: scripts/diff-cover.html
 
-    - name: Upload Artifact
-      id: upload-shop-jar
-      uses: actions/upload-artifact@v4
+    - name: HTML Preview
+      if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      id: html_preview
+      uses: pavi2410/html-preview-action@v4
       with:
-        name: ${{ env.JAR_FILENAME }}
-        path: target/Shop-*.jar
-        
+        html_file: 'scripts/diff-cover.html'
+        job_summary: true
+
     - name: Create workflow summary
       run: |
         echo "# Build Completed Successfully! 🎉" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Version:** ${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
         if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
-          echo "**Diff Cover:** [View report](${{ steps.upload-diff-cover-report.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
+          echo "**Diff Cover:** [View report](${{ steps.html_preview.outputs.url }})" >> $GITHUB_STEP_SUMMARY
         fi
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Download Build" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,9 +161,11 @@ jobs:
           **/target/site/jacoco/jacoco.xml
         token: ${{ secrets.GITHUB_TOKEN }}
         min-coverage-overall: 0
-        min-coverage-changed-files: 0
+        min-coverage-changed-files: 30
         title: Coverage Report
         update-comment: true
+        pass-emoji: ':green_circle:'
+        fail-emoji: ':small_orange_diamond:'
       
     - name: Create Release
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,8 +111,7 @@ jobs:
     - name: Coverage Summary (Job Summary)
       uses: irongut/CodeCoverageSummary@v1.3.0
       with:
-        filename: |
-          **/target/site/jacoco/jacoco.xml
+        filename: '**/target/site/jacoco/jacoco.xml'
         badge: true
         format: markdown
         output: both

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,21 +134,23 @@ jobs:
 
     - name: Create workflow summary
       run: |
-        echo "# Build Completed Successfully! 🎉" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Version:** ${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
+        touch build-summary.md
+        echo "# Build Completed Successfully! 🎉" > build-summary.md
+        echo "" >> build-summary.md
+        echo "**Version:** ${{ env.VERSION }}" >> build-summary.md
         if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
-          echo "**Diff Cover:** [View report](${{ steps.upload-diff-cover-report.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
+          echo "**Diff Cover:** [View report](${{ steps.upload-diff-cover-report.outputs.artifact-url }})" >> build-summary.md
         fi
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### Download Build" >> $GITHUB_STEP_SUMMARY
-        echo "⬇️ [${{ env.JAR_FILENAME }}](${{ steps.upload-shop-jar.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "" >> build-summary.md
+        echo "### Download Build" >> build-summary.md
+        echo "⬇️ [${{ env.JAR_FILENAME }}](${{ steps.upload-shop-jar.outputs.artifact-url }})" >> build-summary.md
+        echo "" >> build-summary.md
+        cat build-summary.md >> $GITHUB_STEP_SUMMARY
 
     - name: Build Summary
       uses: marocchino/sticky-pull-request-comment@v2
       with:
-        path: $GITHUB_STEP_SUMMARY
+        path: build-summary.md
 
     - name: Comment PR with JaCoCo Coverage Report
       if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up JDK
       uses: actions/setup-java@v3
       with:
-        java-version: '22'  # Adjust based on your project requirements
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
         
@@ -55,6 +55,25 @@ jobs:
         echo "Updated version from $CURRENT_VERSION to $NEW_VERSION"
         echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV
         
+    - name: Generate Maven toolchains.xml (JDK 21)
+      run: |
+        mkdir -p ~/.m2
+        cat > ~/.m2/toolchains.xml <<'EOF'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <toolchains>
+          <toolchain>
+            <type>jdk</type>
+            <provides>
+              <version>21</version>
+              <vendor>any</vendor>
+            </provides>
+            <configuration>
+              <jdkHome>${JAVA_HOME}</jdkHome>
+            </configuration>
+          </toolchain>
+        </toolchains>
+        EOF
+
     - name: Build Maven Repository
       run: |
         chmod +x ./buildMavenRepo.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,14 @@ jobs:
       with:
         java-version: '21'
         distribution: 'temurin'
-        cache: maven
+
+    - name: Cache Maven repository (~/.m2/repository)
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-jdk21-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-jdk21-
         
     - name: Cache SpigotBuildTools
       uses: actions/cache@v3
@@ -74,9 +81,13 @@ jobs:
       run: |
         chmod +x ./buildMavenRepo.sh
         ./buildMavenRepo.sh
+    
+    - name: Pre-fetch Maven dependencies (go-offline)
+      run: |
+        mvn -B -Pcoverage -nsu -Drevision=${{ env.VERSION }} -DskipTests dependency:go-offline
       
     - name: Build with Maven
-      run: mvn -B -Pcoverage -Drevision=${{ env.VERSION }} clean verify
+      run: mvn -B -Pcoverage -nsu -T 1C -Drevision=${{ env.VERSION }} clean verify
 
     - name: Publish Test Results
       if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,6 +123,21 @@ jobs:
         verbose: true
         # no need for token, it's not required for our use case
       
+    - name: Generate diff-cover report
+      if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      run: |
+        chmod +x ./scripts/run-diff-cover.sh
+        ./scripts/run-diff-cover.sh "origin/${{ github.base_ref }}" ./scripts/diff-cover.md ./scripts/diff-cover.html
+      continue-on-error: true
+
+    - name: Upload diff-cover HTML artifact
+      if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+      id: upload-diff-cover-report
+      uses: actions/upload-artifact@v4
+      with:
+        name: diff-cover-report.html
+        path: scripts/diff-cover.html
+
     - name: Upload Artifact
       id: upload-shop-jar
       uses: actions/upload-artifact@v4
@@ -135,11 +150,14 @@ jobs:
         echo "# Build Completed Successfully! 🎉" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "**Version:** ${{ env.VERSION }}" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ github.event_name }}" = "pull_request" ] && [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+          echo "**Diff Cover:** [View report](${{ steps.upload-diff-cover-report.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
+        fi
         echo "" >> $GITHUB_STEP_SUMMARY
         echo "### Download Build" >> $GITHUB_STEP_SUMMARY
         echo "⬇️ [${{ env.JAR_FILENAME }}](${{ steps.upload-shop-jar.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        
+      
     - name: Create Release
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,15 @@ jobs:
         ./buildMavenRepo.sh
       
     - name: Build with Maven
-      run: mvn -B clean compile package
+      run: mvn -B clean test package
+
+    - name: Publish Test Results
+      if: always()
+      uses: dorny/test-reporter@v1
+      with:
+        name: JUnit Tests
+        path: '**/target/surefire-reports/*.xml'
+        reporter: java-junit
       
     - name: Upload Artifact
       id: upload-artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     
     steps:
     - uses: actions/checkout@v3
@@ -79,8 +82,8 @@ jobs:
         chmod +x ./buildMavenRepo.sh
         ./buildMavenRepo.sh
       
-    - name: Build with Maven
-      run: mvn -B clean test package
+    - name: Build with Maven (with coverage)
+      run: mvn -B -Pcoverage clean verify
 
     - name: Publish Test Results
       if: always()
@@ -89,6 +92,34 @@ jobs:
         name: JUnit Tests
         path: '**/target/surefire-reports/*.xml'
         reporter: java-junit
+
+    - name: Comment PR with JaCoCo Coverage Report
+      if: github.event_name == 'pull_request'
+      uses: madrapps/jacoco-report@v1.6.1
+      with:
+        paths: |
+          **/target/site/jacoco/jacoco.xml
+        token: ${{ secrets.GITHUB_TOKEN }}
+        min-coverage-overall: 0
+        min-coverage-changed-files: 0
+        title: Coverage Report
+        update-comment: true
+
+    - name: Upload JaCoCo XML
+      uses: actions/upload-artifact@v4
+      with:
+        name: jacoco-xml
+        path: '**/target/site/jacoco/jacoco.xml'
+        if-no-files-found: warn
+
+    - name: Coverage Summary (Job Summary)
+      uses: irongut/CodeCoverageSummary@v1.3.0
+      with:
+        filename: |
+          **/target/site/jacoco/jacoco.xml
+        badge: true
+        format: markdown
+        output: both
       
     - name: Upload Artifact
       id: upload-artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      checks: write
     
     steps:
     - uses: actions/checkout@v3
@@ -82,20 +83,24 @@ jobs:
         chmod +x ./buildMavenRepo.sh
         ./buildMavenRepo.sh
       
-    - name: Build with Maven (with coverage)
+    - name: Build with Maven
       run: mvn -B -Pcoverage clean verify
 
     - name: Publish Test Results
-      if: always()
+      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: dorny/test-reporter@v1
+      continue-on-error: true
       with:
         name: JUnit Tests
         path: '**/target/surefire-reports/*.xml'
         reporter: java-junit
+        fail-on-error: false
+        fail-on-empty: false
 
     - name: Comment PR with JaCoCo Coverage Report
-      if: github.event_name == 'pull_request'
+      if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: madrapps/jacoco-report@v1.6.1
+      continue-on-error: true
       with:
         paths: |
           **/target/site/jacoco/jacoco.xml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,31 +32,22 @@ jobs:
       with:
         path: |
           ./SpigotBuildTools
-          ./m2repo
         key: ${{ runner.os }}-spigot-${{ hashFiles('buildMavenRepo.sh', 'buildMavenRepo.Dockerfile') }}
         restore-keys: |
           ${{ runner.os }}-spigot-
         
-    - name: Update version with commit hash
+    - name: Compute version with commit hash
       run: |
-        # Get the commit hash based on the event type
         if [ "${{ github.event_name }}" = "pull_request" ]; then
           COMMIT_HASH=${{ github.event.pull_request.head.sha }}
         else
           COMMIT_HASH=${{ github.sha }}
         fi
         COMMIT_HASH=${COMMIT_HASH:0:7}
-        
-        # Read the current version from pom.xml
+
         CURRENT_VERSION=$(grep -m 1 "<revision>" pom.xml | sed 's/.*<revision>\(.*\)<\/revision>.*/\1/')
-        
-        # Create new version with commit hash
         NEW_VERSION="${CURRENT_VERSION}-${COMMIT_HASH}"
-        
-        # Update the version in pom.xml
-        sed -i "s/<revision>$CURRENT_VERSION<\/revision>/<revision>$NEW_VERSION<\/revision>/" pom.xml
-        
-        echo "Updated version from $CURRENT_VERSION to $NEW_VERSION"
+
         echo "VERSION=$NEW_VERSION" >> $GITHUB_ENV
         
     - name: Generate Maven toolchains.xml (JDK 21)
@@ -84,7 +75,7 @@ jobs:
         ./buildMavenRepo.sh
       
     - name: Build with Maven
-      run: mvn -B -Pcoverage clean verify
+      run: mvn -B -Pcoverage -Drevision=${{ env.VERSION }} clean verify
 
     - name: Publish Test Results
       if: always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dependency-reduced-pom.xml
 SpigotBuildTools
 */node_modules
 .vscode/settings.json
+scripts/diff-cover.html
+scripts/diff-cover.md

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "ryanluker.vscode-coverage-gutters"
+  ]
+}
+

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build and Package",
+      "type": "shell",
+      "command": "mvn clean package",
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    }
+  ]
+}
+

--- a/compile.sh
+++ b/compile.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 export MAVEN_OPTS="-Xms2g -Xmx4g"
-mvn clean compile package -T 2C
+mvn clean package -T 2C

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -93,6 +93,27 @@
             <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockbukkit.mockbukkit</groupId>
+            <artifactId>mockbukkit-v1.21</artifactId>
+            <version>4.0.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- (binds Hikari / other libs during MockBukkit runtime to prevent errors) -->
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <!-- Paper API added for MockBukkit 4 runtime classes -->
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${spigot.version}</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <!-- Core Dependencies -->
         <dependency>
@@ -222,11 +243,49 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.1.2</version>
+                    <configuration>
+                        <!-- When we eventually drop the compile target to Java 8, MockBukkit (still on 21) may
+                             need reflective access to JDK internals.  Keep the add-opens flag now so we don’t
+                             forget later.  Harmless on 17+ runtimes. -->
+                        <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                        <!-- Parallel test execution -->
+                        <parallel>methods</parallel>
+                        <forkCount>1</forkCount>
+                        <reuseForks>true</reuseForks>
+                        <!-- Ensure JDK 21 is available for tests because MockBukkit 4 requires 21 -->
+                        <jdkToolchain>
+                            <version>21</version>
+                            <vendor>any</vendor>
+                        </jdkToolchain>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
+            <!-- Toolchains plugin: ensure JDK 21 is available for tests because MockBukkit 4 requires 21, but we still want to compile with a lower Java target in mind -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>toolchain</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <toolchains>
+                        <jdk>
+                            <version>21</version>
+                            <vendor>any</vendor>
+                        </jdk>
+                    </toolchains>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -376,7 +376,8 @@
 
     <properties>
         <spigot.version>1.21.1-R0.1-SNAPSHOT</spigot.version>
-        <argLine></argLine>
+        <!-- need to uncomment if you run without the `-Pcoverage` flag -->
+        <!-- <argLine></argLine> -->
     </properties>
 
     <profiles>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,34 +19,6 @@
 
     <repositories>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
-            <id>jitpack.io</id>
-            <url>https://jitpack.io</url>
-        </repository>
-        <repository>
-            <id>sk89q-repo</id>
-            <url>https://maven.enginehub.org/repo/</url>
-        </repository>
-        <repository>
-            <id>ender-zone-repo</id>
-            <url>https://ci.ender.zone/plugin/repository/everything/</url>
-        </repository>
-        <repository>
-            <id>dynmap-repo</id>
-            <url>https://repo.mikeprimm.com/</url>
-        </repository>
-        <repository>
-            <id>codemc-repo</id>
-            <url>https://repo.codemc.org/repository/maven-public/</url>
-        </repository>
-        <repository>
-            <id>bluecolored</id>
-            <url>https://repo.bluecolored.de/releases</url>
-        </repository>
-        <repository>
             <id>central</id>
             <name>Central Repository</name>
             <url>https://repo.maven.apache.org/maven2</url>
@@ -58,6 +30,34 @@
         <repository>
             <id>papermc</id>
             <url>https://repo.papermc.io/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>spigot-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
+            <id>codemc-repo</id>
+            <url>https://repo.codemc.org/repository/maven-public/</url>
+        </repository>
+        <repository>
+            <id>sk89q-repo</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
+        <repository>
+            <id>bluecolored</id>
+            <url>https://repo.bluecolored.de/releases</url>
+        </repository>
+        <repository>
+            <id>dynmap-repo</id>
+            <url>https://repo.mikeprimm.com/</url>
+        </repository>
+        <repository>
+            <id>ender-zone-repo</id>
+            <url>https://ci.ender.zone/plugin/repository/everything/</url>
+        </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 
@@ -286,6 +286,36 @@
                     </toolchains>
                 </configuration>
             </plugin>
+            <!-- Always enable JaCoCo agent and reporting by default -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.11</version>
+                <configuration>
+                    <propertyName>argLine</propertyName>
+                    <append>true</append>
+                    <output>file</output>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${project.build.directory}/jacoco.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -376,47 +406,10 @@
 
     <properties>
         <spigot.version>1.21.1-R0.1-SNAPSHOT</spigot.version>
-        <!-- need to uncomment if you run without the `-Pcoverage` flag -->
-        <!-- <argLine></argLine> -->
     </properties>
 
     <profiles>
-        <profile>
-            <id>coverage</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.jacoco</groupId>
-                        <artifactId>jacoco-maven-plugin</artifactId>
-                        <version>0.8.11</version>
-                        <configuration>
-                            <propertyName>argLine</propertyName>
-                            <append>true</append>
-                            <output>file</output>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>prepare-agent</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>prepare-agent</goal>
-                                </goals>
-                                <configuration>
-                                    <destFile>${project.build.directory}/jacoco.exec</destFile>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>report</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>report</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+        
         <profile>
             <id>coverage-report</id>
             <build>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -250,7 +250,7 @@
                         <!-- When we eventually drop the compile target to Java 8, MockBukkit (still on 21) may
                              need reflective access to JDK internals.  Keep the add-opens flag now so we don’t
                              forget later.  Harmless on 17+ runtimes. -->
-                        <argLine>--add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                        <argLine>${argLine} --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
                         <!-- Parallel test execution -->
                         <parallel>methods</parallel>
                         <forkCount>1</forkCount>
@@ -322,6 +322,22 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- Ensure Surefire picks up ${argLine} (JaCoCo agent) in this module -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <argLine>${argLine} --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <parallel>methods</parallel>
+                    <forkCount>1</forkCount>
+                    <reuseForks>true</reuseForks>
+                    <jdkToolchain>
+                        <version>21</version>
+                        <vendor>any</vendor>
+                    </jdkToolchain>
+                </configuration>
+            </plugin>
 <!--            <plugin>-->
 <!--                <groupId>net.md-5</groupId>-->
 <!--                <artifactId>specialsource-maven-plugin</artifactId>-->
@@ -360,6 +376,67 @@
 
     <properties>
         <spigot.version>1.21.1-R0.1-SNAPSHOT</spigot.version>
+        <argLine></argLine>
     </properties>
+
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.11</version>
+                        <configuration>
+                            <propertyName>argLine</propertyName>
+                            <append>true</append>
+                            <output>file</output>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <destFile>${project.build.directory}/jacoco.exec</destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>coverage-report</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.11</version>
+                        <executions>
+                            <execution>
+                                <id>report-only</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -1010,6 +1010,13 @@ public class Shop extends JavaPlugin {
         return offlinePurchaseNotificationsEnabled;
     }
 
+    private Boolean isMockBukkit = null;
+    public boolean isMockBukkit() { 
+        if (this.isMockBukkit == null) {
+            this.isMockBukkit = plugin.getServer().getClass().getPackage().getName().contains("mockbukkit");
+        }
+        return this.isMockBukkit;
+    }
     public boolean getDebug_allowUseOwnShop() { return debug_allowUseOwnShop; }
     public boolean getDebug_transactionDebugLogs() { return debug_transactionDebugLogs; }
     public int getDebug_shopCreateCooldown() { return debug_shopCreateCooldown; }

--- a/core/src/main/java/com/snowgears/shop/Shop.java
+++ b/core/src/main/java/com/snowgears/shop/Shop.java
@@ -138,6 +138,9 @@ public class Shop extends JavaPlugin {
     private boolean debug_transactionDebugLogs;
     private int debug_shopCreateCooldown;
     private boolean debug_forceResaveAll;
+
+    private Metrics metrics;
+
     public static Shop getPlugin() {
         return plugin;
     }
@@ -625,7 +628,7 @@ public class Shop extends JavaPlugin {
         }
 
         int bstatsPluginId = 25211;
-        Metrics metrics = new Metrics(plugin, bstatsPluginId);
+        metrics = new Metrics(plugin, bstatsPluginId);
         // transactions would be cool
         // It would also be cool to see the number of items transacted (bought/sold & item currency)
         // I don't think showing vault currency is worth it, since people have vastly different economy scaling
@@ -816,6 +819,10 @@ public class Shop extends JavaPlugin {
 
         // Save player name cache to ensure no data loss
         PlayerNameCache.saveToFile();
+
+        // shutdown the database
+        if (logHandler != null) logHandler.shutdown();
+        if (metrics != null) metrics.shutdown();
 
         this.getLogger().info("Disabled Shop " + this.getDescription().getVersion());
     }

--- a/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
+++ b/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
@@ -29,26 +29,17 @@ public abstract class AbstractDisplay {
     protected DisplayType type;
     protected HashMap<UUID, ArrayList<Integer>> entityIDs; //player UUID. display entities
     protected HashMap<UUID, ArrayList<Integer>> displayTagEntityIDs; //player UUID. display tags
-    protected int chunkX;
-    protected int chunkZ;
 
     public AbstractDisplay(Location shopSignLocation) {
         this.shopSignLocation = shopSignLocation;
         entityIDs = new HashMap<>();
         displayTagEntityIDs = new HashMap<>();
-
-        chunkX = UtilMethods.floor(shopSignLocation.getBlockX()) >> 4;
-        chunkZ = UtilMethods.floor(shopSignLocation.getBlockZ()) >> 4;
     }
 
     public boolean isEnabled() { return true; }
 
-    public boolean isInChunk(Chunk chunk){
-        return chunk.getX() == chunkX && chunk.getZ() == chunkZ && chunk.getWorld().toString().equals(shopSignLocation.getWorld().toString());
-    }
-
     public boolean isChunkLoaded(){
-        return shopSignLocation.getWorld() != null && shopSignLocation.getWorld().isChunkLoaded(this.chunkX, this.chunkZ);
+        return UtilMethods.isChunkLoaded(this.shopSignLocation);
     }
 
     //spawns a floating item packet for a specific player

--- a/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
+++ b/core/src/main/java/com/snowgears/shop/display/AbstractDisplay.java
@@ -417,8 +417,10 @@ public abstract class AbstractDisplay {
     }
 
     public void remove(Player player) {
-        removeDisplayEntities(player, false);
-        removeDisplayEntities(player, true);
+        try {
+            removeDisplayEntities(player, false);
+            removeDisplayEntities(player, true);
+        } catch (Error | Exception e) { /** Allow other logic to continue even if this fails (non-critical) */ }
 
 //        if(player != null) {
 //            Shop.getPlugin().getShopHandler().removeActiveShopDisplay(player, this.shopSignLocation);

--- a/core/src/main/java/com/snowgears/shop/display/Display.java
+++ b/core/src/main/java/com/snowgears/shop/display/Display.java
@@ -164,22 +164,26 @@ public class Display extends AbstractDisplay {
     }
 
     private void sendPacket(Player player, Packet packet){
-        if (player != null) {
-            if(isSameWorld(player)) {
-                ServerPlayerConnection connection = (ServerPlayerConnection) Shop.getPlugin().getShopHandler().getCachedPlayerConnection(player);
-                if (connection != null) {
-                    connection.send(packet); //sendPacket()
-                    //System.out.println("Sending player a packet: "+packet.getClass().toString());
+        try {
+            if (player != null) {
+                if(isSameWorld(player)) {
+                    ServerPlayerConnection connection = (ServerPlayerConnection) Shop.getPlugin().getShopHandler().getCachedPlayerConnection(player);
+                    if (connection != null) {
+                        connection.send(packet); //sendPacket()
+                        //System.out.println("Sending player a packet: "+packet.getClass().toString());
+                    }
                 }
             }
-        }
-        else {
-            for (Player onlinePlayer : this.shopSignLocation.getWorld().getPlayers()) {
-                ServerPlayerConnection connection = (ServerPlayerConnection) Shop.getPlugin().getShopHandler().getCachedPlayerConnection(onlinePlayer);
-                if(connection != null) {
-                    connection.send(packet); //sendPacket
+            else {
+                for (Player onlinePlayer : this.shopSignLocation.getWorld().getPlayers()) {
+                    ServerPlayerConnection connection = (ServerPlayerConnection) Shop.getPlugin().getShopHandler().getCachedPlayerConnection(onlinePlayer);
+                    if(connection != null) {
+                        connection.send(packet); //sendPacket
+                    }
                 }
             }
+        } catch (Error | Exception e) {
+            Shop.getPlugin().getLogger().severe("Unknown error sending packet to player for Display (Item/Hologram text), error message: " + e.getMessage());
         }
     }
 

--- a/core/src/main/java/com/snowgears/shop/handler/LogHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/LogHandler.java
@@ -34,7 +34,13 @@ public class LogHandler {
     public LogHandler(Shop plugin, YamlConfiguration shopConfig){
         this.plugin = plugin;
         // Setup database connection and check if we should enable database logging
-        defineDataSource(shopConfig);
+        try {
+            defineDataSource(shopConfig);
+        } catch (Error | Exception e) {
+            plugin.getLogger().log(Level.WARNING, "Error initializing database connection. Database logging will not be used. Exception: " + e.getMessage());
+            this.enabled = false;
+            return;
+        }
 
         if(!enabled)
             return;

--- a/core/src/main/java/com/snowgears/shop/handler/LogHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/LogHandler.java
@@ -35,7 +35,7 @@ public class LogHandler {
         this.plugin = plugin;
         // Setup database connection and check if we should enable database logging
         try {
-            defineDataSource(shopConfig);
+            startup(shopConfig);
         } catch (Error | Exception e) {
             plugin.getLogger().log(Level.WARNING, "Error initializing database connection. Database logging will not be used. Exception: " + e.getMessage());
             this.enabled = false;
@@ -75,7 +75,7 @@ public class LogHandler {
         plugin.getLogger().helpful("Offline Purchase Notifications are Enabled!");
     }
 
-    public void defineDataSource(YamlConfiguration shopConfig){
+    public void startup(YamlConfiguration shopConfig){
         String type = shopConfig.getString("logging.type");
         String serverName = shopConfig.getString("logging.serverName");
         String databaseName = shopConfig.getString("logging.databaseName");
@@ -141,6 +141,12 @@ public class LogHandler {
         }
 
         this.enabled = true;
+    }
+
+    public void shutdown() {
+        if (dataSource != null) {
+            dataSource.close();
+        }
     }
 
     public void logAction(Player player, AbstractShop shop, ShopActionType actionType) {

--- a/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
@@ -90,7 +90,7 @@ public class ShopHandler {
         }, 10);
     }
 
-    private void disableDisplayClass() {
+    public void disableDisplayClass() {
         try {
             final Class<?> clazz = Class.forName("com.snowgears.shop.display.DisplayDisabled");
             if (AbstractDisplay.class.isAssignableFrom(clazz))

--- a/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
@@ -129,7 +129,7 @@ public class ShopHandler {
             String nmsVersion = packageName.substring(packageName.lastIndexOf('.') + 1);
 
             // MockBukkit testing does not support NMS, so we need to just return early
-            if (nmsVersion.equals("mockbukkit")) {
+            if (plugin.isMockBukkit()) {
                 disableDisplayClass();
                 return false;
             }

--- a/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
@@ -568,8 +568,12 @@ public class ShopHandler {
         // Filter by distance
         for (Location shopLocation : nearbyLocations) {
             // Using distanceSquared is more efficient than distance
-            if (location.distanceSquared(shopLocation) <= maxDistanceSquared) {
-                filteredLocations.add(shopLocation);
+            try {
+                if (location.distanceSquared(shopLocation) <= maxDistanceSquared) {
+                    filteredLocations.add(shopLocation);
+                }
+            } catch (Exception e) {
+                // distanceSquared does not exist in MockBukkit and this is the easiest way to disable it
             }
         }
         

--- a/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
@@ -128,6 +128,12 @@ public class ShopHandler {
             // We are still on an older version, so go ahead
             String nmsVersion = packageName.substring(packageName.lastIndexOf('.') + 1);
 
+            // MockBukkit testing does not support NMS, so we need to just return early
+            if (nmsVersion.equals("mockbukkit")) {
+                disableDisplayClass();
+                return false;
+            }
+
             // version did remap even though version number didn't increase
             String mcVersion = Bukkit.getBukkitVersion().substring(0, Bukkit.getBukkitVersion().indexOf('-'));
             //im not doing this right now. I'm only going to support 1.17.1 for now

--- a/core/src/main/java/com/snowgears/shop/handler/TransactionHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/TransactionHandler.java
@@ -122,11 +122,6 @@ public class TransactionHandler {
         //the transaction has finished and the exchange event has not been cancelled
         sendExchangeMessagesAndLog(shop, player, actionType, transaction);
         shop.sendEffects(true, player);
-        //make sure to update the shop sign, but only if the sign lines use a variable that requires a refresh (like stock that is dynamically updated)
-        if(shop.getSignLinesRequireRefresh()){
-            plugin.getLogger().trace("[TransactionHandler.executeTransactionSequence] updateSign");
-            shop.updateSign();
-        }
     }
 
     private void sendErrorMessage(Player player, AbstractShop shop, ShopType actionType, Transaction transaction) {

--- a/core/src/main/java/com/snowgears/shop/hook/ARMHookListener.java
+++ b/core/src/main/java/com/snowgears/shop/hook/ARMHookListener.java
@@ -37,7 +37,7 @@ public class ARMHookListener implements Listener {
                 if (shop != null && shop.getSignLocation() != null && shop.getSignLocation().getWorld().getName().equals(region.getRegionworld().getName())) {
                     if (region.getRegion().contains(shop.getSignLocation().getBlockX(), shop.getSignLocation().getBlockY(), shop.getSignLocation().getBlockZ())) {
                         plugin.getLogger().notice("Deleting Shop because ARM region is being restored! " + shop);
-                        shop.delete();
+                        shop.delete(false); // delay the save and do it below
                         shopOwnersToSave.add(shopOwnerUUID);
                         shopsDeleted++;
                     }
@@ -45,6 +45,7 @@ public class ARMHookListener implements Listener {
             }
         }
 
+        // save any shop owner files (since we delayed save earlier)
         for(UUID shopOwner : shopOwnersToSave) {
             plugin.getShopHandler().saveShops(shopOwner, true);
         }

--- a/core/src/main/java/com/snowgears/shop/hook/PlotSquaredHookListener.java
+++ b/core/src/main/java/com/snowgears/shop/hook/PlotSquaredHookListener.java
@@ -50,7 +50,7 @@ public class PlotSquaredHookListener implements Listener {
                         );
                         if (plot.getArea().contains(location)) {
                             plugin.getLogger().notice("Deleting Shop because PlotSquared Plot is being reset! " + shop);
-                            shop.delete();
+                            shop.delete(false); // delay the save and do it below
                             shopOwnersToSave.add(shopOwnerUUID);
                             shopsDeleted++;
                         }
@@ -59,6 +59,7 @@ public class PlotSquaredHookListener implements Listener {
             }
         }
 
+        // save any shop owner files (since we delayed save earlier)
         for(UUID shopOwner : shopOwnersToSave) {
             plugin.getShopHandler().saveShops(shopOwner, true);
         }

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -370,7 +370,7 @@ public class MiscListener implements Listener {
                 Arrays.asList(ShopType.values()).forEach((shopType -> autocomplete.add(shopType.toString().toLowerCase())));
                 try {
                     player.setCustomChatCompletions(autocomplete);
-                } catch (Error error) {} // Suppress error if autocomplete is not supported
+                } catch (Error | Exception error) {} // Suppress error if autocomplete is not supported
                 if((!plugin.usePerms() && player.isOp()) || (plugin.usePerms() && player.hasPermission("shop.operator"))) {
                     ShopMessage.sendMessage("adminCreateHitChest", null, process, player);
                 }

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -213,6 +213,10 @@ public class MiscListener implements Listener {
     }
 
     public boolean isChestInShopCreationProcess(Location location) {
+        for (ShopCreationProcess process : playerChatCreationSteps.values()) {
+            if (process.getClickedChest().getLocation().equals(location)) {
+                return true;
+            }
         }
         return false;
     }
@@ -270,7 +274,6 @@ public class MiscListener implements Listener {
                 if(!plugin.getAllowCreationMethodChest())
                     return;
 
-                //TODO also protect the chest if its in the middle of a chat creation process
                 //dont let players create shops via chest on shops that already exist
                 // This check is also required for chests to be destroyed properly without new shops getting created. This is because PlayerInteractEvent is called before BlockBreakEvent.
                 AbstractShop existingShop = plugin.getShopHandler().getShopByChest(clicked);
@@ -642,6 +645,13 @@ public class MiscListener implements Listener {
                     event.setCancelled(true);
             }
         } else if (plugin.getShopHandler().isChest(b)) {
+            // Shop will not exist in ShopHandler if it is in the middle of a shop creation process
+            // protect shops that are in the middle of a shop creation process from being destroyed
+            if (this.isChestInShopCreationProcess(b.getLocation())) {
+                ShopMessage.sendMessage("interactionIssue", "destroyUninitializedChest", player, null);
+                event.setCancelled(true); // don't break chest
+                return;
+            }
 
             AbstractShop shop = plugin.getShopHandler().getShopByChest(b);
             if (shop == null) {

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -344,12 +344,10 @@ public class MiscListener implements Listener {
                         return;
                     }
                 }
-                // Cleanup the last process if needed and assume the player wants to start a new process
-                ShopCreationProcess lastProcess = playerChatCreationSteps.get(player.getUniqueId());
-                if (lastProcess != null) {
-                    // Send the player a message that the creation was cancelled so that they understand that a new one is starting
-                    ShopMessage.sendMessage("interactionIssue", "createCancel", player, null);
-                    lastProcess.cleanup(); // removes floating displays
+                // Cleanup the last process if needed and cancel the existing shop creation process if it exists
+                if (playerChatCreationSteps.get(player.getUniqueId()) != null) {
+                    this.cancelShopCreationProcess(player);
+                    return;
                 }
 
                 BlockFace signFacing = plugin.getShopCreationUtil().calculateBlockFaceForSign(player, clicked, event.getBlockFace());

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -639,8 +639,10 @@ public class MiscListener implements Listener {
 
                     ShopMessage.sendMessage(shop.getType().toString(), "opDestroy", player, shop);
                     shop.delete();
-                } else
+                } else {
                     event.setCancelled(true);
+                    ShopMessage.sendMessage("permission", "destroyOther", player, shop);
+                }
             }
         } else if (plugin.getShopHandler().isChest(b)) {
             // Shop will not exist in ShopHandler if it is in the middle of a shop creation process

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -640,8 +640,8 @@ public class MiscListener implements Listener {
                     ShopMessage.sendMessage(shop.getType().toString(), "opDestroy", player, shop);
                     shop.delete();
                 } else {
-                    event.setCancelled(true);
                     ShopMessage.sendMessage("permission", "destroyOther", player, shop);
+                    event.setCancelled(true);
                 }
             }
         } else if (plugin.getShopHandler().isChest(b)) {
@@ -693,6 +693,8 @@ public class MiscListener implements Listener {
                 if(shop.getOwnerUUID().equals(player.getUniqueId()) || player.isOp() || (plugin.usePerms() && (player.hasPermission("shop.operator") || player.hasPermission("shop.destroy.other")))) {
                     ShopMessage.sendMessage("interactionIssue", "destroyChest", player, shop);
                     shop.sendEffects(false, player);
+                } else {
+                    ShopMessage.sendMessage("permission", "destroyOther", player, shop);
                 }
                 // event.setCancelled(true);
             }

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -665,7 +665,7 @@ public class MiscListener implements Listener {
             InventoryHolder ih = ((InventoryHolder)b.getState()).getInventory().getHolder();
 
             if (ih instanceof DoubleChest) {
-                if(shop.getOwnerUUID().equals(player.getUniqueId()) || player.isOp() || (plugin.usePerms() && player.hasPermission("shop.operator"))){
+                if(shop.getOwnerUUID().equals(player.getUniqueId()) || player.isOp() || (plugin.usePerms() && (player.hasPermission("shop.operator") || player.hasPermission("shop.destroy.other")))){
 
                     // the broken block was the initial chest with the sign
                     if(shop.getChestLocation().equals(b.getLocation())){
@@ -690,7 +690,7 @@ public class MiscListener implements Listener {
                 }
             }
             else{
-                if(shop.getOwnerUUID().equals(player.getUniqueId()) || player.isOp() || (plugin.usePerms() && player.hasPermission("shop.operator"))) {
+                if(shop.getOwnerUUID().equals(player.getUniqueId()) || player.isOp() || (plugin.usePerms() && (player.hasPermission("shop.operator") || player.hasPermission("shop.destroy.other")))) {
                     ShopMessage.sendMessage("interactionIssue", "destroyChest", player, shop);
                     shop.sendEffects(false, player);
                 }

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -169,7 +169,7 @@ public class MiscListener implements Listener {
                 plugin.getFoliaLib().getScheduler().runLater(() -> {
                     //the shop has still not been initialized with an item from a player
                     if (!shop.isInitialized()) {
-                        plugin.getShopHandler().removeShop(shop);
+                        shop.delete();
                         if (b.getBlockData() instanceof WallSign) {
                             String[] lines = ShopMessage.getTimeoutSignLines(shop);
                             Sign sign = (Sign) b.getState();
@@ -612,7 +612,6 @@ public class MiscListener implements Listener {
                 ShopMessage.sendMessage(shop.getType().toString(), "destroy", player, shop);
                 // We already log on ShopActionType.DESTROY in the Log Handler, so don't log the shop destroy reason
                 shop.delete();
-                plugin.getShopHandler().saveShops(shop.getOwnerUUID(), true);
 
                 return;
             }
@@ -640,7 +639,6 @@ public class MiscListener implements Listener {
 
                     ShopMessage.sendMessage(shop.getType().toString(), "opDestroy", player, shop);
                     shop.delete();
-                    plugin.getShopHandler().saveShops(shop.getOwnerUUID(), true);
                 } else
                     event.setCancelled(true);
             }

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -687,6 +687,9 @@ public class MiscListener implements Listener {
                         event.setCancelled(false);
                         return;
                     }
+                } else {
+                    ShopMessage.sendMessage("permission", "destroyOther", player, shop);
+                    event.setCancelled(true);
                 }
             }
             else{

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -171,7 +171,7 @@ public class MiscListener implements Listener {
                     if (!shop.isInitialized()) {
                         shop.delete();
                         if (b.getBlockData() instanceof WallSign) {
-                            String[] lines = ShopMessage.getTimeoutSignLines(shop);
+                            String[] lines = ShopMessage.getSignLines("timeout", shop);
                             Sign sign = (Sign) b.getState();
                             sign.setLine(0, lines[0]);
                             sign.setLine(1, lines[1]);

--- a/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/ShopListener.java
@@ -346,13 +346,10 @@ public class ShopListener implements Listener {
                     long hoursSinceLastPlayed = TimeUnit.MILLISECONDS.toHours(msSinceLastPlayed);
 
                     if (hoursSinceLastPlayed >= plugin.getHoursOfflineToRemoveShops()) {
-                        boolean deletedShop = false;
                         for (AbstractShop shop : plugin.getShopHandler().getShops(offlinePlayer.getUniqueId())) {
                             plugin.getLogger().notice("Deleting Shop because player " + offlinePlayer.getName() + " has not logged in within the required " + (int) hoursSinceLastPlayed + " hours! " + shop);
                             shop.delete();
-                            deletedShop = true;
                         }
-                        if (deletedShop) { plugin.getShopHandler().saveShops(offlinePlayer.getUniqueId(), true); }
                     }
                 }
             }

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -135,12 +135,6 @@ public abstract class AbstractShop {
 
     //this calls BlockData which loads the chunk the shop is in by doing so
     public boolean load() {
-        if (signLocation == null) {
-            Shop.getPlugin().getLogger().warning("Error attempting to load shop! No sign location found for Shop, deleting shop: " + this);
-            this.delete();
-            return false;
-        }
-        
         try {
             Block signBlock = signLocation.getBlock();
             if (signBlock.getType() == Material.AIR) {
@@ -154,9 +148,9 @@ public abstract class AbstractShop {
                 return false;
             }
             facing = ((WallSign) signBlock.getBlockData()).getFacing();
-            chestLocation = signBlock.getRelative(facing.getOppositeFace()).getLocation();
-            Block chestBlock = chestLocation.getBlock();
-            
+            Block chestBlock = signBlock.getRelative(facing.getOppositeFace());
+            chestLocation = chestBlock.getLocation();
+
             if (!Shop.getPlugin().getShopHandler().isChest(chestBlock)){
                 Shop.getPlugin().getLogger().warning("Error attempting to load shop! Invalid block type detected when trying to load Shop Chest (detected: " + chestBlock.getType() + "), deleting shop: " + this);
                 this.delete();

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -558,7 +558,8 @@ public abstract class AbstractShop {
     }
 
     public void delete() {
-        display.remove(null);
+        // First, remove the shop from the shop handler in case of any errors with later methods.
+        Shop.getPlugin().getShopHandler().removeShop(this);
 
         if(UtilMethods.isMCVersion17Plus() && Shop.getPlugin().getDisplayLightLevel() > 0) {
             Block displayBlock = this.getChestLocation().getBlock().getRelative(BlockFace.UP);
@@ -577,8 +578,8 @@ public abstract class AbstractShop {
             signBlock.update(true);
         }
 
-        //finally remove the shop from the shop handler
-        Shop.getPlugin().getShopHandler().removeShop(this);
+        // Finally, remove any active displays
+        display.remove(null);
         Shop.getPlugin().getLogger().debug("Deleted Shop " + this);
     }
 

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -557,30 +557,41 @@ public abstract class AbstractShop {
         }, 2);
     }
 
-    public void delete() {
-        // First, remove the shop from the shop handler in case of any errors with later methods.
-        Shop.getPlugin().getShopHandler().removeShop(this);
+    public void delete() { this.delete(true); }
+    public void delete(boolean forceSave) {
+        try {
+            // First, remove the shop from the shop handler in case of any errors with later methods.
+            Shop.getPlugin().getShopHandler().removeShop(this, forceSave);
 
-        if(UtilMethods.isMCVersion17Plus() && Shop.getPlugin().getDisplayLightLevel() > 0) {
-            Block displayBlock = this.getChestLocation().getBlock().getRelative(BlockFace.UP);
-            if(UtilMethods.materialIsNonIntrusive(displayBlock.getType())) {
-                displayBlock.setType(Material.AIR);
+            if(UtilMethods.isMCVersion17Plus() && Shop.getPlugin().getDisplayLightLevel() > 0 && this.getChestLocation() != null) {
+                Block chestBlock = this.getChestLocation().getBlock();
+                if (chestBlock != null && Shop.getPlugin().getShopHandler().isChest(chestBlock)) {
+                    Block displayBlock = chestBlock.getRelative(BlockFace.UP);
+                    if(UtilMethods.materialIsNonIntrusive(displayBlock.getType())) {
+                        displayBlock.setType(Material.AIR);
+                    }
+                }
             }
-        }
 
-        Block b = this.getSignLocation().getBlock();
-        if (b.getBlockData() instanceof WallSign) {
-            Sign signBlock = (Sign) b.getState();
-            signBlock.setLine(0, "");
-            signBlock.setLine(1, "");
-            signBlock.setLine(2, "");
-            signBlock.setLine(3, "");
-            signBlock.update(true);
-        }
+            Block b = this.getSignLocation().getBlock();
+            if (b.getBlockData() instanceof WallSign) {
+                Sign signBlock = (Sign) b.getState();
+                signBlock.setLine(0, "");
+                signBlock.setLine(1, "");
+                signBlock.setLine(2, "");
+                signBlock.setLine(3, "");
+                signBlock.update(true);
+            }
 
-        // Finally, remove any active displays
-        display.remove(null);
-        Shop.getPlugin().getLogger().debug("Deleted Shop " + this);
+            // Finally, remove any active displays
+            if (display != null) {
+                display.remove(null);
+            }
+            Shop.getPlugin().getLogger().debug("Deleted Shop " + this);
+        } catch (Error | Exception e) {
+            Shop.getPlugin().getLogger().severe("Unknown error attempting to delete shop, deletion might not have fully completed successfully: " + e.getMessage());
+            Shop.getPlugin().getLogger().debug("Full stack trace for shop deletion error: ", e);
+        }
     }
 
     public void teleportPlayer(Player player){

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -5,7 +5,6 @@ import com.snowgears.shop.display.AbstractDisplay;
 import com.snowgears.shop.handler.ShopGuiHandler;
 import com.snowgears.shop.util.*;
 import net.md_5.bungee.api.ChatColor;
-import net.md_5.bungee.api.chat.*;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -28,7 +27,6 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
 
 import java.util.*;
-import java.util.logging.Level;
 
 import static com.snowgears.shop.util.UtilMethods.isMCVersion17Plus;
 
@@ -36,6 +34,7 @@ public abstract class AbstractShop {
 
     protected UUID id = UUID.randomUUID();
     protected boolean needsSave = false;
+    protected boolean isLoaded = false;
     protected Location signLocation;
     protected Location chestLocation;
     protected BlockFace facing;
@@ -133,6 +132,10 @@ public abstract class AbstractShop {
         return id;
     }
 
+    public boolean isChunkLoaded() {
+        return UtilMethods.isChunkLoaded(this.getSignLocation());
+    }
+
     //this calls BlockData which loads the chunk the shop is in by doing so
     public boolean load() {
         try {
@@ -159,6 +162,7 @@ public abstract class AbstractShop {
             // Now that we are loaded, we can update the stock
             this.updateStock();
             Shop.getPlugin().getLogger().debug("Loaded shop successfully: " + this);
+            isLoaded = true;
             return true;
         } catch (Error | Exception error) {
             //this shop has no sign on it. return false
@@ -192,11 +196,11 @@ public abstract class AbstractShop {
                 stock = -1;
             return stock;
         }
-        stock = InventoryUtils.getAmount(this.getInventory(), this.getItemStack()) / this.getAmount();
+        int itemsInShop = InventoryUtils.getAmount(this.getInventory(), this.getItemStack());
+        stock = itemsInShop / this.getAmount();
         if(stock == 0 && Shop.getPlugin().getAllowPartialSales()){
             // Calculate the minimum items required to show as in stock
             int minItemAmountRequired = (int) Math.ceil(1 / this.getPricePerItem());
-            int itemsInShop = InventoryUtils.getAmount(this.getInventory(), this.getItemStack());
 
             if(itemsInShop >= minItemAmountRequired){
                 stock = 1;
@@ -214,9 +218,8 @@ public abstract class AbstractShop {
         // Update sign if needed
         boolean hasStockChange = stock != oldStock;
         if(hasStockChange){
-            signLinesRequireRefresh = true;
             Shop.getPlugin().getLogger().trace("[AbstractShop.updateStock] updateSign, new stock != oldStock! newStock: " + stock + " old stock: " + oldStock + "\n" + this);
-            this.updateSign();
+            this.updateSign(true);
 
             //also set marker in here if using a marker integration
             if(Shop.getPlugin().getBluemapHookListener() != null) {
@@ -227,11 +230,8 @@ public abstract class AbstractShop {
             return;
         }
 
-        // If there is not a stock change but we need to refresh the signs, then update the sign.
-        // This is triggered upon a server restart to make sure that the signs are updated.
-        if (!hasStockChange && signLinesRequireRefresh) {
-            this.updateSign();
-        }
+        // Allow sign to update if there is a pending change (signLinesRequireRefresh)
+        this.updateSign();
     }
 
     public int getStock(){
@@ -256,6 +256,7 @@ public abstract class AbstractShop {
     }
 
     public WallSign getSign(){
+        if (!this.isChunkLoaded()) { return null; }
         BlockData signBlockData = this.getSignLocation().getBlock().getBlockData();
         if(signBlockData instanceof WallSign){
             return (WallSign)signBlockData;
@@ -268,7 +269,7 @@ public abstract class AbstractShop {
     }
 
     public Inventory getInventory() {
-        if(chestLocation == null || signLocation == null)
+        if(chestLocation == null || signLocation == null || !this.isChunkLoaded())
             return null;
         Block chestBlock = chestLocation.getBlock();
         if(chestBlock.getType() == Material.ENDER_CHEST) {
@@ -283,7 +284,7 @@ public abstract class AbstractShop {
     }
 
     public Material getContainerType() {
-        if(chestLocation == null)
+        if(chestLocation == null || !this.isChunkLoaded())
             return null;
         try {
             return chestLocation.getBlock().getType();
@@ -401,14 +402,14 @@ public abstract class AbstractShop {
 
         // Remove "0 Damage" from item meta (old config bug)
         this.item = this.removeZeroDamageMeta(is.clone());
-        this.signLinesRequireRefresh = true;
         this.calculateStock();
+        this.updateSign(true);
     }
 
     public void setSecondaryItemStack(ItemStack is) {
         this.secondaryItem = this.removeZeroDamageMeta(is.clone());
-        this.signLinesRequireRefresh = true;
         this.calculateStock();
+        this.updateSign(true);
     }
 
     public ItemStack removeZeroDamageMeta(ItemStack item) {
@@ -433,12 +434,12 @@ public abstract class AbstractShop {
             // Default return original item
             return item;
         } catch (Exception e) {
-            Shop.getPlugin().getLogger().warning("Error removing zero damage meta from item: " + item);
-            Shop.getPlugin().getLogger().warning("checkItemDurability feature may be unsupported on your version of Paper/Spigot!");
+            Shop.getPlugin().getLogger().debug("Error removing zero damage meta from item: " + item);
+            Shop.getPlugin().getLogger().helpful("checkItemDurability feature may be unsupported on your version of Paper/Spigot!");
             return item;
         } catch (Error e) {
-            Shop.getPlugin().getLogger().warning("Error removing zero damage meta from item: " + item);
-            Shop.getPlugin().getLogger().warning("checkItemDurability feature may be unsupported on your version of Paper/Spigot!");
+            Shop.getPlugin().getLogger().debug("Error removing zero damage meta from item: " + item);
+            Shop.getPlugin().getLogger().helpful("checkItemDurability feature may be unsupported on your version of Paper/Spigot!");
             return item;
         }
     }
@@ -501,22 +502,18 @@ public abstract class AbstractShop {
         return UtilMethods.getDurabilityPercent(item);
     }
 
-    public void setSignLinesRequireRefresh(boolean signLinesRequireRefresh){
-        this.signLinesRequireRefresh = signLinesRequireRefresh;
-    }
-
-    public boolean getSignLinesRequireRefresh(){
-        return this.signLinesRequireRefresh;
-    }
-
     public boolean isPerformingTransaction(){
         return isPerformingTransaction;
     }
 
-    public void updateSign() {
+    public void updateSign() { this.updateSign(false); }
+    public void updateSign(boolean forceUpdate) {
         // If we don't need to update the lines, then don't update them!
-        if (!signLinesRequireRefresh) { return; }
-
+        if (!signLinesRequireRefresh && !forceUpdate) { return; }
+        // Do not trigger the sign update if the chunk has not been loaded yet
+        if (!this.isChunkLoaded()) { if (forceUpdate) { signLinesRequireRefresh = true; } return; }
+        // Immediately set to false to prevent multiple calls to updateSign overlapping
+        signLinesRequireRefresh = false;
         signLines = ShopMessage.getSignLines(this, this.type);
 
         // Use the sign's location to ensure the update runs in the correct region in Folia
@@ -526,38 +523,42 @@ public abstract class AbstractShop {
 
             Sign signBlock;
             try {
-                signBlock = (Sign) signLocation.getBlock().getState();
+                signBlock = (Sign) signLocation.getBlock().getState(); // this will load the sign
             } catch (ClassCastException e){
                 Shop.getPlugin().getLogger().warning("Error attempting to update Shop sign! Sign Block for Shop is not a Sign (detected: " + signLocation.getBlock().getType() + "), deleting shop: " + this);
                 this.delete();
                 return;
             }
 
-            String[] lines = signLines.clone();
+            String[] oldLines = signBlock.getLines();
+            String[] newLines = signLines.clone();
+            boolean hasSignUpdate = false;
+            // If the sign lines are the same, don't update them!
+            boolean linesMatch = newLines[0].equals(oldLines[0]) && newLines[1].equals(oldLines[1]) && newLines[2].equals(oldLines[2]) && newLines[3].equals(oldLines[3]);
 
             if (!isInitialized()) {
-                signBlock.setLine(0, ChatColor.RED + ChatColor.stripColor(lines[0]));
-                signBlock.setLine(1, ChatColor.RED + ChatColor.stripColor(lines[1]));
-                signBlock.setLine(2, ChatColor.RED + ChatColor.stripColor(lines[2]));
-                signBlock.setLine(3, ChatColor.RED + ChatColor.stripColor(lines[3]));
-            } else {
-                signBlock.setLine(0, lines[0]);
-                signBlock.setLine(1, lines[1]);
-                signBlock.setLine(2, lines[2]);
-                signBlock.setLine(3, lines[3]);
+                hasSignUpdate = true; // force update the sign
+                signBlock.setLine(0, ChatColor.RED + ChatColor.stripColor(newLines[0]));
+                signBlock.setLine(1, ChatColor.RED + ChatColor.stripColor(newLines[1]));
+                signBlock.setLine(2, ChatColor.RED + ChatColor.stripColor(newLines[2]));
+                signBlock.setLine(3, ChatColor.RED + ChatColor.stripColor(newLines[3]));
+            } else if (!linesMatch) {
+                hasSignUpdate = true; // force update the sign
+                signBlock.setLine(0, newLines[0]);
+                signBlock.setLine(1, newLines[1]);
+                signBlock.setLine(2, newLines[2]);
+                signBlock.setLine(3, newLines[3]);
             }
-
+            // If the sign is glowing, update it if the setting has changed
             if(isMCVersion17Plus()) {
-                if (Shop.getPlugin().getGlowingSignText()) {
-                    signBlock.setGlowingText(true);
-                }
-                else{
-                    signBlock.setGlowingText(false);
+                boolean shouldGlow = Shop.getPlugin().getGlowingSignText();
+                if (shouldGlow != signBlock.isGlowingText()) { 
+                    hasSignUpdate = true;
+                    signBlock.setGlowingText(shouldGlow);
                 }
             }
-
-            signBlock.update(true);
-            signLinesRequireRefresh = false;
+            // Update the sign if it has changed
+            if (hasSignUpdate) { signBlock.update(true); }
 
             // Update the floating holograms for anybody who currently has them open
             if (display != null) display.updateDisplayTags();
@@ -583,10 +584,11 @@ public abstract class AbstractShop {
             Block b = this.getSignLocation().getBlock();
             if (b.getBlockData() instanceof WallSign) {
                 Sign signBlock = (Sign) b.getState();
-                signBlock.setLine(0, "");
-                signBlock.setLine(1, "");
-                signBlock.setLine(2, "");
-                signBlock.setLine(3, "");
+                String[] deletedLines = ShopMessage.getSignLines("deleted", this);
+                signBlock.setLine(0, deletedLines[0]);
+                signBlock.setLine(1, deletedLines[1]);
+                signBlock.setLine(2, deletedLines[2]);
+                signBlock.setLine(3, deletedLines[3]);
                 signBlock.update(true);
             }
 

--- a/core/src/main/java/com/snowgears/shop/util/NMSBullshitHandler.java
+++ b/core/src/main/java/com/snowgears/shop/util/NMSBullshitHandler.java
@@ -39,7 +39,7 @@ public class NMSBullshitHandler {
         Shop.getPlugin().getLogger().debug("mcVersion: " + mcVersion);
 
         // MockBukkit testing does not support NMS, so we need to just return early
-        if (mcVersion.contains("mockbukkit")) { 
+        if (plugin.isMockBukkit()) { 
             return;
         }
 

--- a/core/src/main/java/com/snowgears/shop/util/NMSBullshitHandler.java
+++ b/core/src/main/java/com/snowgears/shop/util/NMSBullshitHandler.java
@@ -77,15 +77,9 @@ public class NMSBullshitHandler {
                     Shop.getPlugin().getLogger().warning("Failed to cache some reflection methods: " + e.getMessage());
                 }
             }
-        } catch (ClassNotFoundException e) {
-            Shop.getPlugin().getLogger().severe("Unable to retrieve a NMS class used for NBT data.");
-            e.printStackTrace();
-        } catch (Exception e) {
-            Shop.getPlugin().getLogger().severe("Unable to retrieve a NMS class used for NBT data.");
-            e.printStackTrace();
-        } catch (Error e) {
-            Shop.getPlugin().getLogger().severe("Unable to retrieve a NMS class used for NBT data.");
-            e.printStackTrace();
+        } catch (Error | Exception e) {
+            Shop.getPlugin().getLogger().log(java.util.logging.Level.SEVERE, "Unable to retrieve a NMS class used for NBT data. Are you using a supported server type/version? We suggest you use PaperMC for running Shop! Visual displays will now be disabled.");
+            Shop.getPlugin().getShopHandler().disableDisplayClass();
         }
     }
 
@@ -111,9 +105,11 @@ public class NMSBullshitHandler {
                 chatMessageFromStringMethod = craftChatMessageClass.getMethod("fromStringOrNull", String.class);
             }
             return (net.minecraft.network.chat.Component) chatMessageFromStringMethod.invoke(null, text);
-        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+        } catch (Error | Exception e) { /** Suppress errors */ }
+
+        Shop.getPlugin().getLogger().log(java.util.logging.Level.SEVERE, "Unable to load CraftChatMessage class! Are you using a supported server type/version? We suggest you use PaperMC for running Shop! Visual displays will now be disabled.");
+        Shop.getPlugin().getShopHandler().disableDisplayClass();
+        return null;
     }
 
     public net.minecraft.world.item.ItemStack getMCItemStack(ItemStack is) {
@@ -122,9 +118,11 @@ public class NMSBullshitHandler {
                 asNMSCopyMethod = craftItemStackClass.getMethod("asNMSCopy", org.bukkit.inventory.ItemStack.class);
             }
             return (net.minecraft.world.item.ItemStack) asNMSCopyMethod.invoke(null, is);
-        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+        } catch (Error | Exception e) { /** Suppress errors */ }
+
+        Shop.getPlugin().getLogger().log(java.util.logging.Level.SEVERE, "Unable to get MCItemStack! Are you using a supported server type/version? We suggest you use PaperMC for running Shop! Visual displays will now be disabled.");
+        Shop.getPlugin().getShopHandler().disableDisplayClass();
+        return null;
     }
 
     public net.minecraft.world.level.Level getMCLevel(Location location) {
@@ -136,9 +134,10 @@ public class NMSBullshitHandler {
                 }
                 return (net.minecraft.world.level.Level) getHandleWorldMethod.invoke(craftWorld);
             }
-        } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+        } catch (Error | Exception e) { /** Suppress errors */ }
+
+        Shop.getPlugin().getLogger().log(java.util.logging.Level.SEVERE, "Unable to get ServerLevel! Are you using a supported server type/version? We suggest you use PaperMC for running Shop! Visual displays will now be disabled.");
+        Shop.getPlugin().getShopHandler().disableDisplayClass();
         return null;
     }
 
@@ -151,9 +150,10 @@ public class NMSBullshitHandler {
                 }
                 return (ServerLevel) getHandleWorldMethod.invoke(craftWorld);
             }
-        } catch (InvocationTargetException | NoSuchMethodException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
+        } catch (Error | Exception e) { /** Suppress errors */ }
+
+        Shop.getPlugin().getLogger().log(java.util.logging.Level.SEVERE, "Unable to get ServerLevel! Are you using a supported server type/version? We suggest you use PaperMC for running Shop! Visual displays will now be disabled.");
+        Shop.getPlugin().getShopHandler().disableDisplayClass();
         return null;
     }
 
@@ -169,21 +169,20 @@ public class NMSBullshitHandler {
                     try {
                         Field playerConnection = entityPlayer.getClass().getDeclaredField("connection");
                         return (ServerPlayerConnection) playerConnection.get(entityPlayer);
-                    } catch (NoSuchFieldException e) {
+                    } catch (Error | Exception e) {
                         // Try to access the obfuscated field directly on CraftBukkit (for Spigot support)
                         try {
                             Field playerConnection = entityPlayer.getClass().getField("c");
                             return (ServerPlayerConnection) playerConnection.get(entityPlayer);
-                        } catch (NoSuchFieldException err) {
-                            Shop.getPlugin().getLogger().log(java.util.logging.Level.SEVERE, "Unable to get player connection! Are you using a supported Spigot version? We suggest you use PaperMC for running Shop!");
-                            err.printStackTrace();
-                        }
+                        } catch (Error | Exception err) { /** Suppress errors */ }
                     }
                 }
             }
-        } catch(NoSuchMethodException | IllegalAccessException | InvocationTargetException e){
-            e.printStackTrace();
-        }
+        } catch(Error | Exception e){ /** Suppress errors */ }
+        Shop.getPlugin().getLogger().log(java.util.logging.Level.SEVERE, "Unable to hook into internal ServerPlayerConnection to send Display packets to users! Are you using a supported server type/version? We suggest you use PaperMC for running Shop! Visual displays will now be disabled.");
+        // Disable the display class so that we don't try to use it anymore since we can't send packets to users.
+        Shop.getPlugin().getShopHandler().disableDisplayClass();
+
         return null;
     }
 }

--- a/core/src/main/java/com/snowgears/shop/util/NMSBullshitHandler.java
+++ b/core/src/main/java/com/snowgears/shop/util/NMSBullshitHandler.java
@@ -38,13 +38,19 @@ public class NMSBullshitHandler {
         String mcVersion = plugin.getServer().getClass().getPackage().getName();
         Shop.getPlugin().getLogger().debug("mcVersion: " + mcVersion);
 
+        // MockBukkit testing does not support NMS, so we need to just return early
+        if (mcVersion.contains("mockbukkit")) { 
+            return;
+        }
+
         // Check if we are on Paper 1.20.5 or later, it will not include the CB relocation version (i.e. "1_20_R3")
         if (!mcVersion.equals("org.bukkit.craftbukkit")) {
             Shop.getPlugin().getLogger().warning("Minecraft version is old or Spigot, loaded version is: " + mcVersion);
 
             String[] mcVersionSplit = mcVersion.replace(".", ",").split(",");
             // Convert mcVersion into a number like 120.4 (1_20_R4) or 121.1 (1_21_R1) so that we can use it later
-            serverVersion = Double.parseDouble(mcVersionSplit[mcVersionSplit.length-1].replace("_R", ".").replaceAll("[rvV_]*", ""));
+            String versionNumberString = mcVersionSplit[mcVersionSplit.length-1].replace("_R", ".").replaceAll("[rvV_]*", "");
+            serverVersion = Double.parseDouble(versionNumberString);
         }
 
         // log the server version we are on, it will be 0 when we are on a Paper server

--- a/core/src/main/java/com/snowgears/shop/util/ShopCreationUtil.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopCreationUtil.java
@@ -239,7 +239,10 @@ public class ShopCreationUtil {
         shop.setNeedsSave(true);
         ShopMessage.sendMessage(shop.getType().toString(), "create", player, shop);
         shop.sendEffects(true, player);
-        // Save the shop to disk
+        // Save the shop to disk 
+        // TODO: We should move this save trigger elsewhere, it doesn't belong in `sendCreationSuccess`,
+        //       it is currently non-intuitive that this is the method to save a shop when it is created.
+        //       We should move it elsewhere.
         Shop.getPlugin().getShopHandler().saveShops(shop.getOwnerUUID(), true);
         // Cleanup the shop creation process
         cleanupShopCreationProcess(player);

--- a/core/src/main/java/com/snowgears/shop/util/ShopCreationUtil.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopCreationUtil.java
@@ -185,7 +185,11 @@ public class ShopCreationUtil {
             signBlockState.update();
 
             shop.setAdmin(isAdmin);
-            shop.load();
+            boolean loaded = shop.load();
+            if (!loaded) {
+                plugin.getLogger().warning("Shop creation failed, unable to load the shop. Aborting shop creation."); // only seen this happen in tests
+                return null;
+            }
 
             PlayerCreateShopEvent e = new PlayerCreateShopEvent(player, shop);
             plugin.getServer().getPluginManager().callEvent(e);

--- a/core/src/main/java/com/snowgears/shop/util/ShopCreationUtil.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopCreationUtil.java
@@ -238,8 +238,7 @@ public class ShopCreationUtil {
     public void sendCreationSuccess(Player player, AbstractShop shop){
         if (shop.getDisplay() != null) shop.getDisplay().spawn(player);
         Shop.getPlugin().getLogger().trace("[ShopCreationUtil.sendCreationSuccess] updateSign");
-        shop.setSignLinesRequireRefresh(true);
-        shop.updateSign();
+        shop.updateSign(true);
         shop.setNeedsSave(true);
         ShopMessage.sendMessage(shop.getType().toString(), "create", player, shop);
         shop.sendEffects(true, player);

--- a/core/src/main/java/com/snowgears/shop/util/ShopLogger.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopLogger.java
@@ -97,6 +97,8 @@ import org.bukkit.ChatColor;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.StringWriter;
+import java.io.PrintWriter;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -191,6 +193,10 @@ public class ShopLogger extends Logger {
         if (this.getLogLevel().intValue() > DEBUG.intValue()) { return; }
         Bukkit.getConsoleSender().sendMessage(INTENSE_WHITE + "[" + plugin.getDescription().getName() + "] " + DIM_GREY + "[Debug] " + message + RESET);
     }
+    public void debug(String message, Throwable t) {
+        debug(message);
+        debug(getStackTrace(t), false);
+    }
     public void trace(String message) { logFilterLevel(TRACE, addColor(VERY_DIM_GREY, "[Trace] " + message)); }
     public void spam(String message) { logFilterLevel(SPAM, addColor(VERY_VERY_DIM_GREY, "[Spam] " + message)); }
     public void spam(String message, boolean withChatColors) {
@@ -216,5 +222,12 @@ public class ShopLogger extends Logger {
 
     public void enableColor(boolean enabled) {
         enableColor = enabled;
+    }
+
+    // Get the stack trace of a Throwable as a string
+    public String getStackTrace(Throwable t) {
+        StringWriter sw = new StringWriter();
+        t.printStackTrace(new PrintWriter(sw));
+        return sw.toString();
     }
 }

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -854,10 +854,8 @@ public class ShopMessage {
         return lines;
     }
 
-    public static String[] getTimeoutSignLines(AbstractShop shop){
-
-        String[] lines = shopSignTextMap.get("timeout");
-
+    public static String[] getSignLines(String key, AbstractShop shop){
+        String[] lines = shopSignTextMap.get(key);
         for(int i=0; i<lines.length; i++) {
             lines[i] = formatMessage(lines[i], shop, null, true);
             lines[i] = ChatColor.translateAlternateColorCodes('&', lines[i]);
@@ -1065,98 +1063,39 @@ public class ShopMessage {
         messageMap.put("command_notify_off", chatConfig.getString("command.notify_off"));
     }
 
+    private String[] getSignConfigLines(String key) { return getConfigLines(signConfig, key);  }
+    private String[] getConfigLines(YamlConfiguration config, String key) {
+        List<String> lines = new ArrayList<>();
+        int count = 1;
+        try {
+            String message = config.getString(key + "." + count);
+            while (message != null) {
+                lines.add(message);
+                count++;
+                message = config.getString(key + "." + count);
+            }
+        } catch (NullPointerException e) {}
+        return lines.toArray(new String[0]);
+    }
+
     private void loadSignTextFromConfig() {
         messageMap.put("signtext_instockcolor", signConfig.getString("stock_color.in_stock"));
         messageMap.put("signtext_outofstockcolor", signConfig.getString("stock_color.out_of_stock"));
         Set<String> allTypes = signConfig.getConfigurationSection("sign_text").getKeys(false);
         for (String typeString : allTypes) {
-
             ShopType type = null;
             try { type = ShopType.valueOf(typeString);}
             catch (IllegalArgumentException e){}
 
             if (type != null) {
-                try {
-                    Set<String> normalLineNumbers = signConfig.getConfigurationSection("sign_text." + typeString + ".normal").getKeys(false);
-                    String[] normalLines = new String[4];
-
-                    int i = 0;
-                    for (String number : normalLineNumbers) {
-                        String message = signConfig.getString("sign_text." + typeString + ".normal." + number);
-                        if (message == null)
-                            normalLines[i] = "";
-                        else
-                            normalLines[i] = message;
-                        i++;
-                    }
-
-                    this.shopSignTextMap.put(type.toString() + "_normal", normalLines);
-                } catch (NullPointerException e) {}
-
-                try {
-                    Set<String> adminLineNumbers = signConfig.getConfigurationSection("sign_text." + typeString + ".admin").getKeys(false);
-                    String[] adminLines = new String[4];
-
-                    int i = 0;
-                    for (String number : adminLineNumbers) {
-                        String message = signConfig.getString("sign_text." + typeString + ".admin." + number);
-                        if (message == null)
-                            adminLines[i] = "";
-                        else
-                            adminLines[i] = message;
-                        i++;
-                    }
-
-                    this.shopSignTextMap.put(type.toString() + "_admin", adminLines);
-                } catch (NullPointerException e) {}
-
-                try {
-                    Set<String> normalNoDisplayLineNumbers = signConfig.getConfigurationSection("sign_text." + typeString + ".normal_no_display").getKeys(false);
-                    String[] normalNoDisplayLines = new String[4];
-
-                    int i = 0;
-                    for (String number : normalNoDisplayLineNumbers) {
-                        String message = signConfig.getString("sign_text." + typeString + ".normal_no_display." + number);
-                        if (message == null)
-                            normalNoDisplayLines[i] = "";
-                        else
-                            normalNoDisplayLines[i] = message;
-                        i++;
-                    }
-
-                    this.shopSignTextMap.put(type.toString() + "_normal_no_display", normalNoDisplayLines);
-                } catch (NullPointerException e) {}
-
-                try {
-                    Set<String> adminNoDisplayLineNumbers = signConfig.getConfigurationSection("sign_text." + typeString + ".admin_no_display").getKeys(false);
-                    String[] adminNoDisplayLines = new String[4];
-
-                    int i = 0;
-                    for (String number : adminNoDisplayLineNumbers) {
-                        String message = signConfig.getString("sign_text." + typeString + ".admin_no_display." + number);
-                        if (message == null)
-                            adminNoDisplayLines[i] = "";
-                        else
-                            adminNoDisplayLines[i] = message;
-                        i++;
-                    }
-
-                    this.shopSignTextMap.put(type.toString() + "_admin_no_display", adminNoDisplayLines);
-                } catch (NullPointerException e) {}
+                this.shopSignTextMap.put(type.toString() + "_normal", getSignConfigLines("sign_text." + typeString + ".normal"));
+                this.shopSignTextMap.put(type.toString() + "_admin", getSignConfigLines("sign_text." + typeString + ".admin"));
+                this.shopSignTextMap.put(type.toString() + "_normal_no_display", getSignConfigLines("sign_text." + typeString + ".normal_no_display"));
+                this.shopSignTextMap.put(type.toString() + "_admin_no_display", getSignConfigLines("sign_text." + typeString + ".admin_no_display"));
             }
         }
-        String[] timeoutLines = new String[4];
-
-        for (int i=1; i<5; i++) {
-            String message = signConfig.getString("sign_text.timeout." + i);
-            if (message == null)
-                timeoutLines[i] = "";
-            else
-                timeoutLines[i] = message;
-            i++;
-        }
-
-        this.shopSignTextMap.put("timeout", timeoutLines);
+        this.shopSignTextMap.put("timeout", getSignConfigLines("sign_text.timeout"));
+        this.shopSignTextMap.put("deleted", getSignConfigLines("sign_text.deleted"));
     }
 
     private void loadDisplayTextFromConfig() {

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -971,6 +971,7 @@ public class ShopMessage {
         messageMap.put("permission_use", chatConfig.getString("permission.use"));
         messageMap.put("permission_create", chatConfig.getString("permission.create"));
         messageMap.put("permission_destroy", chatConfig.getString("permission.destroy"));
+        messageMap.put("permission_destroyOther", chatConfig.getString("permission.destroyOther"));
         messageMap.put("permission_buildLimit", chatConfig.getString("permission.buildLimit"));
 
         messageMap.put("creativeSelection_disabled", chatConfig.getString("creativeSelection.disabled"));

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -991,6 +991,7 @@ public class ShopMessage {
         messageMap.put("interactionIssue_teleportInsufficientCooldown", chatConfig.getString("interaction_issue.teleportInsufficientCooldown"));
         messageMap.put("interactionIssue_initialize", chatConfig.getString("interaction_issue.initializeOtherShop"));
         messageMap.put("interactionIssue_destroyChest", chatConfig.getString("interaction_issue.destroyChest"));
+        messageMap.put("interactionIssue_destroyUninitializedChest", chatConfig.getString("interaction_issue.destroyUninitializedChest"));
         messageMap.put("interactionIssue_useOwnShop", chatConfig.getString("interaction_issue.useOwnShop"));
         messageMap.put("interactionIssue_useShopAlreadyInUse", chatConfig.getString("interaction_issue.useShopAlreadyInUse"));
         messageMap.put("interactionIssue_adminOpen", chatConfig.getString("interaction_issue.adminOpen"));

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -877,7 +877,7 @@ public class UtilMethods {
 
     public static String cleanNumberText(String text){
         String cleaned = "";
-        String toClean = ChatColor.stripColor(text);
+        String toClean = ChatColor.stripColor(text).trim(); // remove color and whitespace not between characters
         for(int i=0; i<toClean.length(); i++) {
             if(Character.isDigit(toClean.charAt(i)))
                 cleaned += toClean.charAt(i);

--- a/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
+++ b/core/src/main/java/com/snowgears/shop/util/UtilMethods.java
@@ -259,6 +259,46 @@ public class UtilMethods {
         }
     }
 
+    /**
+     * Checks if a chunk is loaded
+     * 
+     * @param location The location to check
+     * @return True if the chunk is loaded, false otherwise
+     * 
+     * Note: This method should be used instead of `location.getChunk().isChunkLoaded()` 
+     * because calling `location.getChunk()` will force a chunk load, which defeats 
+     * the purpose of checking if the chunk is already loaded.
+     */
+    public static boolean isChunkLoaded(Location location) {
+        if (location == null || location.getWorld() == null) { return false; }
+        return location.getWorld().isChunkLoaded(UtilMethods.floor(location.getBlockX()) >> 4, UtilMethods.floor(location.getBlockZ()) >> 4);
+    }
+    public static int getChunkX(Location location){ return UtilMethods.floor(location.getBlockX()) >> 4; }
+    public static int getChunkZ(Location location){ return UtilMethods.floor(location.getBlockZ()) >> 4; }
+    public static boolean isInChunk(Location location, Chunk chunk){
+        if (location == null || location.getWorld() == null || chunk == null) { return false; }
+        if (!chunk.getWorld().toString().equals(location.getWorld().toString())) { return false; }
+        return chunk.getX() == getChunkX(location) && chunk.getZ() == getChunkZ(location);
+    }
+    /**
+     * Chunk keys are used to identify chunks in the shop handler inside of Maps/sets
+     * these helpers are used to create and get chunk keys from locations and chunks
+     * and help with consistency across the codebase.
+     */
+    public static String getChunkKey(Location location){
+        int chunkX = getChunkX(location);
+        int chunkZ = getChunkZ(location);
+        String worldName = location.getWorld() != null ? location.getWorld().getName() : "unknown_world";
+        return createChunkKey(worldName, chunkX, chunkZ);
+    }
+    public static String getChunkKey(Chunk chunk){
+        return createChunkKey(chunk.getWorld().getName(), chunk.getX(), chunk.getZ());
+    }
+    public static String createChunkKey(String worldName, int chunkX, int chunkZ) {
+        return worldName + "_" + chunkX + "_" + chunkZ;
+    }
+    
+    // todo: dig deeper into why we need to use this method
     public static int floor(double num) {
         int floor = (int) num;
         return floor == num ? floor : floor - (int) (Double.doubleToRawLongBits(num) >>> 63);

--- a/core/src/main/resources/chatConfig.yml
+++ b/core/src/main/resources/chatConfig.yml
@@ -246,7 +246,8 @@ description:
 permission:
    use: "&cYou are not authorized to use [shop type] shops."
    create: "&cYou are not authorized to create [shop type] shops."
-   destroy: "&cYou are not authorized to destroy shops."
+   destroy: "&cYou are not authorized to destroy your own shops."
+   destroyOther: "&cYou are not authorized to destroy other players shops."
    buildLimit: "&cYou have already reached your build limit of [user amount]/[build limit] shops."
 
 hover:

--- a/core/src/main/resources/chatConfig.yml
+++ b/core/src/main/resources/chatConfig.yml
@@ -191,6 +191,7 @@ interaction_issue:
    initializeOtherShop: "&cYou may not initialize another players shop with an item."
    useShopAlreadyInUse: "&cThis shop is in the middle of a transaction."
    destroyChest: "&cYou must remove the sign from this shop to break it."
+   destroyUninitializedChest: "&cThis chest cannot be destroyed while a shop is being created for it."
    useOwnShop: "&7You cannot use your own shop."
    adminOpen: "&7Admin shops are not able to be opened."
    worldBlacklist: "&cShops are not allowed to be created in this world."

--- a/core/src/main/resources/signConfig.yml
+++ b/core/src/main/resources/signConfig.yml
@@ -162,6 +162,11 @@ sign_text:
       2: "&7CREATION TIMEOUT"
       3: ""
       4: ""
+   deleted:
+      1: "&cSHOP CLOSED"
+      2: ""
+      3: ""
+      4: ""
    zeroPrice: "FREE"
    adminStock: "unlimited"
    serverDisplayName: "Server"

--- a/core/src/test/java/com/snowgears/shop/PluginLoadTest.java
+++ b/core/src/test/java/com/snowgears/shop/PluginLoadTest.java
@@ -1,0 +1,20 @@
+package com.snowgears.shop;
+
+import com.snowgears.shop.testsupport.BaseMockBukkitTest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Basic sanity check to verify the plugin can be loaded and enabled inside a MockBukkit environment.
+ * <p>
+ * This ensures that MockBukkit is correctly wired into the build and that the plugin’s lifecycle
+ * methods do not immediately throw exceptions when run on a mock server.
+ */
+public class PluginLoadTest extends BaseMockBukkitTest {
+    @Test
+    void pluginShouldEnable() {
+        assertNotNull(getPlugin(), "Plugin should be loaded by MockBukkit");
+        assertTrue(getPlugin().isEnabled(), "Plugin should be enabled inside MockBukkit environment");
+    }
+}

--- a/core/src/test/java/com/snowgears/shop/integration/features/CreationDestructionCostTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/CreationDestructionCostTest.java
@@ -1,0 +1,87 @@
+package com.snowgears.shop.integration.features;
+
+import com.snowgears.shop.shop.AbstractShop;
+import com.snowgears.shop.testsupport.BaseMockBukkitTest;
+import com.snowgears.shop.util.CurrencyType;
+import com.snowgears.shop.util.EconomyUtils;
+
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.simulate.entity.PlayerSimulation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("integration")
+public class CreationDestructionCostTest extends BaseMockBukkitTest {
+
+    @Test
+    void destroy_cost_insufficientFunds_prevents_destroy() {
+        setPluginField("currencyType", CurrencyType.ITEM);
+        setPluginField("destructionCost", 5.0);
+
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 28, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        // Ensure player has 2 currency
+        player.getInventory().addItem(new ItemStack(Material.EMERALD, 2));
+        // Try to destroy shop
+        new PlayerSimulation(player).simulateBlockBreak(shop.getSignLocation().getBlock());
+        // §cYou do not have the funds required to create this shop.
+        assertEquals(2, EconomyUtils.getFunds(player, player.getInventory()), "Player should have 2 emeralds");
+        assertEquals("§cYou do not have the funds required to destroy this shop.", waitForNextMessage(player), "Player should be sent dialog after failing to destroy shop");
+        assertNotNull(getPlugin().getShopHandler().getShop(shop.getSignLocation()), "Shop should remain when player cannot afford destruction cost");
+    }
+
+    @Test
+    void destroy_cost_sufficientFunds_allows_destroy() {
+        setPluginField("currencyType", CurrencyType.ITEM);
+        setPluginField("destructionCost", 5.0);
+
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 30, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+        
+        player.getInventory().addItem(new ItemStack(Material.EMERALD, 15));
+        new PlayerSimulation(player).simulateBlockBreak(shop.getSignLocation().getBlock());
+
+        assertEquals(10, EconomyUtils.getFunds(player, player.getInventory()), "Player should have 10 emeralds");
+        assertEquals("§7You have destroyed your selling shop.", waitForNextMessage(player), "Player should be sent dialog after destroying shop sign");
+        assertEquals(Material.AIR, world.getBlockAt(shop.getSignLocation()).getType(), "Shop should be destroyed when player can afford destruction cost");
+        assertNull(getPlugin().getShopHandler().getShop(shop.getSignLocation()), "Shop should be destroyed when player can afford destruction cost");
+    }
+
+    @Test
+    void destroy_returns_creation_cost_experience_currency() {
+        setPluginField("currencyType", CurrencyType.EXPERIENCE);
+        setPluginField("returnCreationCost", true);
+        setPluginField("destructionCost", 1.0);
+        setPluginField("creationCost", 10.0);
+
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        player.giveExp(1000);
+        assertEquals(1000, EconomyUtils.getFunds(player, player.getInventory()), "Player should have 1000 experience");
+
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 32, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        assertEquals(990, EconomyUtils.getFunds(player, player.getInventory()), "Player should have 15 emeralds");
+
+        new PlayerSimulation(player).simulateBlockBreak(shop.getSignLocation().getBlock());
+
+        assertEquals(999, EconomyUtils.getFunds(player, player.getInventory()), "Player should gain at least creationCost experience when destroying their own shop with returnCreationCost=true");
+    }
+}

--- a/core/src/test/java/com/snowgears/shop/integration/features/CreationDestructionCostTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/CreationDestructionCostTest.java
@@ -8,7 +8,6 @@ import com.snowgears.shop.util.EconomyUtils;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.inventory.ItemStack;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.ServerMock;
@@ -28,7 +27,6 @@ public class CreationDestructionCostTest extends BaseMockBukkitTest {
         ServerMock server = getServer();
         World world = server.addSimpleWorld("world");
         PlayerMock player = server.addPlayer();
-
 
         AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 28, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
 

--- a/core/src/test/java/com/snowgears/shop/integration/features/EfficientChunkLoadTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/EfficientChunkLoadTest.java
@@ -1,0 +1,150 @@
+package com.snowgears.shop.integration.features;
+
+import com.snowgears.shop.Shop;
+import com.snowgears.shop.shop.AbstractShop;
+import com.snowgears.shop.testsupport.BaseMockBukkitTest;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Sign;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("integration")
+public class EfficientChunkLoadTest extends BaseMockBukkitTest {
+
+    private static boolean isChunkLoaded(World world, Location loc) {
+        int cx = loc.getBlockX() >> 4;
+        int cz = loc.getBlockZ() >> 4;
+        return world.isChunkLoaded(cx, cz);
+    }
+
+    private static void unloadChunk(WorldMock world, Location loc) {
+        int cx = loc.getBlockX() >> 4;
+        int cz = loc.getBlockZ() >> 4;
+        world.unloadChunk(cx, cz);
+        assertFalse(world.isChunkLoaded(cx, cz), "Precondition: chunk should be unloaded for test");
+    }
+
+    @Test
+    void updateSign_forceDoesNotLoadChunk_whenUnloaded() {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        WorldMock world = addSimpleWorldPatched("world");
+        PlayerMock player = server.addPlayer();
+
+        // Create a valid shop via chest flow
+        AbstractShop shop = ShopCreationChestTest.createShop(
+                server, plugin, player, world,
+                new Location(world, 100, 65, 100), new ItemStack(Material.DIRT), "sell", 8, "1"
+        );
+        assertNotNull(shop);
+        assertTrue(isChunkLoaded(world, shop.getSignLocation()), "Precondition: chunk should be loaded after creation");
+
+        // Unload the sign's chunk
+        Location signLoc = shop.getSignLocation();
+        unloadChunk(world, signLoc);
+
+        // Act: Force an update while unloaded
+        shop.updateSign(true);
+        server.getScheduler().performTicks(2);
+
+        // Assert: chunk remains unloaded; sign update should be deferred until it loads
+        assertFalse(isChunkLoaded(world, signLoc), "updateSign(true) should not load the chunk when unloaded");
+    }
+
+    @Test
+    void getInventory_returnsNull_andDoesNotLoadChunk_whenUnloaded() {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        WorldMock world = addSimpleWorldPatched("world");
+        PlayerMock player = server.addPlayer();
+
+        AbstractShop shop = ShopCreationChestTest.createShop(
+                server, plugin, player, world,
+                new Location(world, 104, 65, 100), new ItemStack(Material.DIRT), "sell", 8, "1"
+        );
+        assertNotNull(shop);
+        assertTrue(isChunkLoaded(world, shop.getSignLocation()), "Precondition: chunk should be loaded after creation");
+
+        Location signLoc = shop.getSignLocation();
+        unloadChunk(world, signLoc);
+
+        // Act
+        var inv = shop.getInventory();
+
+        // Assert
+        assertNull(inv, "Inventory should be null when the chunk is unloaded");
+        assertFalse(isChunkLoaded(world, signLoc), "getInventory should not load the chunk when unloaded");
+    }
+
+    @Test
+    void delete_forcesChunkLoad_andClearsSign() {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        WorldMock world = addSimpleWorldPatched("world");
+        PlayerMock player = server.addPlayer();
+
+        AbstractShop shop = ShopCreationChestTest.createShop(
+                server, plugin, player, world,
+                new Location(world, 108, 65, 100), new ItemStack(Material.DIRT), "sell", 8, "1"
+        );
+        assertNotNull(shop);
+        Location signLoc = shop.getSignLocation();
+        assertTrue(isChunkLoaded(world, signLoc), "Precondition: chunk should be loaded after creation");
+
+        unloadChunk(world, signLoc);
+        assertFalse(isChunkLoaded(world, signLoc), "Precondition: chunk should be unloaded for test");
+
+        // Act: delete should force load and clear the sign text
+        shop.delete();
+
+        // Assert: chunk is now loaded
+        assertTrue(isChunkLoaded(world, signLoc), "delete() should force-load the chunk to clear the sign");
+
+        // Sign should be cleared
+        Sign sign = (Sign) signLoc.getBlock().getState();
+        String[] lines = sign.getLines();
+        assertEquals("§cSHOP CLOSED", lines[0]); // default "deleted" sign text
+        assertEquals("", lines[1]);
+        assertEquals("", lines[2]);
+        assertEquals("", lines[3]);
+
+        // And the shop should be removed from the handler
+        assertNull(plugin.getShopHandler().getShop(signLoc), "Shop should be removed from handler after delete");
+    }
+
+    @Test
+    void getContainerType_shouldNotLoadChunk_whenUnloaded() {
+        // This test documents intended behavior: querying container type should not load chunks.
+        // If it fails, it indicates a bug where getContainerType() is calling getBlock() without a chunk-loaded guard.
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        WorldMock world = addSimpleWorldPatched("world");
+        PlayerMock player = server.addPlayer();
+
+        AbstractShop shop = ShopCreationChestTest.createShop(
+                server, plugin, player, world,
+                new Location(world, 112, 65, 100), new ItemStack(Material.DIRT), "sell", 8, "1"
+        );
+        assertNotNull(shop);
+        assertTrue(isChunkLoaded(world, shop.getSignLocation()), "Precondition: chunk should be loaded after creation");
+
+        Location signLoc = shop.getSignLocation();
+        unloadChunk(world, signLoc);
+
+        // Act
+        shop.getContainerType();
+
+        // Assert: should not have loaded the chunk
+        assertFalse(isChunkLoaded(world, signLoc), "getContainerType() should not load the chunk when unloaded");
+    }
+}
+
+

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopCreationChestTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopCreationChestTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import org.bukkit.scheduler.BukkitTask;
+import org.mockbukkit.mockbukkit.simulate.entity.PlayerSimulation;
 
 import java.util.List;
 import java.util.Collections;
@@ -27,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("integration")
 public class ShopCreationChestTest extends BaseMockBukkitTest {
-
 
     @Test
     void createUsingChestFlow_withChatSteps() {
@@ -79,7 +79,7 @@ public class ShopCreationChestTest extends BaseMockBukkitTest {
         assertEquals("§eTo set up your shop, please type your responses in chat when prompted.", msg, "Player should be sent dialog to set up shop");
         msg = waitForNextMessage(player);
         assertTrue(msg.contains("§eEnter in chat what to do with §a"), "Player should be sent dialog for shop type");
-        assertTrue(msg.contains("(s)§b §7(sell, buy, barter, gamble, combo)"), "Player should be sent dialog for shop type");
+        assertTrue(msg.contains("(s)§b §7("), "Player should be sent dialog for shop type");
         msg = player.nextMessage();
         if (msg != null) {
             assertEquals("§7(Adding §eadmin §7will make the shop unlimited stock.)", msg, "Player should be sent admin dialog if player is op");

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopCreationChestTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopCreationChestTest.java
@@ -1,0 +1,116 @@
+package com.snowgears.shop.integration.features;
+
+import com.snowgears.shop.Shop;
+import com.snowgears.shop.shop.AbstractShop;
+import com.snowgears.shop.util.ShopMessage;
+import com.snowgears.shop.testsupport.BaseMockBukkitTest;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.List;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("integration")
+public class ShopCreationChestTest extends BaseMockBukkitTest {
+
+
+    @Test
+    void createUsingChestFlow_withChatSteps() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        // create the shop
+        AbstractShop shop = createShop(player, world, 10, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+        assertEquals(Material.DIRT, shop.getItemStack().getType());
+    }
+
+    AbstractShop createShop(PlayerMock player, World world, int x, int y, int z, ItemStack item, String type, int amount, String price) {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        return createShop(server, plugin, player, world, new Location(world, x, y, z), item, type, amount, price);
+    }
+    static AbstractShop createShop(ServerMock server, Shop plugin, PlayerMock player, World world, int x, int y, int z, ItemStack item, String type, int amount, String price) {
+        return createShop(server, plugin, player, world, new Location(world, x, y, z), item, type, amount, price);
+    }
+    static AbstractShop createShop(ServerMock server, Shop plugin, PlayerMock player, World world, Location chestLoc, ItemStack item, String type, int amount, String price) {
+
+        player.setOp(true);
+
+        // Enable chest creation
+        setConfig("allowCreateMethodChest", true);
+
+        // Place chest with free space to the NORTH for sign placement
+        Block chestBlock = world.getBlockAt(chestLoc);
+        chestBlock.setType(Material.CHEST);
+        // Ensure the block to the NORTH is air so sign can be placed
+        world.getBlockAt(chestLoc.clone().add(0, 0, -1)).setType(Material.AIR);
+        // Stub sign-face calculation to avoid MockBukkit material checks
+        stubCalculateBlockFaceForSign(BlockFace.NORTH);
+
+        // Start creation by sneaking and left-clicking the chest with an item in hand
+        player.setSneaking(true);
+        player.getInventory().setItemInMainHand(item);
+        PlayerInteractEvent startCreate = new PlayerInteractEvent(
+                player,
+                Action.LEFT_CLICK_BLOCK,
+                item,
+                chestBlock,
+                BlockFace.NORTH,
+                EquipmentSlot.HAND
+        );
+        server.getPluginManager().callEvent(startCreate);
+        server.getScheduler().performTicks(20);
+        String msg = waitForNextMessage(player);
+        assertEquals("§eTo set up your shop, please type your responses in chat when prompted.", msg, "Player should be sent dialog to set up shop");
+        msg = waitForNextMessage(player);
+        assertTrue(msg.contains("§eEnter in chat what to do with §a"), "Player should be sent dialog for shop type");
+        assertTrue(msg.contains("(s)§b §7(sell, buy, barter, gamble, combo)"), "Player should be sent dialog for shop type");
+        msg = player.nextMessage();
+        if (msg != null) {
+            assertEquals("§7(Adding §eadmin §7will make the shop unlimited stock.)", msg, "Player should be sent admin dialog if player is op");
+        }
+        assertEquals(null, player.nextMessage(), "Player should not have any more messages");
+
+        // Provide chat inputs to finish the creation process
+        // Step 1: Shop type (SELL). Use the localized creation word to ensure parsing works.
+        sendChatMessage(player, type);
+        // Step 2: Item amount
+        msg = waitForNextMessage(player);
+        assertTrue(msg.contains("§eEnter in chat the amount of §a"), "Player should be sent dialog for amount");
+        assertTrue(msg.contains("(s)§b §eyou want to sell per transaction."), "Player should be sent dialog for amount");
+        sendChatMessage(player, amount + "");
+        // Step 3: Price
+        msg = waitForNextMessage(player);
+        assertTrue(msg.contains("§eEnter in chat the price you will sell §a"), "Player should be sent dialog for price");
+        sendChatMessage(player, price);
+        msg = waitForNextMessage(player);
+        assertTrue(msg.contains("§eYou have created a shop that sells §6"), "Player should be sent dialog for successfully setup shop");
+
+        // Assert: shop created and initialized (attached to the chest)
+        AbstractShop created = plugin.getShopHandler().getShopByChest(chestBlock);
+        assertNotNull(created, "Shop should be created via chest flow");
+        assertTrue(created.isInitialized(), "Shop should be initialized after chat steps");
+        assertNotNull(created.getItemStack(), "Shop item should be set");
+        assertEquals(null, player.nextMessage(), "Player should not have any more messages");
+        assertEquals(item.getType(), created.getItemStack().getType());
+        // wait for all async tasks to complete
+        server.getScheduler().waitAsyncTasksFinished();
+        return created;
+    }
+}
+

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopCreationSignTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopCreationSignTest.java
@@ -1,0 +1,98 @@
+package com.snowgears.shop.integration.features;
+
+import com.snowgears.shop.Shop;
+import com.snowgears.shop.shop.AbstractShop;
+import com.snowgears.shop.testsupport.BaseMockBukkitTest;
+import com.snowgears.shop.util.ShopMessage;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.type.WallSign;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+import java.util.List;
+import java.util.ArrayList;
+import org.bukkit.entity.Player;
+import org.bukkit.block.sign.Side;
+import org.bukkit.block.BlockFace;
+import net.kyori.adventure.text.Component;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("integration")
+public class ShopCreationSignTest extends BaseMockBukkitTest {
+
+    @Test
+    void createUsingSign() {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+
+        // Arrange: world & player
+        WorldMock world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+
+        // Ensure sign creation enabled; display is disabled and economy mocked by base
+        setConfig("allowCreateMethodSign", true);
+
+        // Place the wall sign and chest behind it
+        Location signLoc = new Location(world, 5, 65, 5);
+        Block signBlock = world.getBlockAt(signLoc);
+        signBlock.setType(Material.OAK_WALL_SIGN);
+        WallSign data = (WallSign) signBlock.getBlockData();
+        data.setFacing(BlockFace.NORTH); // chest on WEST
+        // signBlock.setBlockData(data);
+        world.setBlockData(signBlock.getLocation(), data); // Setting the sign direction does not seem to be working with MockBukkit, the default is NORTH though.
+        Location chestLoc = signBlock.getRelative(BlockFace.NORTH.getOppositeFace()).getLocation();
+        
+        Block chestBlock = world.getBlockAt(chestLoc);
+        chestBlock.setType(Material.CHEST);
+        System.out.println("Chest location: " + chestLoc);
+        // playerSim.simulateBlockPlace(Material.CHEST, new Location(world, 5, 65, 6));
+
+        // Fire SignChangeEvent with proper lines
+        List<Component> lines = new ArrayList<>();
+        lines.add(Component.text(ShopMessage.getCreationWord("SHOP")));
+        lines.add(Component.text("1"));      // amount
+        lines.add(Component.text("10"));     // price
+        lines.add(Component.text(ShopMessage.getCreationWord("SELL")));
+        SignChangeEvent signEvent = new SignChangeEvent(signBlock, (Player) player, lines, Side.FRONT);
+        server.getPluginManager().callEvent(signEvent);
+
+        // Assert player is sent dialog to set up shop
+        player.assertSaid("§6Now just hit the sign with the item you want to sell to other players!");
+        player.assertNoMoreSaid();
+
+        // Assert shop created and registered
+        AbstractShop shop = plugin.getShopHandler().getShop(signLoc);
+        assertNotNull(shop, "Shop should be created via sign event");
+        assertFalse(shop.isInitialized(), "Shop should not be initialized yet");
+
+        // Initialize via left-click on sign with an item in hand
+        ItemStack toInit = new ItemStack(Material.DIAMOND);
+        player.getInventory().setItemInMainHand(toInit);
+        PlayerInteractEvent initEvent = new PlayerInteractEvent(
+                player,
+                Action.LEFT_CLICK_BLOCK,
+                toInit,
+                signBlock,
+                BlockFace.WEST,
+                EquipmentSlot.HAND
+        );
+        server.getPluginManager().callEvent(initEvent);
+
+        player.assertSaid("§eYou have created a shop that sells §6Diamond(s)§e.");
+        player.assertNoMoreSaid();
+
+        assertTrue(shop.isInitialized(), "Shop should be initialized after left-click with item");
+    }
+}
+

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopDestroyTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopDestroyTest.java
@@ -1,34 +1,41 @@
 package com.snowgears.shop.integration.features;
 
-import com.snowgears.shop.Shop;
 import com.snowgears.shop.shop.AbstractShop;
-import com.snowgears.shop.util.ShopMessage;
 import com.snowgears.shop.testsupport.BaseMockBukkitTest;
+import com.snowgears.shop.util.CurrencyType;
+import com.snowgears.shop.event.PlayerDestroyShopEvent;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-import org.bukkit.event.block.Action;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
-import org.bukkit.scheduler.BukkitTask;
 import org.mockbukkit.mockbukkit.simulate.entity.PlayerSimulation;
+import org.bukkit.Bukkit;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Collections;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("integration")
 public class ShopDestroyTest extends BaseMockBukkitTest {
-
+    @BeforeEach
+    void resetConfig() {
+        setPluginField("currencyType", CurrencyType.ITEM);
+        setPluginField("creationCost", 0.0);
+        setPluginField("destructionCost", 0.0);
+        setPluginField("returnCreationCost", false);
+        setPluginField("destroyShopRequiresSneak", false);
+        setConfig("usePerms", false);
+    }
 
     @Test
     void destroyOwn_op() {
@@ -36,11 +43,12 @@ public class ShopDestroyTest extends BaseMockBukkitTest {
         World world = server.addSimpleWorld("world");
         PlayerMock player = server.addPlayer();
         // create the shop
-        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 10, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 8, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
 
         PlayerSimulation simulation = new PlayerSimulation(player);
         simulation.simulateBlockBreak(shop.getSignLocation().getBlock());
         assertEquals("§7You have destroyed your selling shop.", waitForNextMessage(player), "Player should be sent dialog after destroying shop sign");
+        assertEquals(Material.AIR, world.getBlockAt(shop.getSignLocation()).getType(), "Shop should be deleted when player has destroy permission");
     }
     @Test
     void destroyOwn_permissions() {
@@ -55,18 +63,21 @@ public class ShopDestroyTest extends BaseMockBukkitTest {
         player.addAttachment(getPlugin(), "shop.destroy", false);
         player.addAttachment(getPlugin(), "shop.operator", false);
         // create the shop
-        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 18, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 18, 65, 0, new ItemStack(Material.DIRT), "sell", 8, "1");
         PlayerSimulation simulation = new PlayerSimulation(player);
         simulation.simulateBlockBreak(shop.getSignLocation().getBlock());
         assertEquals("§cYou are not authorized to destroy your own shops.", waitForNextMessage(player), "Player should be sent dialog denying own shop destroy without shop.destroy permission");
-        
+        assertEquals(Material.OAK_WALL_SIGN, world.getBlockAt(shop.getSignLocation()).getType(), "Shop should still exist when player lacks destroy permission");
+
         player.addAttachment(getPlugin(), "shop.destroy", true);
         simulation.simulateBlockBreak(shop.getSignLocation().getBlock());
         assertEquals("§7You have destroyed your selling shop.", waitForNextMessage(player), "Player should be sent dialog after destroying shop sign");
+        assertEquals(Material.AIR, world.getBlockAt(shop.getSignLocation()).getType(), "Shop should be deleted when player has destroy permission");
     }
 
     @Test
     void destroyOther_noPermission() {
+        setConfig("usePerms", false);
         ServerMock server = getServer();
         World world = server.addSimpleWorld("world");
         PlayerMock player = server.addPlayer();
@@ -78,6 +89,8 @@ public class ShopDestroyTest extends BaseMockBukkitTest {
         PlayerSimulation simulationTwo = new PlayerSimulation(playerTwo);
         simulationTwo.simulateBlockBreak(shop.getSignLocation().getBlock());
         assertEquals("§cYou are not authorized to destroy other players shops.", waitForNextMessage(playerTwo), "Player two should be sent dialog denying shop destruction");
+        assertNotNull(getPlugin().getShopHandler().getShop(shop.getSignLocation()), "Shop should still exist when unauthorized player tries to break sign");
+        assertEquals(Material.OAK_WALL_SIGN, world.getBlockAt(shop.getSignLocation()).getType(), "Shop should still exist when unauthorized player tries to break sign");
     }
     @Test
     void destroyOther_op() {
@@ -93,6 +106,8 @@ public class ShopDestroyTest extends BaseMockBukkitTest {
         PlayerSimulation simulationTwo = new PlayerSimulation(playerTwo);
         simulationTwo.simulateBlockBreak(shop.getSignLocation().getBlock());
         assertEquals("§7You have destroyed a selling shop owned by Steve.", waitForNextMessage(playerTwo), "Player two should be sent dialog allowing shop destruction");
+        assertNull(getPlugin().getShopHandler().getShop(shop.getSignLocation()), "Shop should be deleted by operator");
+        assertEquals(Material.AIR, world.getBlockAt(shop.getSignLocation()).getType(), "Shop should be deleted by operator");
     }
 
     @Test
@@ -112,13 +127,166 @@ public class ShopDestroyTest extends BaseMockBukkitTest {
         PlayerSimulation simulationTwo = new PlayerSimulation(playerTwo);
         simulationTwo.simulateBlockBreak(shop.getSignLocation().getBlock());
         assertEquals("§cYou are not authorized to destroy other players shops.", waitForNextMessage(playerTwo), "Player two should be sent dialog denying shop destruction");
-        
+        assertNotNull(getPlugin().getShopHandler().getShop(shop.getSignLocation()), "Shop should still exist when player lacks destroy.other permission");
+        assertEquals(Material.OAK_WALL_SIGN, world.getBlockAt(shop.getSignLocation()).getType(), "Shop should still exist when player lacks destroy.other permission");
+
         PlayerMock playerThree = server.addPlayer();
         playerThree.setOp(false);
         playerThree.addAttachment(getPlugin(), "shop.destroy.other", true);
         PlayerSimulation simulationThree = new PlayerSimulation(playerThree);
         simulationThree.simulateBlockBreak(shop.getSignLocation().getBlock());
         assertEquals("§7You have destroyed a selling shop owned by Toby.", waitForNextMessage(playerThree), "Player three should be sent dialog allowing shop destruction");
+        assertNull(getPlugin().getShopHandler().getShop(shop.getSignLocation()), "Shop should be deleted when player has destroy.other permission");
+        assertEquals(Material.AIR, world.getBlockAt(shop.getSignLocation()).getType(), "Shop should be deleted when player has destroy.other permission");
+    }
+
+    @Test
+    void chestBreak_primary_prompts_sign_for_owner() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // create the shop
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 20, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        Block chest = shop.getChestLocation().getBlock();
+        assertEquals(Material.CHEST, chest.getType());
+
+        PlayerSimulation simulation = new PlayerSimulation(player);
+        simulation.simulateBlockBreak(chest);
+        assertEquals("§cYou must remove the sign from this shop to break it.", waitForNextMessage(player), "Owner should be prompted to break sign first when breaking primary chest");
+        // Chest should remain since event is cancelled
+        assertEquals(Material.CHEST, chest.getType(), "Primary chest should not break");
+    }
+
+    @Test
+    void chestBreak_expansion_allowed_for_owner() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // create the shop
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 22, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        // Place an adjacent chest to create a double chest (expansion chest)
+        Location primary = shop.getChestLocation();
+        Location expansionLoc = primary.clone().add(1, 0, 0);
+        Block expansion = world.getBlockAt(expansionLoc);
+        expansion.setType(Material.CHEST);
+
+        // Sanity: both halves are chests
+        assertEquals(Material.CHEST, primary.getBlock().getType());
+        assertEquals(Material.CHEST, expansion.getType());
+
+        PlayerSimulation simulation = new PlayerSimulation(player);
+        simulation.simulateBlockBreak(expansion);
+
+        // Expansion chest should be allowed to break
+        assertEquals(Material.AIR, expansion.getType(), "Expansion chest half should break for authorized owner");
+        // Primary chest should remain and shop should still exist
+        assertEquals(Material.CHEST, primary.getBlock().getType(), "Primary chest should remain");
+        assertNotNull(getPlugin().getShopHandler().getShopByChest(primary.getBlock()), "Shop should still exist after breaking expansion chest");
+    }
+
+    @Test
+    void breakBlockUnderShop_protection() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock owner = server.addPlayer();
+
+        // create the shop
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), owner, world, 24, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        // Place a block under the chest
+        Location under = shop.getChestLocation().clone().add(0, -1, 0);
+        Block underBlock = world.getBlockAt(under);
+        underBlock.setType(Material.STONE);
+        assertEquals(Material.STONE, underBlock.getType());
+
+        // Unauthorized player cannot break the block under the chest
+        PlayerMock random = server.addPlayer();
+        random.setOp(false);
+        PlayerSimulation simRandom = new PlayerSimulation(random);
+        simRandom.simulateBlockBreak(underBlock);
+        assertEquals(Material.STONE, underBlock.getType(), "Unauthorized player should not break block under shop chest");
+
+        // Owner can break the block under the chest
+        PlayerSimulation simOwner = new PlayerSimulation(owner);
+        simOwner.simulateBlockBreak(underBlock);
+        assertEquals(Material.AIR, underBlock.getType(), "Owner should be able to break block under shop chest");
+    }
+
+    @Test
+    void destroyRequiresSneak_mustSneakToDestroy() {
+        setConfig("destroyShopRequiresSneak", true);
+
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // create the shop
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 26, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        // Not sneaking: should be cancelled and shop remains
+        player.setSneaking(false);
+        PlayerSimulation simulation = new PlayerSimulation(player);
+        simulation.simulateBlockBreak(shop.getSignLocation().getBlock());
+        assertNotNull(getPlugin().getShopHandler().getShop(shop.getSignLocation()), "Shop should remain when not sneaking with destroyShopRequiresSneak=true");
+
+        // Sneaking: should destroy the shop
+        player.setSneaking(true);
+        simulation.simulateBlockBreak(shop.getSignLocation().getBlock());
+        assertNull(getPlugin().getShopHandler().getShop(shop.getSignLocation()), "Shop should be destroyed when sneaking and destroyShopRequiresSneak=true");
+    }
+
+    // Cost-related tests moved to CreationDestructionCostTest
+
+    @Test
+    void destroy_event_cancellable_prevents_delete() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 34, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        // Register a listener that cancels PlayerDestroyShopEvent
+        Listener l = new Listener() {
+            @EventHandler
+            public void onDestroy(PlayerDestroyShopEvent e) {
+                e.setCancelled(true);
+            }
+        };
+        Bukkit.getPluginManager().registerEvents(l, getPlugin());
+
+        new PlayerSimulation(player).simulateBlockBreak(shop.getSignLocation().getBlock());
+        assertNotNull(getPlugin().getShopHandler().getShop(shop.getSignLocation()), "Shop should remain when PlayerDestroyShopEvent is cancelled");
+    }
+
+    @Test
+    void explosion_protects_shop_blocks() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 36, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        Block signBlock = shop.getSignLocation().getBlock();
+        Block chestBlock = shop.getChestLocation().getBlock();
+
+        List<Block> toBlow = new ArrayList<>();
+        toBlow.add(signBlock);
+        toBlow.add(chestBlock);
+
+        // Mock the event since direct construction is not part of the API contract
+        EntityExplodeEvent event = org.mockito.Mockito.mock(EntityExplodeEvent.class);
+        org.mockito.Mockito.when(event.blockList()).thenReturn(toBlow);
+
+        // Call listener directly
+        new com.snowgears.shop.listener.ShopListener(getPlugin()).onExplosion(event);
+
+        // Listener should have removed shop blocks from the list
+        assertFalse(toBlow.contains(signBlock), "Explosion should not include shop sign block");
+        assertFalse(toBlow.contains(chestBlock), "Explosion should not include shop chest block");
     }
 }
 

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopDestroyTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopDestroyTest.java
@@ -1,0 +1,123 @@
+package com.snowgears.shop.integration.features;
+
+import com.snowgears.shop.Shop;
+import com.snowgears.shop.shop.AbstractShop;
+import com.snowgears.shop.util.ShopMessage;
+import com.snowgears.shop.testsupport.BaseMockBukkitTest;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.bukkit.scheduler.BukkitTask;
+import org.mockbukkit.mockbukkit.simulate.entity.PlayerSimulation;
+
+import java.util.List;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("integration")
+public class ShopDestroyTest extends BaseMockBukkitTest {
+
+
+    @Test
+    void destroyOwn_op() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        // create the shop
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 10, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        PlayerSimulation simulation = new PlayerSimulation(player);
+        simulation.simulateBlockBreak(shop.getSignLocation().getBlock());
+        assertEquals("§7You have destroyed your selling shop.", waitForNextMessage(player), "Player should be sent dialog after destroying shop sign");
+    }
+    @Test
+    void destroyOwn_permissions() {
+        setConfig("usePerms", true);
+        
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        player.setName("Toby");
+        player.setOp(false);
+        player.addAttachment(getPlugin(), "shop.create.sell", true);
+        player.addAttachment(getPlugin(), "shop.destroy", false);
+        player.addAttachment(getPlugin(), "shop.operator", false);
+        // create the shop
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 18, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+        PlayerSimulation simulation = new PlayerSimulation(player);
+        simulation.simulateBlockBreak(shop.getSignLocation().getBlock());
+        assertEquals("§cYou are not authorized to destroy your own shops.", waitForNextMessage(player), "Player should be sent dialog denying own shop destroy without shop.destroy permission");
+        
+        player.addAttachment(getPlugin(), "shop.destroy", true);
+        simulation.simulateBlockBreak(shop.getSignLocation().getBlock());
+        assertEquals("§7You have destroyed your selling shop.", waitForNextMessage(player), "Player should be sent dialog after destroying shop sign");
+    }
+
+    @Test
+    void destroyOther_noPermission() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        // create the shop
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 12, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        PlayerMock playerTwo = server.addPlayer();
+        playerTwo.setOp(false);
+        PlayerSimulation simulationTwo = new PlayerSimulation(playerTwo);
+        simulationTwo.simulateBlockBreak(shop.getSignLocation().getBlock());
+        assertEquals("§cYou are not authorized to destroy other players shops.", waitForNextMessage(playerTwo), "Player two should be sent dialog denying shop destruction");
+    }
+    @Test
+    void destroyOther_op() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        player.setName("Steve");
+        // create the shop
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 14, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        PlayerMock playerTwo = server.addPlayer();
+        playerTwo.setOp(true);
+        PlayerSimulation simulationTwo = new PlayerSimulation(playerTwo);
+        simulationTwo.simulateBlockBreak(shop.getSignLocation().getBlock());
+        assertEquals("§7You have destroyed a selling shop owned by Steve.", waitForNextMessage(playerTwo), "Player two should be sent dialog allowing shop destruction");
+    }
+
+    @Test
+    void destroyOther_permissions() {
+        setConfig("usePerms", true);
+        
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        player.setName("Toby");
+        player.setOp(true);
+        // create the shop
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 16, 65, 10, new ItemStack(Material.DIRT), "sell", 8, "1");
+
+        PlayerMock playerTwo = server.addPlayer();
+        playerTwo.setOp(false);
+        PlayerSimulation simulationTwo = new PlayerSimulation(playerTwo);
+        simulationTwo.simulateBlockBreak(shop.getSignLocation().getBlock());
+        
+        PlayerMock playerThree = server.addPlayer();
+        playerThree.setOp(false);
+        playerThree.addAttachment(getPlugin(), "shop.destroy.other", true);
+        PlayerSimulation simulationThree = new PlayerSimulation(playerThree);
+        simulationThree.simulateBlockBreak(shop.getSignLocation().getBlock());
+        assertEquals("§7You have destroyed a selling shop owned by Toby.", waitForNextMessage(playerThree), "Player three should be sent dialog allowing shop destruction");
+    }
+}
+

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopDestroyTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopDestroyTest.java
@@ -111,6 +111,7 @@ public class ShopDestroyTest extends BaseMockBukkitTest {
         playerTwo.setOp(false);
         PlayerSimulation simulationTwo = new PlayerSimulation(playerTwo);
         simulationTwo.simulateBlockBreak(shop.getSignLocation().getBlock());
+        assertEquals("§cYou are not authorized to destroy other players shops.", waitForNextMessage(playerTwo), "Player two should be sent dialog denying shop destruction");
         
         PlayerMock playerThree = server.addPlayer();
         playerThree.setOp(false);

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopMissingBlocksTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopMissingBlocksTest.java
@@ -97,15 +97,15 @@ public class ShopMissingBlocksTest extends BaseMockBukkitTest {
         assertNotNull(getPlugin().getShopHandler().getShop(signLoc), "Shop should be registered");
 
         // Corrupt the sign block so it is no longer a Sign
-        world.getBlockAt(signLoc).setType(Material.CHEST);
+        world.getBlockAt(signLoc).setType(Material.DIRT);
+        world.loadChunk(signLoc.getChunk());
 
         // Trigger updateSign, which should catch the ClassCastException and delete the shop
-        shop.setSignLinesRequireRefresh(true);
-        shop.updateSign();
-        server.getScheduler().performTicks(5);
+        shop.updateSign(true);
         server.getScheduler().waitAsyncTasksFinished();
 
         assertNull(getPlugin().getShopHandler().getShop(signLoc), "Shop should be deleted when updateSign detects non-Sign block at sign location");
+        assertTrue(world.getBlockAt(signLoc).getType() == Material.DIRT, "Sign block should remain dirt");
     }
 
     @Test

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopMissingBlocksTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopMissingBlocksTest.java
@@ -1,0 +1,174 @@
+package com.snowgears.shop.integration.features;
+
+import com.snowgears.shop.Shop;
+import com.snowgears.shop.shop.AbstractShop;
+import com.snowgears.shop.shop.ShopType;
+import com.snowgears.shop.testsupport.BaseMockBukkitTest;
+import com.snowgears.shop.util.PricePair;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.type.WallSign;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@Tag("integration")
+public class ShopMissingBlocksTest extends BaseMockBukkitTest {
+
+    // Note: We intentionally do not test a null signLocation, as constructing a shop
+    // with a null sign is not supported by public creation APIs and would NPE during
+    // construction (display initialization). The remaining tests exercise the new
+    // defensive branches added to load()/updateSign().
+
+    @Test
+    void load_returnsFalse_whenSignBlockIsAir() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        Location signLoc = new Location(world, 5, 65, 5);
+        world.getBlockAt(signLoc).setType(Material.AIR);
+
+        AbstractShop shop = AbstractShop.create(signLoc, player.getUniqueId(), 10, 0, 1, false, ShopType.SELL, null);
+        assertNotNull(shop);
+
+        boolean loaded = shop.load();
+        assertFalse(loaded, "Shop.load() should return false when sign block is AIR");
+    }
+
+    @Test
+    void load_returnsFalse_whenSignBlockIsNotWallSign() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        Location signLoc = new Location(world, 6, 65, 5);
+        world.getBlockAt(signLoc).setType(Material.OAK_SIGN); // standing sign, not a WallSign
+
+        AbstractShop shop = AbstractShop.create(signLoc, player.getUniqueId(), 10, 0, 1, false, ShopType.SELL, null);
+        assertNotNull(shop);
+
+        boolean loaded = shop.load();
+        assertFalse(loaded, "Shop.load() should return false when sign block is not a WallSign");
+    }
+
+    @Test
+    void load_returnsFalse_whenChestBehindSignIsInvalid() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        Location signLoc = new Location(world, 7, 65, 5);
+        Block signBlock = world.getBlockAt(signLoc);
+        signBlock.setType(Material.OAK_WALL_SIGN);
+        WallSign data = (WallSign) signBlock.getBlockData();
+        data.setFacing(BlockFace.NORTH);
+        world.setBlockData(signLoc, data);
+
+        // Place a non-container behind the sign (opposite of facing)
+        Block behind = signBlock.getRelative(BlockFace.NORTH.getOppositeFace());
+        behind.setType(Material.STONE);
+
+        AbstractShop shop = AbstractShop.create(signLoc, player.getUniqueId(), 10, 0, 1, false, ShopType.SELL, null);
+        assertNotNull(shop);
+
+        boolean loaded = shop.load();
+        assertFalse(loaded, "Shop.load() should return false when the block behind a valid WallSign is not a valid container");
+    }
+
+    @Test
+    void updateSign_deletesShop_whenSignBlockNotASign() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // Create a valid shop via chest flow helper so it is registered
+        AbstractShop shop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 12, 65, 12, new org.bukkit.inventory.ItemStack(Material.DIRT), "sell", 8, "1");
+        assertNotNull(shop);
+        Location signLoc = shop.getSignLocation();
+        assertNotNull(getPlugin().getShopHandler().getShop(signLoc), "Shop should be registered");
+
+        // Corrupt the sign block so it is no longer a Sign
+        world.getBlockAt(signLoc).setType(Material.CHEST);
+
+        // Trigger updateSign, which should catch the ClassCastException and delete the shop
+        shop.setSignLinesRequireRefresh(true);
+        shop.updateSign();
+        server.getScheduler().performTicks(5);
+        server.getScheduler().waitAsyncTasksFinished();
+
+        assertNull(getPlugin().getShopHandler().getShop(signLoc), "Shop should be deleted when updateSign detects non-Sign block at sign location");
+    }
+
+    @Test
+    void load_catchesException_andDeletes() throws Exception {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // Create a valid shop first so construction succeeds and it is registered
+        AbstractShop realShop = ShopCreationChestTest.createShop(server, getPlugin(), player, world, 44, 65, 12, new org.bukkit.inventory.ItemStack(Material.DIRT), "sell", 8, "1");
+        assertNotNull(realShop);
+        Location originalSignLoc = realShop.getSignLocation();
+        assertNotNull(getPlugin().getShopHandler().getShop(originalSignLoc), "Shop should be registered prior to test");
+
+        // Spy the real shop and force an exception during the load cycle
+        AbstractShop shop = Mockito.spy(realShop);
+        Mockito.doThrow(new RuntimeException("Simulated exception during updateStock"))
+                .when(shop).updateStock();
+
+        boolean loaded = shop.load();
+        assertFalse(loaded, "Shop.load() should catch unexpected exceptions and return false");
+        assertNull(getPlugin().getShopHandler().getShop(originalSignLoc), "No shop should be registered at the sign location when creation fails");
+    }
+
+    @Test
+    void createShop_returnsNull_whenLoadFails_dueToMismatchedSignAndChest() {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+
+        // Prepare a valid chest far from the sign
+        Location chestLoc = new Location(world, 20, 65, 20);
+        Block chestBlock = world.getBlockAt(chestLoc);
+        chestBlock.setType(Material.CHEST);
+
+        // Prepare a WallSign that does NOT face the chest (and with a non-container behind it)
+        Location signLoc = new Location(world, 30, 65, 30);
+        Block signBlock = world.getBlockAt(signLoc);
+        signBlock.setType(Material.OAK_WALL_SIGN);
+        WallSign data = (WallSign) signBlock.getBlockData();
+        data.setFacing(BlockFace.NORTH);
+        world.setBlockData(signLoc, data);
+        // Ensure behind-the-sign is not a valid container
+        signBlock.getRelative(BlockFace.SOUTH).setType(Material.STONE);
+
+        PricePair pricePair = new PricePair(10, 0);
+        AbstractShop created = plugin.getShopCreationUtil().createShop(
+                player,
+                chestBlock,
+                signBlock,
+                pricePair,
+                1,
+                false,
+                ShopType.SELL,
+                BlockFace.NORTH,
+                false
+        );
+
+        assertNull(created, "ShopCreationUtil.createShop should return null when shop.load() fails due to invalid/mismatched blocks");
+        assertNull(plugin.getShopHandler().getShop(signLoc), "No shop should be registered at the sign location when creation fails");
+    }
+}
+
+

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopSaveTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopSaveTest.java
@@ -315,16 +315,6 @@ public class ShopSaveTest extends BaseMockBukkitTest {
         assertFalse(playerFile.exists(), "Player save should be removed when player has no shops");
     }
 
-    private static int countMatches(String haystack, String needle) {
-        int count = 0;
-        int idx = 0;
-        while ((idx = haystack.indexOf(needle, idx)) != -1) {
-            count++;
-            idx += needle.length();
-        }
-        return count;
-    }
-
     private static Object getAtPath(java.util.Map<String, Object> root, String path) {
         String[] parts = path.split("\\.");
         Object current = root;
@@ -339,7 +329,6 @@ public class ShopSaveTest extends BaseMockBukkitTest {
     }
     @Test
     void saveShops_withNoShops_deletesExistingFile() throws IOException {
-        ServerMock server = getServer();
         Shop plugin = getPlugin();
         // Use a random UUID that has no shops registered in the handler
         UUID randomPlayer = UUID.randomUUID();

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopSaveTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopSaveTest.java
@@ -1,0 +1,456 @@
+package com.snowgears.shop.integration.features;
+
+import com.snowgears.shop.Shop;
+import com.snowgears.shop.shop.AbstractShop;
+import com.snowgears.shop.testsupport.BaseMockBukkitTest;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.UUID;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mockStatic;
+import org.mockito.MockedStatic;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+import org.mockbukkit.mockbukkit.simulate.entity.PlayerSimulation;
+import org.yaml.snakeyaml.Yaml;
+
+@Tag("integration")
+public class ShopSaveTest extends BaseMockBukkitTest {
+
+    @Test
+    void saveShops_happyPath_writesYamlAndNoBackup() {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // Arrange: create an initialized shop for the player
+        ItemStack item = new ItemStack(Material.DIRT);
+        AbstractShop shop = ShopCreationChestTest.createShop(
+                server,
+                plugin,
+                player,
+                world,
+                new Location(world, 10, 65, 10),
+                item,
+                "sell",
+                8,
+                "1"
+        );
+        assertNotNull(shop, "Shop should be created for the player");
+        assertTrue(shop.isInitialized(), "Shop should be initialized after creation flow");
+
+        // Act: explicitly save the player's shops
+        int shopsSaved = plugin.getShopHandler().saveShops(player.getUniqueId(), true);
+        assertEquals(1, shopsSaved, "Exactly one shop should be saved");
+
+        // Assert: file exists, has content, and no leftover .bak remains
+        File dataDir = new File(plugin.getDataFolder(), "Data");
+        File playerFile = new File(dataDir, player.getUniqueId().toString() + ".yml");
+        assertTrue(playerFile.exists(), "Player YAML file should exist after saving");
+        assertTrue(playerFile.length() > 0, "Player YAML file should not be empty");
+
+        File backupFile = new File(dataDir, player.getUniqueId().toString() + ".yml.bak");
+        assertFalse(backupFile.exists(), "No backup file should remain after successful save");
+
+        // Optionally verify that the YAML contains a section for the player's UUID without deserializing Bukkit objects
+        String yaml = assertDoesNotThrow(() -> Files.readString(playerFile.toPath()), "Should be able to read saved YAML as text");
+        assertTrue(yaml.contains("shops:"), "YAML should contain the shops root key");
+        assertTrue(yaml.contains(player.getUniqueId().toString()), "YAML should contain the player's UUID");
+    }
+
+    @Test
+    void createTempFileFails_preservesExistingFile_andReturnsError() throws Exception {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // Create one shop so saveShops attempts to write
+        ShopCreationChestTest.createShop(server, plugin, player, world, new Location(world, 40, 65, 40), new ItemStack(Material.DIRT), "sell", 1, "1");
+
+        // Overwrite target with sentinel original content to verify preservation on failure
+        File dataDir = new File(plugin.getDataFolder(), "Data");
+        assertTrue(dataDir.mkdirs() || dataDir.exists());
+        File playerFile = new File(dataDir, player.getUniqueId().toString() + ".yml");
+        Files.writeString(playerFile.toPath(), "ORIGINAL_CONTENT");
+        String original = Files.readString(playerFile.toPath());
+
+        // Mock Files.createTempFile to throw, other Files calls should pass through
+        try (MockedStatic<Files> filesMock = mockStatic(Files.class, invocation -> {
+            if (invocation.getMethod().getName().equals("createTempFile")) {
+                throw new IOException("Simulated: createTempFile failed");
+            }
+            return invocation.callRealMethod();
+        })) {
+            int result = plugin.getShopHandler().saveShops(player.getUniqueId(), true);
+            assertEquals(-2, result, "Should return -2 when temp file cannot be created, but file was left untouched (and/or restored successfully from backup)");
+        }
+
+        // Assert the existing file is unchanged and no .bak exists
+        assertTrue(playerFile.exists());
+        assertEquals(original, Files.readString(playerFile.toPath()));
+        assertFalse(Files.exists(playerFile.toPath().resolveSibling(playerFile.getName() + ".bak")));
+    }
+
+    @Test
+    void yamlSaveThrows_preservesExistingFile_andReturnsError() throws Exception {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // Create one shop so saveShops attempts to write
+        ShopCreationChestTest.createShop(server, plugin, player, world, new Location(world, 41, 65, 41), new ItemStack(Material.DIRT), "sell", 1, "1");
+
+        // Overwrite target with sentinel original content to verify preservation on failure
+        File dataDir = new File(plugin.getDataFolder(), "Data");
+        assertTrue(dataDir.mkdirs() || dataDir.exists());
+        File playerFile = new File(dataDir, player.getUniqueId().toString() + ".yml");
+        Files.writeString(playerFile.toPath(), "ORIGINAL_CONTENT");
+        String original = Files.readString(playerFile.toPath());
+
+        // Allow createTempFile to succeed but force YamlConfiguration.save to throw
+        try (MockedConstruction<org.bukkit.configuration.file.YamlConfiguration> yamlMock =
+                     Mockito.mockConstruction(org.bukkit.configuration.file.YamlConfiguration.class,
+                             (mock, context) -> {
+                                 Mockito.doThrow(new IOException("Simulated: yaml save failed"))
+                                         .when(mock).save(Mockito.any(File.class));
+                             })) {
+            int result = plugin.getShopHandler().saveShops(player.getUniqueId(), true);
+            assertEquals(-2, result, "Should return -2 when YAML save fails, but file was left untouched (and/or restored successfully from backup)");
+        }
+
+        // Assert the existing file is unchanged and no .bak exists
+        assertTrue(playerFile.exists());
+        assertEquals(original, Files.readString(playerFile.toPath()));
+        assertFalse(Files.exists(playerFile.toPath().resolveSibling(playerFile.getName() + ".bak")));
+    }
+
+    @Test
+    void totalDataLoss_disablesPlugin_andReturnsMinusFive() throws Exception {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // Arrange: create a shop so saveShops will attempt to write
+        ShopCreationChestTest.createShop(server, plugin, player, world, new Location(world, 42, 65, 42), new ItemStack(Material.DIRT), "sell", 1, "1");
+
+        // Pre-compute target and backup paths
+        File dataDir = new File(plugin.getDataFolder(), "Data");
+        File playerFile = new File(dataDir, player.getUniqueId().toString() + ".yml");
+        Path target = playerFile.toPath();
+        Path backup = target.resolveSibling(target.getFileName().toString() + ".bak");
+
+        // Ensure starting state has no files
+        Files.deleteIfExists(target);
+        Files.deleteIfExists(backup);
+
+        // Mock: ATOMIC_MOVE fails → fallback; fallback temp->target move fails; no backup exists; final check sees both missing
+        try (MockedStatic<Files> filesMock = mockStatic(Files.class, invocation -> {
+            String name = invocation.getMethod().getName();
+            if (name.equals("createTempFile")) {
+                return invocation.callRealMethod();
+            }
+            if (name.equals("move")) {
+                Object[] args = invocation.getArguments();
+                // If atomic move is requested, fail to force fallback
+                for (Object o : args) {
+                    if (o == StandardCopyOption.ATOMIC_MOVE) {
+                        throw new IOException("Simulated: atomic move unsupported");
+                    }
+                }
+                // In fallback, fail temp -> target move to trigger restore branch
+                Path src = (Path) args[0];
+                Path dst = (Path) args[1];
+                if (src.getFileName().toString().endsWith(".tmp") && dst.equals(target)) {
+                    throw new IOException("Simulated: fallback move failed");
+                }
+                return invocation.callRealMethod();
+            }
+            if (name.equals("exists")) {
+                Path p = (Path) invocation.getArguments()[0];
+                if (p.equals(target) || p.equals(backup)) {
+                    return false; // simulate total loss: neither exists
+                }
+                return invocation.callRealMethod();
+            }
+            if (name.equals("deleteIfExists")) {
+                return invocation.callRealMethod();
+            }
+            return invocation.callRealMethod();
+        })) {
+            int result = plugin.getShopHandler().saveShops(player.getUniqueId(), true);
+            assertEquals(-5, result, "Should return -5 on total data loss");
+            server.getScheduler().waitAsyncEventsFinished();
+            server.getScheduler().waitAsyncTasksFinished();
+            assertFalse(plugin.isEnabled(), "Plugin should be disabled to prevent cascading data loss");
+        }
+
+        // Final state: both files should be absent
+        assertFalse(Files.exists(target));
+        assertFalse(Files.exists(backup));
+    }
+    @Test
+    void saveShops_yamlContainsExpectedStructure_forMultipleShops() {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        PlayerMock player2 = server.addPlayer();
+
+        // Arrange: create two initialized shops for the player
+        AbstractShop shop1 = ShopCreationChestTest.createShop(
+                server, plugin, player, world,
+                new Location(world, 20, 65, 20), new ItemStack(Material.DIRT), "sell", 4, "2"
+        );
+        // Create a shop for the second player to make sure they are saved seperately
+        AbstractShop player2Shop = ShopCreationChestTest.createShop(
+                server, plugin, player2, world,
+                new Location(world, 19, 65, 19), new ItemStack(Material.OAK_LOG), "sell", 4, "1"
+        );
+
+        AbstractShop shop2 = ShopCreationChestTest.createShop(
+                server, plugin, player, world,
+                new Location(world, 21, 65, 21), new ItemStack(Material.STONE), "sell", 8, "3"
+        );
+        // Make sure the shops are both created
+        assertTrue(shop1.isInitialized() && shop2.isInitialized() && player2Shop.isInitialized());
+        assertEquals(2, plugin.getShopHandler().getNumberOfShops(player.getUniqueId()), "Two shops should exist for the player");
+        assertEquals(1, plugin.getShopHandler().getNumberOfShops(player2.getUniqueId()), "One shop should exist for the second player");
+
+        // Assert: YAML structure contains both shop indexes and expected keys
+        // Shop will have been saved automatically when created, so no need to explicitly trigger the save function.
+        File dataDir = new File(plugin.getDataFolder(), "Data");
+        File playerFile = new File(dataDir, player.getUniqueId().toString() + ".yml");
+        File player2File = new File(dataDir, player2.getUniqueId().toString() + ".yml");
+        assertTrue(playerFile.exists());
+        assertTrue(player2File.exists());
+        String yamlText = assertDoesNotThrow(() -> Files.readString(playerFile.toPath()));
+        String yamlText2 = assertDoesNotThrow(() -> Files.readString(player2File.toPath()));
+        String playerUuid = player.getUniqueId().toString();
+        String player2Uuid = player2.getUniqueId().toString();
+
+        // Parse YAML safely using SnakeYAML (no Bukkit deserialization)
+        @SuppressWarnings("unchecked")
+        var root1 = (java.util.Map<String, Object>) new Yaml().load(yamlText);
+        @SuppressWarnings("unchecked")
+        var root2 = (java.util.Map<String, Object>) new Yaml().load(yamlText2);
+
+        // shops map exists
+        @SuppressWarnings("unchecked")
+        var shops1 = (java.util.Map<String, Object>) getAtPath(root1, "shops");
+        @SuppressWarnings("unchecked")
+        var shops2 = (java.util.Map<String, Object>) getAtPath(root2, "shops");
+        assertNotNull(shops1, "shops should exist in player1 YAML");
+        assertNotNull(shops2, "shops should exist in player2 YAML");
+        assertTrue(shops1.containsKey(playerUuid), "player1 file should have player1 UUID");
+        assertFalse(shops1.containsKey(player2Uuid), "player1 file should not have player2 UUID");
+        assertTrue(shops2.containsKey(player2Uuid), "player2 file should have their UUID");
+        assertFalse(shops2.containsKey(playerUuid), "player2 file should not have player1 UUID");
+
+        // Player1 shop 1 assertions
+        assertEquals(4, getAtPath(root1, "shops." + playerUuid + ".1.amount"));
+        assertEquals(2.0, ((Number) getAtPath(root1, "shops." + playerUuid + ".1.price")).doubleValue(), 0.0001);
+        assertEquals("sell", getAtPath(root1, "shops." + playerUuid + ".1.type"));
+        assertEquals("DIRT", getAtPath(root1, "shops." + playerUuid + ".1.item.type"));
+        // Player1 shop 2 assertions
+        assertEquals(8, getAtPath(root1, "shops." + playerUuid + ".2.amount"));
+        assertEquals(3.0, ((Number) getAtPath(root1, "shops." + playerUuid + ".2.price")).doubleValue(), 0.0001);
+        assertEquals("sell", getAtPath(root1, "shops." + playerUuid + ".2.type"));
+        assertEquals("STONE", getAtPath(root1, "shops." + playerUuid + ".2.item.type"));
+
+        // Player2 only one shop (index 1)
+        assertEquals(4, getAtPath(root2, "shops." + player2Uuid + ".1.amount"));
+        assertEquals(1.0, ((Number) getAtPath(root2, "shops." + player2Uuid + ".1.price")).doubleValue(), 0.0001);
+        assertEquals("sell", getAtPath(root2, "shops." + player2Uuid + ".1.type"));
+        assertEquals("OAK_LOG", getAtPath(root2, "shops." + player2Uuid + ".1.item.type"));
+    }
+
+    @Test
+    void createThenDeleteShop_andSave_removesPlayerSaveFile() throws Exception {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // Create one shop
+        AbstractShop shop = ShopCreationChestTest.createShop(
+                server, plugin, player, world,
+                new Location(world, 30, 65, 30), new ItemStack(Material.DIRT), "sell", 1, "1"
+        );
+        assertTrue(shop.isInitialized());
+
+        // Save and verify file exists
+        int savedFirst = plugin.getShopHandler().saveShops(player.getUniqueId(), true);
+        assertEquals(1, savedFirst);
+        File dataDir = new File(plugin.getDataFolder(), "Data");
+        File playerFile = new File(dataDir, player.getUniqueId().toString() + ".yml");
+        assertTrue(playerFile.exists(), "Player save should exist after save");
+
+        // Delete the shop by breaking the sign
+        PlayerSimulation sim = new PlayerSimulation(player);
+        sim.simulateBlockBreak(shop.getSignLocation().getBlock());
+        // Ensure the shop is actually gone in handler
+        assertNull(plugin.getShopHandler().getShop(shop.getSignLocation()), "Shop should be removed after breaking sign");
+
+        // Save again; file should be removed because player has no shops now
+        int savedSecond = plugin.getShopHandler().saveShops(player.getUniqueId(), true);
+        assertEquals(-1, savedSecond, "File should be deleted when player has no shops");
+        assertFalse(playerFile.exists(), "Player save should be removed when player has no shops");
+    }
+
+    private static int countMatches(String haystack, String needle) {
+        int count = 0;
+        int idx = 0;
+        while ((idx = haystack.indexOf(needle, idx)) != -1) {
+            count++;
+            idx += needle.length();
+        }
+        return count;
+    }
+
+    private static Object getAtPath(java.util.Map<String, Object> root, String path) {
+        String[] parts = path.split("\\.");
+        Object current = root;
+        for (String part : parts) {
+            if (current == null) return null;
+            if (!(current instanceof java.util.Map)) return null;
+            @SuppressWarnings("unchecked")
+            java.util.Map<String, Object> map = (java.util.Map<String, Object>) current;
+            current = map.get(part);
+        }
+        return current;
+    }
+    @Test
+    void saveShops_withNoShops_deletesExistingFile() throws IOException {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        // Use a random UUID that has no shops registered in the handler
+        UUID randomPlayer = UUID.randomUUID();
+
+        // Pre-create a file as if it existed from a prior run
+        File dataDir = new File(plugin.getDataFolder(), "Data");
+        assertTrue(dataDir.mkdirs() || dataDir.exists(), "Data directory should exist");
+        File playerFile = new File(dataDir, randomPlayer.toString() + ".yml");
+        assertTrue(playerFile.createNewFile() || playerFile.exists(), "Precondition: player YAML should exist before save");
+        assertTrue(playerFile.exists(), "Precondition: player YAML exists");
+
+        // Act: saving for a player with no shops should delete the file
+        int shopsSaved = plugin.getShopHandler().saveShops(randomPlayer, true);
+        assertEquals(-1, shopsSaved, "No shops should be saved for a player with no shops");
+        assertFalse(playerFile.exists(), "Player YAML file should be deleted when no shops exist");
+    }
+
+
+    @Test
+    void atomicMoveUnsupported_fallbackSucceeds_andBackupRemoved() throws IOException {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // Arrange: create a shop so saveShops writes a YAML
+        ShopCreationChestTest.createShop(server, plugin, player, world, new Location(world, 10, 65, 10), new ItemStack(Material.DIRT), "sell", 1, "5");
+
+        // Pre-create an existing file to force backup path
+        File dataDir = new File(plugin.getDataFolder(), "Data");
+        File playerFile = new File(dataDir, player.getUniqueId().toString() + ".yml");
+        assertTrue(dataDir.mkdirs() || dataDir.exists());
+        java.nio.file.Files.writeString(playerFile.toPath(), "OLD_DATA", StandardCharsets.UTF_8);
+        assertTrue(playerFile.exists());
+
+        // Simulate: ATOMIC_MOVE fails, other moves act normal
+        try (MockedStatic<Files> filesMock = mockStatic(Files.class, invocation -> {
+            if (invocation.getMethod().getName().equals("move")) {
+                Object[] args = invocation.getArguments();
+                // args: source, target, options...
+                for (Object o : args) {
+                    if (o == StandardCopyOption.ATOMIC_MOVE) {
+                        throw new IOException("Simulated: atomic move unsupported");
+                    }
+                }
+            }
+            return invocation.callRealMethod();
+        })) {
+            int savedCount = plugin.getShopHandler().saveShops(player.getUniqueId(), true);
+            assertEquals(1, savedCount);
+        }
+
+        // Assert: final file exists and backup was removed
+        Path target = playerFile.toPath();
+        Path backup = target.resolveSibling(target.getFileName().toString() + ".bak");
+        assertTrue(java.nio.file.Files.exists(target), "Target file should exist after fallback");
+        assertFalse(java.nio.file.Files.exists(backup), "Backup should be deleted after successful fallback");
+
+        String content = java.nio.file.Files.readString(target);
+        assertTrue(content.contains("shops:"), "New YAML content should be present");
+        assertFalse(content.contains("OLD_DATA"), "Old sentinel content should have been replaced");
+    }
+
+    @Test
+    void fallbackMoveFails_backupRestored_andTargetPreserved() throws IOException {
+        ServerMock server = getServer();
+        Shop plugin = getPlugin();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+
+        // Arrange: create a shop so saveShops will attempt to write
+        ShopCreationChestTest.createShop(server, plugin, player, world, new Location(world, 12, 65, 12), new ItemStack(Material.DIRT), "sell", 1, "5");
+
+        // Pre-create original target file with sentinel content
+        File dataDir = new File(plugin.getDataFolder(), "Data");
+        File playerFile = new File(dataDir, player.getUniqueId().toString() + ".yml");
+        assertTrue(dataDir.mkdirs() || dataDir.exists());
+        java.nio.file.Files.writeString(playerFile.toPath(), "ORIGINAL_CONTENT", StandardCharsets.UTF_8);
+        String original = java.nio.file.Files.readString(playerFile.toPath());
+
+        // Simulate: ATOMIC_MOVE fails; backup move succeeds; temp->target fails; restore backup succeeds
+        try (MockedStatic<Files> filesMock = mockStatic(Files.class, invocation -> {
+            String name = invocation.getMethod().getName();
+            if (name.equals("move")) {
+                Object[] args = invocation.getArguments();
+                Path source = (Path) args[0];
+                Path target = (Path) args[1];
+                for (Object o : args) {
+                    if (o == StandardCopyOption.ATOMIC_MOVE) {
+                        throw new IOException("Simulated: atomic move unsupported");
+                    }
+                }
+                // temp -> target move should fail
+                if (source.getFileName().toString().endsWith(".tmp") && target.getFileName().toString().endsWith(".yml")) {
+                    throw new IOException("Simulated: failure moving temp into place");
+                }
+            }
+            return invocation.callRealMethod();
+        })) {
+            // int saved = plugin.getShopHandler().saveShops(player.getUniqueId(), true);
+            // assertEquals(-1, saved);
+            ShopCreationChestTest.createShop(server, plugin, player, world, new Location(world, 10, 65, 12), new ItemStack(Material.COBBLESTONE), "sell", 64, "2");
+        }
+
+        // Assert: target restored to original content and no lingering .bak file
+        Path target = playerFile.toPath();
+        Path backup = target.resolveSibling(target.getFileName().toString() + ".bak");
+        assertTrue(Files.exists(target), "Target should exist after restore");
+        assertFalse(Files.exists(backup), "Backup should not remain after restore");
+        String finalContent = Files.readString(target);
+        assertEquals(original, finalContent, "Original content should be restored on failure");
+    }
+}
+

--- a/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
+++ b/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
@@ -49,6 +49,8 @@ public abstract class BaseMockBukkitTest {
 
         // Disable displays to avoid NMS/NBT code paths in tests
         setConfig("displayType", DisplayType.NONE);
+        // No cooldown between shop creations to allow us to create multiple. We can change this in tests if needed.
+        setConfig("debug_shopCreateCooldown", 0);
 
         // Spy and stub NBTAdapter.getNBTforItem to return a static string
         NBTAdapter original = (NBTAdapter) getPluginField("nbtAdapter");

--- a/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
+++ b/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
@@ -1,10 +1,21 @@
 package com.snowgears.shop.testsupport;
 
 import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import org.mockbukkit.mockbukkit.ServerMock;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
+import java.util.Collections;
 import com.snowgears.shop.Shop;
+import com.snowgears.shop.display.DisplayType;
+import com.snowgears.shop.util.CurrencyType;
+import com.snowgears.shop.util.NBTAdapter;
+import com.snowgears.shop.util.ShopCreationUtil;
+import net.milkbowl.vault.economy.Economy;
+import net.milkbowl.vault.economy.EconomyResponse;
+import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.mockito.Mockito;
 
 /**
  * Base class for MockBukkit based tests.
@@ -29,6 +40,30 @@ public abstract class BaseMockBukkitTest {
     static void initServer() {
         server = MockBukkit.mock();
         plugin = MockBukkit.load(Shop.class);
+
+        server.getScheduler().waitAsyncTasksFinished();
+
+        // Disable displays to avoid NMS/NBT code paths in tests
+        setConfig("displayType", DisplayType.NONE);
+
+        // Inject Economy mock if Vault currency is enabled
+        if (plugin.getCurrencyType() == CurrencyType.VAULT) {
+            Economy mockedEconomy = Mockito.mock(Economy.class);
+            Mockito.when(mockedEconomy.getBalance(Mockito.any(org.bukkit.OfflinePlayer.class))).thenReturn(10_000.0);
+            Mockito.when(mockedEconomy.withdrawPlayer(Mockito.any(org.bukkit.OfflinePlayer.class), Mockito.anyDouble()))
+                    .thenAnswer(inv -> new EconomyResponse(inv.getArgument(1), 10_000.0, ResponseType.SUCCESS, "ok"));
+            Mockito.when(mockedEconomy.depositPlayer(Mockito.any(org.bukkit.OfflinePlayer.class), Mockito.anyDouble()))
+                    .thenAnswer(inv -> new EconomyResponse(inv.getArgument(1), 10_000.0, ResponseType.SUCCESS, "ok"));
+            setPluginField("econ", mockedEconomy);
+        }
+
+        // Spy and stub NBTAdapter.getNBTforItem to return a static string
+        NBTAdapter original = (NBTAdapter) getPluginField("nbtAdapter");
+        if (original != null) {
+            NBTAdapter spy = Mockito.spy(original);
+            Mockito.doReturn("{count:1,id:\"minecraft:dirt\"}").when(spy).getNBTforItem(Mockito.any());
+            setPluginField("nbtAdapter", spy);
+        }
     }
 
     @AfterAll
@@ -44,5 +79,69 @@ public abstract class BaseMockBukkitTest {
 
     protected Shop getPlugin() {
         return plugin;
+    }
+
+    // ---------- Test tooling helpers ----------
+    protected static void sendChatMessage(PlayerMock player, String message) {
+        AsyncPlayerChatEvent amountEvent = new AsyncPlayerChatEvent(true, player, message, Collections.emptySet());
+        // server.getPluginManager().callEventAsynchronously(amountEvent);
+        // server.getScheduler().executeAsyncEvent(amountEvent);
+        try {
+            server.getScheduler().executeAsyncEvent(amountEvent).get();
+        } catch (Error | Exception e) {
+            throw new RuntimeException("Failed to send chat message", e);
+        }
+    }
+
+    protected static String waitForNextMessage(PlayerMock player) {
+        String nextMessage = null;
+        int attempts = 0;   
+        while (nextMessage == null && attempts < 1000) {
+            nextMessage = player.nextMessage();
+            if (nextMessage == null) {
+                server.getScheduler().performTicks(1);
+                attempts++;
+            }
+        }
+        System.out.println("ticks: " + attempts + ", message: `" + nextMessage + "`");
+        return nextMessage;
+    }
+
+    protected static <T> T getPluginField(String fieldName) {
+        try {
+            var field = Shop.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return (T) field.get(plugin);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get field '" + fieldName + "' on Shop", e);
+        }
+    }
+
+    protected static void setPluginField(String fieldName, Object value) {
+        try {
+            var field = Shop.class.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(plugin, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set field '" + fieldName + "' on Shop", e);
+        }
+    }
+
+    protected static void setConfig(String fieldName, boolean value) {
+        setPluginField(fieldName, value);
+    }
+
+    protected static <E extends Enum<E>> void setConfig(String fieldName, E value) {
+        setPluginField(fieldName, value);
+    }
+
+    // Allow tests to stub calculateBlockFaceForSign to avoid MockBukkit material checks
+    protected static void stubCalculateBlockFaceForSign(org.bukkit.block.BlockFace face) {
+        ShopCreationUtil original = getPluginField("shopCreationUtil");
+        if (original != null) {
+            ShopCreationUtil spy = Mockito.spy(original);
+            Mockito.doReturn(face).when(spy).calculateBlockFaceForSign(Mockito.any(), Mockito.any(), Mockito.any());
+            setPluginField("shopCreationUtil", spy);
+        }
     }
 }

--- a/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
+++ b/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
@@ -4,6 +4,7 @@ import org.mockbukkit.mockbukkit.MockBukkit;
 import org.mockbukkit.mockbukkit.entity.PlayerMock;
 import org.mockbukkit.mockbukkit.ServerMock;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
+import org.bukkit.block.BlockFace;
 import java.util.Collections;
 import com.snowgears.shop.Shop;
 import com.snowgears.shop.display.DisplayType;
@@ -16,6 +17,7 @@ import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.mockito.Mockito;
+import org.mockito.internal.util.MockUtil;
 
 /**
  * Base class for MockBukkit based tests.
@@ -136,9 +138,9 @@ public abstract class BaseMockBukkitTest {
     }
 
     // Allow tests to stub calculateBlockFaceForSign to avoid MockBukkit material checks
-    protected static void stubCalculateBlockFaceForSign(org.bukkit.block.BlockFace face) {
+    protected static void stubCalculateBlockFaceForSign(BlockFace face) {
         ShopCreationUtil original = getPluginField("shopCreationUtil");
-        if (original != null) {
+        if (original != null && !MockUtil.isMock(original)) {
             ShopCreationUtil spy = Mockito.spy(original);
             Mockito.doReturn(face).when(spy).calculateBlockFaceForSign(Mockito.any(), Mockito.any(), Mockito.any());
             setPluginField("shopCreationUtil", spy);

--- a/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
+++ b/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
@@ -47,6 +47,8 @@ public abstract class BaseMockBukkitTest {
 
         server.getScheduler().waitAsyncTasksFinished();
 
+        setConfig("checkUpdates", false);
+        // setRawConfig("logging.type", "OFF"); // happens after the plugin is loaded so kinda useless...
         // Disable displays to avoid NMS/NBT code paths in tests
         setConfig("displayType", DisplayType.NONE);
         // No cooldown between shop creations to allow us to create multiple. We can change this in tests if needed.
@@ -63,7 +65,13 @@ public abstract class BaseMockBukkitTest {
 
     @AfterEach
     void tearDownServer() {
+        // Must disable, otherwise shutdown is slow at test end
+        plugin.onDisable();
+        server.getScheduler().waitAsyncTasksFinished();
+
+        // Unmock the server to cleanup after ourselves
         MockBukkit.unmock();
+
         server = null;
         plugin = null;
     }
@@ -100,6 +108,10 @@ public abstract class BaseMockBukkitTest {
         }
         System.out.println("ticks: " + attempts + ", message: `" + nextMessage + "`");
         return nextMessage;
+    }
+
+    protected static void setRawConfig(String fieldName, String value) {
+        plugin.getConfig().set(fieldName, value);
     }
 
     protected static <T> T getPluginField(String fieldName) {

--- a/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
+++ b/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
@@ -16,6 +16,8 @@ import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 import org.mockito.internal.util.MockUtil;
 
@@ -38,8 +40,8 @@ public abstract class BaseMockBukkitTest {
     private static ServerMock server;
     private static Shop plugin;
 
-    @BeforeAll
-    static void initServer() {
+    @BeforeEach
+    void initServer() {
         server = MockBukkit.mock();
         plugin = MockBukkit.load(Shop.class);
 
@@ -47,17 +49,6 @@ public abstract class BaseMockBukkitTest {
 
         // Disable displays to avoid NMS/NBT code paths in tests
         setConfig("displayType", DisplayType.NONE);
-
-        // Inject Economy mock if Vault currency is enabled
-        if (plugin.getCurrencyType() == CurrencyType.VAULT) {
-            Economy mockedEconomy = Mockito.mock(Economy.class);
-            Mockito.when(mockedEconomy.getBalance(Mockito.any(org.bukkit.OfflinePlayer.class))).thenReturn(10_000.0);
-            Mockito.when(mockedEconomy.withdrawPlayer(Mockito.any(org.bukkit.OfflinePlayer.class), Mockito.anyDouble()))
-                    .thenAnswer(inv -> new EconomyResponse(inv.getArgument(1), 10_000.0, ResponseType.SUCCESS, "ok"));
-            Mockito.when(mockedEconomy.depositPlayer(Mockito.any(org.bukkit.OfflinePlayer.class), Mockito.anyDouble()))
-                    .thenAnswer(inv -> new EconomyResponse(inv.getArgument(1), 10_000.0, ResponseType.SUCCESS, "ok"));
-            setPluginField("econ", mockedEconomy);
-        }
 
         // Spy and stub NBTAdapter.getNBTforItem to return a static string
         NBTAdapter original = (NBTAdapter) getPluginField("nbtAdapter");
@@ -68,8 +59,8 @@ public abstract class BaseMockBukkitTest {
         }
     }
 
-    @AfterAll
-    static void tearDownServer() {
+    @AfterEach
+    void tearDownServer() {
         MockBukkit.unmock();
         server = null;
         plugin = null;
@@ -129,7 +120,19 @@ public abstract class BaseMockBukkitTest {
         }
     }
 
+    protected static void setConfig(String fieldName, Object value) {
+        setPluginField(fieldName, value);
+    }
+
     protected static void setConfig(String fieldName, boolean value) {
+        setPluginField(fieldName, value);
+    }
+
+    protected static void setConfig(String fieldName, int value) {
+        setPluginField(fieldName, value);
+    }
+
+    protected static void setConfig(String fieldName, double value) {
         setPluginField(fieldName, value);
     }
 
@@ -145,5 +148,17 @@ public abstract class BaseMockBukkitTest {
             Mockito.doReturn(face).when(spy).calculateBlockFaceForSign(Mockito.any(), Mockito.any(), Mockito.any());
             setPluginField("shopCreationUtil", spy);
         }
+    }
+    protected static void setupEconomy() {
+        // Inject Economy mock if Vault currency is enabled
+        if (plugin.getCurrencyType() == CurrencyType.VAULT) {
+            Economy mockedEconomy = Mockito.mock(Economy.class);
+            Mockito.when(mockedEconomy.getBalance(Mockito.any(org.bukkit.OfflinePlayer.class))).thenReturn(10_000.0);
+            Mockito.when(mockedEconomy.withdrawPlayer(Mockito.any(org.bukkit.OfflinePlayer.class), Mockito.anyDouble()))
+                    .thenAnswer(inv -> new EconomyResponse(inv.getArgument(1), 10_000.0, ResponseType.SUCCESS, "ok"));
+            Mockito.when(mockedEconomy.depositPlayer(Mockito.any(org.bukkit.OfflinePlayer.class), Mockito.anyDouble()))
+                    .thenAnswer(inv -> new EconomyResponse(inv.getArgument(1), 10_000.0, ResponseType.SUCCESS, "ok"));
+            setPluginField("econ", mockedEconomy);
+        } 
     }
 }

--- a/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
+++ b/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
@@ -14,8 +14,6 @@ import com.snowgears.shop.util.ShopCreationUtil;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
 import net.milkbowl.vault.economy.EconomyResponse.ResponseType;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;

--- a/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
+++ b/core/src/test/java/com/snowgears/shop/testsupport/BaseMockBukkitTest.java
@@ -1,0 +1,48 @@
+package com.snowgears.shop.testsupport;
+
+import org.mockbukkit.mockbukkit.MockBukkit;
+import org.mockbukkit.mockbukkit.ServerMock;
+import com.snowgears.shop.Shop;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * Base class for MockBukkit based tests.
+ * <p>
+ * Brings up a single {@link ServerMock} once per test-class and tears it down afterwards.
+ * Sub-classes can call {@link #getServer()} or {@link #getPlugin()}.
+ * Example usage:
+public class PluginLoadTest extends BaseMockBukkitTest {
+    @Test
+    void pluginShouldEnable() {
+        assertNotNull(getPlugin(), "Plugin should be loaded by MockBukkit");
+        assertTrue(getPlugin().isEnabled(), "Plugin should be enabled inside MockBukkit environment");
+    }
+}
+ */
+public abstract class BaseMockBukkitTest {
+
+    private static ServerMock server;
+    private static Shop plugin;
+
+    @BeforeAll
+    static void initServer() {
+        server = MockBukkit.mock();
+        plugin = MockBukkit.load(Shop.class);
+    }
+
+    @AfterAll
+    static void tearDownServer() {
+        MockBukkit.unmock();
+        server = null;
+        plugin = null;
+    }
+
+    protected ServerMock getServer() {
+        return server;
+    }
+
+    protected Shop getPlugin() {
+        return plugin;
+    }
+}

--- a/runDev.sh
+++ b/runDev.sh
@@ -28,8 +28,7 @@ EOF
 
 # Build the plugin
 export MAVEN_OPTS="-Xms8g -Xmx16g"
-mvn -B -Pcoverage -Drevision="$NEW_VERSION" clean verify -T 8C #-o
-# mvn clean compile package -T 8C #-o
+mvn -Drevision="$NEW_VERSION" clean package -T 8C #-o
 
 # Copy latest plugin in
 rm ../paper-test-1.21.8/plugins/Shop-*.jar 

--- a/runDev.sh
+++ b/runDev.sh
@@ -29,10 +29,8 @@ mvn clean compile package -T 8C #-o
 resetVersion
 
 # Copy latest plugin in
-rm ../paper-test-1.21.6/plugins/Shop-*.jar 
-# rm -r ../paper-test-1.21.4/plugins/.paper-remapped
-cp target/Shop-*.jar ../paper-test-1.21.6/plugins
+rm ../paper-test-1.21.8/plugins/Shop-*.jar 
+cp target/Shop-*.jar ../paper-test-1.21.8/plugins
 
-cd ../paper-test-1.21.6/
-# rm -r plugins/.paper-remapped
-java -Xms4G -Xmx8G -jar paper-1.21.6*.jar --nogui
+cd ../paper-test-1.21.8/
+java -Xms4G -Xmx8G -jar paper*.jar --nogui

--- a/runDev.sh
+++ b/runDev.sh
@@ -6,22 +6,8 @@ CURRENT_VERSION=$(grep -m 1 "<revision>" pom.xml | sed 's/.*<revision>\(.*\)<\/r
 # Create new version with commit hash and human readable timestamp
 TIMESTAMP=$(date +"%b-%d-%Y_%H-%M")
 NEW_VERSION="${CURRENT_VERSION}-${COMMIT_HASH}-${TIMESTAMP}-dev"
-# Move this into a function
-function updateVersion() {
-    # Update the version in pom.xml
-    sed -i '' "s|<revision>$CURRENT_VERSION</revision>|<revision>$NEW_VERSION</revision>|" pom.xml
-    echo "Updated version from $CURRENT_VERSION to $NEW_VERSION"
-}
-function resetVersion() {
-    # Reset the version in pom.xml
-    # Is this global? do we need to pass in the version?
-    sed -i '' "s|<revision>$NEW_VERSION</revision>|<revision>$CURRENT_VERSION</revision>|" pom.xml
-    echo "Reset version from $NEW_VERSION to $CURRENT_VERSION"
-}
 
 
-# Temporarily update the version to the commit hash while we build the dev version
-updateVersion
 # Ensure Maven toolchain for JDK 21 is present so tests run with MockBukkit
 mkdir -p ~/.m2
 cat > ~/.m2/toolchains.xml <<'EOF'
@@ -42,9 +28,8 @@ EOF
 
 # Build the plugin
 export MAVEN_OPTS="-Xms8g -Xmx16g"
-mvn clean compile package -T 8C #-o
-# Reset the version in pom.xml
-resetVersion
+mvn -B -Pcoverage -Drevision="$NEW_VERSION" clean verify -T 8C #-o
+# mvn clean compile package -T 8C #-o
 
 # Copy latest plugin in
 rm ../paper-test-1.21.8/plugins/Shop-*.jar 

--- a/runDev.sh
+++ b/runDev.sh
@@ -22,6 +22,24 @@ function resetVersion() {
 
 # Temporarily update the version to the commit hash while we build the dev version
 updateVersion
+# Ensure Maven toolchain for JDK 21 is present so tests run with MockBukkit
+mkdir -p ~/.m2
+cat > ~/.m2/toolchains.xml <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<toolchains>
+  <toolchain>
+    <type>jdk</type>
+    <provides>
+      <version>21</version>
+      <vendor>any</vendor>
+    </provides>
+    <configuration>
+      <jdkHome>${JAVA_HOME}</jdkHome>
+    </configuration>
+  </toolchain>
+</toolchains>
+EOF
+
 # Build the plugin
 export MAVEN_OPTS="-Xms8g -Xmx16g"
 mvn clean compile package -T 8C #-o

--- a/scripts/run-diff-cover.sh
+++ b/scripts/run-diff-cover.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run diff-cover using JaCoCo coverage against a target branch (default: origin/master)
+# - Requires jacoco.xml at core/target/site/jacoco/
+# - Auto-creates a local Python venv and installs diff-cover if not already available
+# - Generates HTML and Markdown reports to scripts/diff-cover.html/.md by default
+
+# Determine script and repo locations
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if git -C "$SCRIPT_DIR" rev-parse --show-toplevel >/dev/null 2>&1; then
+  REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+else
+  REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+cd "$REPO_ROOT"
+
+COMPARE_BRANCH="${1:-origin/master}"
+REPORT_MD="${2:-$SCRIPT_DIR/diff-cover.md}"
+REPORT_HTML="${3:-$SCRIPT_DIR/diff-cover.html}"
+
+JACOCO_DIR="$REPO_ROOT/core/target/site/jacoco"
+JACOCO_XML="$JACOCO_DIR/jacoco.xml"
+
+# Candidate source roots for mapping JaCoCo file paths (repo-relative)
+SRC_ROOTS=()
+[[ -d "core/src/main/java" ]] && SRC_ROOTS+=("core/src/main/java")
+[[ -d "core/src/main/kotlin" ]] && SRC_ROOTS+=("core/src/main/kotlin")
+[[ -d "src/main/java" ]] && SRC_ROOTS+=("src/main/java")
+[[ -d "src/main/kotlin" ]] && SRC_ROOTS+=("src/main/kotlin")
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [compare-branch] [output-md] [output-html]
+
+Defaults:
+  compare-branch: origin/master
+  output-md:      scripts/diff-cover.md
+  output-html:    scripts/diff-cover.html
+
+Examples:
+  $(basename "$0")
+  $(basename "$0") origin/master
+  $(basename "$0") master /tmp/diff-cover.md
+  $(basename "$0") master /tmp/diff-cover.md /tmp/diff-cover.html
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+# Ensure JaCoCo XML exists
+if [[ ! -f "$JACOCO_XML" ]]; then
+  # Fallback: any XML in the directory
+  if compgen -G "$JACOCO_DIR/*.xml" > /dev/null; then
+    # Pick the newest xml file
+    JACOCO_XML=$(ls -1t "$JACOCO_DIR"/*.xml | head -n 1)
+    echo "Using JaCoCo report: $JACOCO_XML"
+  else
+    echo "ERROR: JaCoCo XML not found. Expected at: $JACOCO_XML" >&2
+    echo "Hint: Build coverage first, e.g.: mvn -pl core clean test jacoco:report" >&2
+    exit 1
+  fi
+fi
+
+# Ensure compare branch is available; fetch if needed
+if ! git rev-parse --verify --quiet "$COMPARE_BRANCH" >/dev/null 2>&1; then
+  # If format is remote/branch (e.g., origin/master), fetch that ref
+  if [[ "$COMPARE_BRANCH" == */* ]]; then
+    remote="${COMPARE_BRANCH%%/*}"
+    ref="${COMPARE_BRANCH#*/}"
+    echo "Fetching $remote $ref ..."
+    git fetch "$remote" "$ref" --quiet || true
+  else
+    echo "Fetching origin $COMPARE_BRANCH ..."
+    git fetch origin "$COMPARE_BRANCH" --quiet || true
+  fi
+fi
+
+wrap_markdown_collapsed() {
+  # Wraps the markdown report in a collapsible section to keep PR comment compact
+  local tmp_file="${REPORT_MD}.tmp"
+  {
+    echo "### Diff Cover report"
+    echo
+    echo "<details>"
+    echo "<summary>Click to expand</summary>"
+    echo
+    cat "$REPORT_MD"
+    echo
+    echo "</details>"
+  } > "$tmp_file"
+  mv "$tmp_file" "$REPORT_MD"
+  echo "Wrapped markdown report in a collapsible section: $REPORT_MD"
+}
+
+run_diff_cover() {
+  local diff_cover_bin="$1"
+  local src_args=()
+  if (( ${#SRC_ROOTS[@]} > 0 )); then
+    src_args=(--src-roots "${SRC_ROOTS[@]}")
+  fi
+  echo "Running: $diff_cover_bin $JACOCO_XML --compare-branch $COMPARE_BRANCH ${src_args[*]} --html-report $REPORT_HTML --markdown-report $REPORT_MD"
+  "$diff_cover_bin" "$JACOCO_XML" \
+    --compare-branch "$COMPARE_BRANCH" \
+    ${src_args[@]:-} \
+    --html-report "$REPORT_HTML" \
+    --markdown-report "$REPORT_MD"
+  echo "Report generated: $REPORT_HTML"
+  echo "Report generated: $REPORT_MD"
+  wrap_markdown_collapsed
+}
+
+# If diff-cover is available globally, use it
+if command -v diff-cover >/dev/null 2>&1; then
+  run_diff_cover "diff-cover"
+  exit 0
+fi
+
+# Otherwise, create and use a local venv under scripts/
+VENV_DIR="$SCRIPT_DIR/.venv-diff-cover"
+PYTHON_BIN=""
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+else
+  echo "ERROR: Python not found. Please install Python 3." >&2
+  exit 2
+fi
+
+if [[ ! -d "$VENV_DIR" ]]; then
+  echo "Creating virtual environment at $VENV_DIR..."
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+fi
+
+# shellcheck source=/dev/null
+source "$VENV_DIR/bin/activate"
+python -m pip install --upgrade pip >/dev/null
+python -m pip install "diff-cover>=7.7,<9" >/dev/null
+
+run_diff_cover "diff-cover"
+
+deactivate


### PR DESCRIPTION
# Summary
This MR fixes multiple issues around shop deletion, event handling, creation flow protection, permissions/messaging, and persistence safety. It also adds comprehensive integration tests (MockBukkit) to lock in behavior and prevent regressions.

## Key changes

- **Deletion consistency and safety**
  - Remove shops internally before changing visuals to avoid ghost/half-deleted shops.
  - Wrap display cleanup in try/catch to avoid aborting deletion on non-critical failures.
  - `AbstractShop.delete(boolean forceSave)` and `ShopHandler.removeShop(shop, forceSave)` trigger durable saves when shops are deleted; callers updated.

- **Event ordering and cancellation fixes**
  - Stop cancelling `PlayerInteractEvent` broadly; allow `BlockBreakEvent` to run so legitimate chest breaks work.
  - Prevent creation on a chest that already hosts a shop.
  - In `BlockBreakEvent`, explicitly uncancel for the expansion half of double chests (allowing break) while keeping primary chest protected.

- **Creation flow safeguards**
  - Starting a new creation cancels the current one cleanly.
  - Protect chests that are in the middle of a creation process from being destroyed (clear player feedback).

- **Permissions and user messaging**
  - Clearly distinguish messages and checks for destroying your own shop vs. destroying others.
  - Honor `shop.destroy.other` alongside operator permission; show new `permission.destroyOther` dialog when denying.

- **Input hygiene**
  - Trim whitespace around numbers taken from chat/signs to avoid parsing issues.

- **Load-time hardening**
  - Shops referencing missing/invalid sign/chest are deleted during load with helpful logs instead of lingering and causing errors.

- **Safe, durable saves**
  - Build YAML in memory; write to a temp file; atomically move into place when possible.
  - Fallback path: back up original file, move new file into place, delete backup on success; attempt restore on failure.
  - Return codes from `saveShops` now signal outcomes: 1+ shops saved; 0 nothing to do; -1 file deleted (no shops); -2 save failed but original intact; -3 backup requires manual restore; -5 critical failure (plugin disabled immediately to prevent data loss).

## Implementation highlights

- Internal-first deletion order and tolerant display teardown prevent partial/ghost deletions and hard crashes.
- Creation event handler changes prevent early cancellation and avoid creating shops on existing chests.
- Chest protection during creation blocks accidental loss and informs players.
- YAML save logic is robust against interruptions or filesystem limitations; detailed logs aid diagnosis, and the system shuts down on catastrophic double-missing (target and backup) to halt cascading loss.

## Tests added (integration)

- `ShopCreationChestTest`: chest-based flow, prevention on existing chest, timeout behavior.
- `ShopCreationSignTest`: sign-based creation and initialization.
- `ShopDestroyTest`: destroy own/other with and without permissions, primary/expansion chest behavior, event cancellability, explosion protection, destroy-while-creating denial.
- `CreationDestructionCostTest`: destruction costs with item/experience currencies and returnCreationCost.
- `ShopSaveTest`: happy path, YAML content validation, atomic fallback, backup restore on failure, early failures (-2), delete-on-no-shops (-1), total data loss (-5) disables plugin.

## Affected areas

- `listener`: `MiscListener`, `ShopListener`
- `shop`: `AbstractShop`
- `display`: `AbstractDisplay`
- `handler`: `ShopHandler`
- `util`: `UtilMethods`, `ShopMessage`, `ShopCreationUtil`, `ShopLogger`
- Resources: `chatConfig.yml`

## Risks and mitigations

- Event flow changes: Verified by integration tests that legitimate breaks/creation still work and creation on existing chest is blocked.
- Save logic changes: Extensive tests cover atomic/fallback/restore paths and return codes; logs are more explicit.
- Deletion timing: Internal removal first is safer; display failures no longer block deletion.

## How to test (quick)

- Create and initialize a shop via chest and sign flows; delete via sign break as owner/op/other.
- Attempt to start a new creation while already in one (previous cancels); try to break chest mid-creation (denied with message).
- Verify expansion chest can be broken by authorized players; primary chest prompts “remove the sign first”.
- Check that shop files are written and updated; simulate save failures (see tests) if needed.

## Notes

- New save return codes are relied upon in tests; external callers should handle these values if integrating programmatically.
- Detailed logs guide operators during save failures, including guidance for NBT-related migrations across Minecraft version jumps.