### PR TITLE
Fix shop sign `[stock color]` desync on load (stuck “out of stock” red)

### DIFF
--- a/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
+++ b/core/src/main/java/com/snowgears/shop/handler/ShopHandler.java
@@ -1274,9 +1274,15 @@ public class ShopHandler {
                             continue;
                         }
 
-                        //this inits a new shop but wont calculate anything yet
+                        // This inits a new shop but won't have a chestLocation until load().
                         AbstractShop shop = AbstractShop.create(signLoc, owner, price, priceSell, amount, isAdmin, shopType, facing);
                         if (id != null) shop.setId(id);
+
+                        // Important: apply saved stock BEFORE setting item stacks, since setItemStack()
+                        // may calculate stock (inventory may be null pre-load) and may also render sign text.
+                       int stock = config.getInt("shops." + shopOwner + "." + shopNumber + ".stock");
+                        shop.setStockOnLoad(stock);
+
                         shop.setItemStack(itemStack);
                         if (shop.getType() == ShopType.BARTER) {
                             ItemStack barterItemStack = config.getItemStack("shops." + shopOwner + "." + shopNumber + ".itemBarter");
@@ -1291,8 +1297,6 @@ public class ShopHandler {
                             shop.setFakeSign(true);
                         }
 
-                        int stock = config.getInt("shops." + shopOwner + "." + shopNumber + ".stock");
-                        shop.setStockOnLoad(stock);
                         // Load the GUI Icon so that it appears when players perform a search, even if the chunks haven't loaded yet.
                         shop.refreshGuiIcon();
 

--- a/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
+++ b/core/src/main/java/com/snowgears/shop/shop/AbstractShop.java
@@ -125,6 +125,9 @@ public abstract class AbstractShop {
                 return false;
             }
             // Now that we are loaded, we can update the stock
+            // Force sign lines to refresh on load. This avoids stale sign text when the cached stock
+            // matches the newly calculated stock (updateStock() only forces sign updates on change).
+            this.signLinesRequireRefresh = true;
             this.updateStock();
             Shop.getPlugin().getLogger().debug("Loaded shop successfully: " + this);
             isLoaded = true;

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopSignStockColorDesyncOnLoadTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopSignStockColorDesyncOnLoadTest.java
@@ -1,0 +1,98 @@
+package com.snowgears.shop.integration.features;
+
+import com.snowgears.shop.shop.AbstractShop;
+import com.snowgears.shop.shop.ShopType;
+import com.snowgears.shop.testsupport.BaseMockBukkitTest;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.Sign;
+import org.bukkit.block.data.type.WallSign;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.ServerMock;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import org.mockbukkit.mockbukkit.world.WorldMock;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("integration")
+public class ShopSignStockColorDesyncOnLoadTest extends BaseMockBukkitTest {
+
+    @Test
+    void load_shouldUpdateStockColorOnSign_whenShopHasStock() {
+        ServerMock server = getServer();
+        WorldMock world = addSimpleWorldPatched("world");
+        PlayerMock owner = server.addPlayer();
+
+        // Arrange: a valid wall sign with a chest behind it
+        Location signLoc = new Location(world, 20, 65, 20);
+        Block signBlock = world.getBlockAt(signLoc);
+        signBlock.setType(Material.OAK_WALL_SIGN);
+        WallSign wallSign = (WallSign) signBlock.getBlockData();
+        wallSign.setFacing(BlockFace.NORTH);
+        world.setBlockData(signLoc, wallSign);
+
+        Location chestLoc = signBlock.getRelative(BlockFace.NORTH.getOppositeFace()).getLocation();
+        Block chestBlock = world.getBlockAt(chestLoc);
+        chestBlock.setType(Material.CHEST);
+
+        // Put enough items into the chest for a positive stock value.
+        // Use a clean division so we can set stockOnLoad to the exact computed value.
+        int shopAmount = 8;
+        int itemsInChest = 64;
+        int expectedStock = itemsInChest / shopAmount; // 8
+        assertTrue(expectedStock > 0, "Test precondition: expectedStock must be positive");
+
+        Inventory inv = ((InventoryHolder) chestBlock.getState()).getInventory();
+        inv.addItem(new ItemStack(Material.DIRT, itemsInChest));
+
+        // Create the shop without loading it (mimics loadShopsFromConfig wiring order).
+        AbstractShop shop = AbstractShop.create(
+                signLoc,
+                owner.getUniqueId(),
+                10,
+                0,
+                shopAmount,
+                false,
+                ShopType.SELL,
+                BlockFace.NORTH
+        );
+        assertNotNull(shop);
+
+        // Reproduce problematic order:
+        // 1) set item first (can render sign using default stock=0 and set signLinesRequireRefresh=false)
+        shop.setItemStack(new ItemStack(Material.DIRT));
+
+        // Let scheduled sign update run (updateSign uses a 2 tick delay)
+        server.getScheduler().performTicks(3);
+
+        Sign signState = (Sign) signLoc.getBlock().getState();
+        String line0BeforeLoad = signState.getLine(0);
+        assertTrue(line0BeforeLoad.startsWith("§4"),
+                "Precondition: sign should be rendered as out-of-stock (red) before load; was: " + line0BeforeLoad);
+
+        // 2) set stock from disk AFTER sign was rendered
+        shop.setStockOnLoad(expectedStock);
+
+        // 3) load should reconcile sign color to in-stock (green)
+        assertTrue(shop.load(), "Shop.load() should succeed with valid sign+chest");
+        assertEquals(expectedStock, shop.getStock(), "Stock should match the computed value after load()");
+
+        // Give any follow-up scheduled tasks a chance to run
+        server.getScheduler().performTicks(3);
+
+        Sign signAfterLoad = (Sign) signLoc.getBlock().getState();
+        String line0AfterLoad = signAfterLoad.getLine(0);
+
+        // Expected behavior: sign line 1 should show in-stock color (green) when stock > 0.
+        assertTrue(line0AfterLoad.startsWith("§a"),
+                "Sign should be in-stock (green) after load when stock > 0; was: " + line0AfterLoad);
+    }
+}
+
+


### PR DESCRIPTION
Users were reporting shops having stock but displaying red as out of stock (seems to just be a visual issue) as they can still buy from them

<img width="1136" height="651" alt="image1" src="https://github.com/user-attachments/assets/d4a5fc0c-3259-4f91-968a-ecb4303a25d7" />
<img width="1147" height="584" alt="image2" src="https://github.com/user-attachments/assets/bfc57703-0219-43fe-9507-ce993a2abaee" />

---
(AI Generated description)
## Problem
Some shops display the `[shop]` line in `out_of_stock` color (red) even when they have stock and transactions still succeed. Hover info correctly shows stock, but the sign’s color can remain stale after startup/load.

#### Root Cause
- Sign lines are generated from cached `stock`.
- During shop load, sign rendering could occur before `stock` was restored from disk, and later `load()` could skip refreshing the sign if `updateStock()` recomputed the same value (no “stock change” → no forced sign update, while `updateSign()` is gated by `signLinesRequireRefresh`).

#### Fix
- **Load ordering**: In `ShopHandler.loadShopsFromConfig()`, apply `setStockOnLoad(stock)` **before** `setItemStack()` / `setSecondaryItemStack()` to avoid early sign rendering with default `stock=0`.
- **Load refresh safety**: In `AbstractShop.load()`, set `signLinesRequireRefresh = true` immediately before `updateStock()` so the sign is refreshed even when `oldStock == newStock`.

#### Tests
- Added `ShopSignStockColorDesyncOnLoadTest` to reproduce the stuck-red sign scenario and verify the sign updates to in-stock color after `load()` when `stock > 0`.
- Ran `mvn -pl core test` successfully.

#### Risk / Compatibility
Changes are limited to shop load initialization and sign refresh behavior; no transaction logic changes.