### PR TITLE
(#30) Fix PlotSquared integration

### DIFF
--- a/core/src/main/java/com/snowgears/shop/hook/PlotSquaredHookListener.java
+++ b/core/src/main/java/com/snowgears/shop/hook/PlotSquaredHookListener.java
@@ -2,15 +2,20 @@ package com.snowgears.shop.hook;
 
 import com.snowgears.shop.Shop;
 import com.snowgears.shop.shop.AbstractShop;
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
 import org.bukkit.event.Listener;
+import org.jetbrains.annotations.Nullable;
 
 import com.plotsquared.core.PlotAPI;
-import com.plotsquared.core.events.post.PostPlotDeleteEvent;
-import com.plotsquared.core.events.post.PostPlotClearEvent;
+import com.plotsquared.core.events.PlotClearEvent;
+import com.plotsquared.core.events.PlotDeleteEvent;
 import com.plotsquared.core.plot.Plot;
-import com.plotsquared.core.location.Location;
+import com.plotsquared.core.plot.PlotArea;
+import org.bukkit.Location;
 
 import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 import com.google.common.eventbus.Subscribe;
 
@@ -26,36 +31,39 @@ public class PlotSquaredHookListener implements Listener {
     }
 
     @Subscribe
-    public void onPlotDelete(PostPlotDeleteEvent e) {
+    public void onPlotDelete(PlotDeleteEvent e) {
         deleteAllShopsInPlot(e.getPlot());
     }
     
     @Subscribe
-    public void onPlotClear(PostPlotClearEvent e) {
+    public void onPlotClear(PlotClearEvent e) {
         deleteAllShopsInPlot(e.getPlot());
     }
 
-    private void deleteAllShopsInPlot(Plot plot){
+    private void deleteAllShopsInPlot(@Nullable Plot plot){
+        if (plot == null) {
+            return;
+        }
+
         HashSet<UUID> shopOwnersToSave = new HashSet<>();
         int shopsDeleted = 0;
         for(UUID shopOwnerUUID : plugin.getShopHandler().getShopOwnerUUIDs()){
             for(AbstractShop shop : plugin.getShopHandler().getShops(shopOwnerUUID)) {
-                if (shop != null && shop.getSignLocation() != null && shop.getSignLocation().getWorld().getName().equals(plot.getArea().getWorldName())) {
-                    if (shop.getChestLocation() != null) {
-                        Location location = Location.at(
-                            shop.getChestLocation().getWorld().getName(), 
-                            shop.getChestLocation().getBlockX(), 
-                            shop.getChestLocation().getBlockY(), 
-                            shop.getChestLocation().getBlockZ()
-                        );
-                        if (plot.getArea().contains(location)) {
-                            plugin.getLogger().notice("Deleting Shop because PlotSquared Plot is being reset! " + shop);
-                            shop.delete(false); // delay the save and do it below
-                            shopOwnersToSave.add(shopOwnerUUID);
-                            shopsDeleted++;
-                        }
-                    }
+                if (shop == null) {
+                    continue;
                 }
+                final Location signLocation = shop.getSignLocation();
+                if (signLocation == null) {
+                    continue;
+                }
+                if (!isShopSignInsidePlot(plot, signLocation)) {
+                    continue;
+                }
+
+                plugin.getLogger().notice("Deleting Shop because PlotSquared Plot is being reset! " + shop);
+                shop.delete(false); // delay the save and do it below
+                shopOwnersToSave.add(shopOwnerUUID);
+                shopsDeleted++;
             }
         }
 
@@ -67,5 +75,45 @@ public class PlotSquaredHookListener implements Listener {
         if (shopsDeleted > 0) {
             plugin.getLogger().notice("(PlotSquared Hook) Deleted " + shopsDeleted + " Shops inside Plot `" + plot.getId() + "` during plot reset");
         }
+    }
+
+    static boolean isShopSignInsidePlot(@Nullable Plot plot, @Nullable Location signLocation) {
+        if (plot == null) {
+            return false;
+        }
+
+        final PlotArea area = plot.getArea();
+        final String plotWorldName = area == null ? null : area.getWorldName();
+        return isShopSignInsidePlotRegions(plotWorldName, plot.getRegions(), signLocation);
+    }
+
+    static boolean isShopSignInsidePlotRegions(
+        @Nullable String plotWorldName,
+        @Nullable Set<CuboidRegion> regions,
+        @Nullable Location signLocation
+    ) {
+        if (plotWorldName == null || signLocation == null || signLocation.getWorld() == null) {
+            return false;
+        }
+        if (!signLocation.getWorld().getName().equals(plotWorldName)) {
+            return false;
+        }
+        if (regions == null || regions.isEmpty()) {
+            return false;
+        }
+
+        final BlockVector3 vec = BlockVector3.at(
+            signLocation.getBlockX(),
+            signLocation.getBlockY(),
+            signLocation.getBlockZ()
+        );
+
+        for (CuboidRegion region : regions) {
+            if (region != null && region.contains(vec)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/core/src/test/java/com/snowgears/shop/hook/PlotSquaredHookListenerTest.java
+++ b/core/src/test/java/com/snowgears/shop/hook/PlotSquaredHookListenerTest.java
@@ -1,0 +1,61 @@
+package com.snowgears.shop.hook;
+
+import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.regions.CuboidRegion;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PlotSquaredHookListenerTest {
+
+    @Test
+    void isShopSignInsidePlot_trueWhenSignIsInRegionAndWorldMatches() {
+        CuboidRegion region = new CuboidRegion(
+            BlockVector3.at(0, 0, 0),
+            BlockVector3.at(10, 255, 10)
+        );
+
+        World world = mock(World.class);
+        when(world.getName()).thenReturn("plotworld");
+        Location signLocation = new Location(world, 5, 64, 5);
+
+        assertTrue(PlotSquaredHookListener.isShopSignInsidePlotRegions("plotworld", Set.of(region), signLocation));
+    }
+
+    @Test
+    void isShopSignInsidePlot_falseWhenWorldDoesNotMatch() {
+        CuboidRegion region = new CuboidRegion(
+            BlockVector3.at(0, 0, 0),
+            BlockVector3.at(10, 255, 10)
+        );
+
+        World otherWorld = mock(World.class);
+        when(otherWorld.getName()).thenReturn("otherworld");
+        Location signLocation = new Location(otherWorld, 5, 64, 5);
+
+        assertFalse(PlotSquaredHookListener.isShopSignInsidePlotRegions("plotworld", Set.of(region), signLocation));
+    }
+
+    @Test
+    void isShopSignInsidePlot_falseWhenOutsideAllRegions() {
+        CuboidRegion region = new CuboidRegion(
+            BlockVector3.at(0, 0, 0),
+            BlockVector3.at(10, 255, 10)
+        );
+
+        World world = mock(World.class);
+        when(world.getName()).thenReturn("plotworld");
+        Location signLocation = new Location(world, 100, 64, 100);
+
+        assertFalse(PlotSquaredHookListener.isShopSignInsidePlotRegions("plotworld", Set.of(region), signLocation));
+    }
+}
+
+


### PR DESCRIPTION
Multiple users have been reporting mass PlotSquared deletions, and I finally got some time to look into it. Turns out I was utilizing the API wrong. This should fix it though!

---
(AI Generated Summary)
### Description
This change fixes issue #30 where `/plot delete` (and plot clear/reset) could delete shops far beyond the deleted plot.

#### Root cause
The PlotSquared hook was using plot **area** containment (`plot.getArea().contains(...)`), which can match essentially the whole plot world/area, causing mass shop deletion.

#### What changed
- Switched PlotSquared listeners from post events to pre events:
  - `PostPlotDeleteEvent` → `PlotDeleteEvent`
  - `PostPlotClearEvent` → `PlotClearEvent`
- Replaced plot-area containment with plot **region** containment via `plot.getRegions()`.
- Containment is now based on the **shop sign location** (not the chest), as intended.

#### Tests
- Added `PlotSquaredHookListenerTest` to validate region-based containment behavior.
- `mvn -pl core test` passes.

#### Manual verification
On a server with PlotSquared:
- Place shops on two different plots in the same plot world.
- Run `/plot clear` and `/plot delete` on one plot.
- Verify only shops whose sign is inside that plot are deleted; other plots’ shops remain.