### PR TITLE
Allow shop create cancel by breaking chest twice

### DIFF
--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -309,6 +309,7 @@ public class MiscListener implements Listener {
                             ShopCreationProcess process = new ShopCreationProcess(player, clicked, signFacing);
                             playerChatCreationSteps.put(player.getUniqueId(), process);
                             lastChatCreation.put(player.getUniqueId(), new Date().getTime());
+                            process.markInteracted();
                             plugin.getCreativeSelectionListener().putPlayerInCreativeSelection(player, clicked.getLocation(), false);
                         }
                     }
@@ -322,6 +323,7 @@ public class MiscListener implements Listener {
                             return;
                         }
                         currentProcess.setBarterItemStack(event.getItem());
+                        currentProcess.markInteracted();
                         currentProcess.displayFloatingText(currentProcess.getShopType().toString(), "createHitChestBarterAmount");
                         return;
                     }
@@ -354,6 +356,7 @@ public class MiscListener implements Listener {
                 process.setItemStack(event.getItem());
                 playerChatCreationSteps.put(player.getUniqueId(), process);
                 lastChatCreation.put(player.getUniqueId(), new Date().getTime());
+                process.markInteracted();
 
                 //send player text prompts after they have clicked the chest with the item they want to create a shop with
                 ShopMessage.sendMessage("initialCreateInstruction", null, process, player);
@@ -639,13 +642,18 @@ public class MiscListener implements Listener {
                 // The owner of a chest/chat creation can cancel it by breaking the chest a second time.
                 // Sign-based creation stays protected (a real shop and sign already exist on the chest).
                 if (process.getPlayerUUID().equals(player.getUniqueId()) && !process.isSignCreation()) {
-                    if (process.isDestroyArmed()) {
-                        // second deliberate attempt: cancel creation and let the chest break in the same hit
-                        this.cancelShopCreationProcess(player);
-                        return;
+                    // Ignore breaks that are part of the natural creation flow: while the player is still
+                    // selecting an item, or when the break coincides with the click that started/advanced
+                    // creation (in creative mode a single click both interacts and breaks the block).
+                    if (!process.isAwaitingItemSelection() && !process.wasJustInteracted()) {
+                        if (process.isDestroyArmed()) {
+                            // second deliberate attempt: cancel creation and let the chest break in the same hit
+                            this.cancelShopCreationProcess(player);
+                            return;
+                        }
+                        process.setDestroyArmed(true);
+                        ShopMessage.sendMessage("interactionIssue", "destroyUninitializedChestCancel", player, null);
                     }
-                    process.setDestroyArmed(true);
-                    ShopMessage.sendMessage("interactionIssue", "destroyUninitializedChestCancel", player, null);
                 } else {
                     ShopMessage.sendMessage("interactionIssue", "destroyUninitializedChest", player, null);
                 }

--- a/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
+++ b/core/src/main/java/com/snowgears/shop/listener/MiscListener.java
@@ -202,12 +202,16 @@ public class MiscListener implements Listener {
     }
 
     public boolean isChestInShopCreationProcess(Location location) {
+        return getShopCreationProcessByChest(location) != null;
+    }
+
+    public ShopCreationProcess getShopCreationProcessByChest(Location location) {
         for (ShopCreationProcess process : playerChatCreationSteps.values()) {
             if (process.getClickedChest().getLocation().equals(location)) {
-                return true;
+                return process;
             }
         }
-        return false;
+        return null;
     }
 
     // Fired anytime a player interacts with a block, air, or entity.
@@ -630,8 +634,21 @@ public class MiscListener implements Listener {
         } else if (plugin.getShopHandler().isChest(b)) {
             // Shop will not exist in ShopHandler if it is in the middle of a shop creation process
             // protect shops that are in the middle of a shop creation process from being destroyed
-            if (this.isChestInShopCreationProcess(b.getLocation())) {
-                ShopMessage.sendMessage("interactionIssue", "destroyUninitializedChest", player, null);
+            ShopCreationProcess process = this.getShopCreationProcessByChest(b.getLocation());
+            if (process != null) {
+                // The owner of a chest/chat creation can cancel it by breaking the chest a second time.
+                // Sign-based creation stays protected (a real shop and sign already exist on the chest).
+                if (process.getPlayerUUID().equals(player.getUniqueId()) && !process.isSignCreation()) {
+                    if (process.isDestroyArmed()) {
+                        // second deliberate attempt: cancel creation and let the chest break in the same hit
+                        this.cancelShopCreationProcess(player);
+                        return;
+                    }
+                    process.setDestroyArmed(true);
+                    ShopMessage.sendMessage("interactionIssue", "destroyUninitializedChestCancel", player, null);
+                } else {
+                    ShopMessage.sendMessage("interactionIssue", "destroyUninitializedChest", player, null);
+                }
                 event.setCancelled(true); // don't break chest
                 return;
             }

--- a/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
@@ -35,6 +35,7 @@ public class ShopCreationProcess {
     boolean isAdmin;
     private PricePair pricePair;
     private boolean destroyArmed;
+    private volatile boolean justInteracted;
 
     public AbstractDisplay display;
     private PlaceholderContext placeholderContext;
@@ -127,6 +128,22 @@ public class ShopCreationProcess {
 
     public boolean isDestroyArmed() { return destroyArmed; }
     public void setDestroyArmed(boolean destroyArmed) { this.destroyArmed = destroyArmed; }
+
+    // True while the player is selecting an item to trade. Hitting the chest during these steps is part of
+    // the natural creation flow, not an attempt to destroy the chest, so it must never arm the cancel.
+    public boolean isAwaitingItemSelection() {
+        return step == ChatCreationStep.ITEM || step == ChatCreationStep.BARTER_ITEM;
+    }
+
+    // Marks that the player just clicked the chest to start or advance creation. In creative mode a single
+    // click both interacts and instantly breaks the block, so the coincident BlockBreakEvent (same tick) must
+    // not be treated as a destroy attempt. The flag clears on the next tick, leaving later breaks to act normally.
+    public void markInteracted() {
+        this.justInteracted = true;
+        Shop.getPlugin().getFoliaLib().getScheduler().runLater(() -> this.justInteracted = false, 1L);
+    }
+
+    public boolean wasJustInteracted() { return justInteracted; }
 
     // True for sign-based creation, where a real (uninitialized) shop and sign already exist on the chest.
     public boolean isSignCreation() {

--- a/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopCreationProcess.java
@@ -34,6 +34,7 @@ public class ShopCreationProcess {
     private ShopType shopType;
     boolean isAdmin;
     private PricePair pricePair;
+    private boolean destroyArmed;
 
     public AbstractDisplay display;
     private PlaceholderContext placeholderContext;
@@ -123,6 +124,16 @@ public class ShopCreationProcess {
 
     public ChatCreationStep getStep() { return step; }
     public void setStep(ChatCreationStep step) { this.step = step; }
+
+    public boolean isDestroyArmed() { return destroyArmed; }
+    public void setDestroyArmed(boolean destroyArmed) { this.destroyArmed = destroyArmed; }
+
+    // True for sign-based creation, where a real (uninitialized) shop and sign already exist on the chest.
+    public boolean isSignCreation() {
+        return step == ChatCreationStep.SIGN_CREATION
+                || step == ChatCreationStep.SIGN_ITEM
+                || step == ChatCreationStep.SIGN_BARTER_ITEM;
+    }
 
     public void setPricePair(PricePair pricePair){
         this.pricePair = pricePair;

--- a/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
+++ b/core/src/main/java/com/snowgears/shop/util/ShopMessage.java
@@ -966,6 +966,7 @@ public class ShopMessage {
         messageMap.put("interactionIssue_initialize", chatConfig.getString("interaction_issue.initializeOtherShop"));
         messageMap.put("interactionIssue_destroyChest", chatConfig.getString("interaction_issue.destroyChest"));
         messageMap.put("interactionIssue_destroyUninitializedChest", chatConfig.getString("interaction_issue.destroyUninitializedChest"));
+        messageMap.put("interactionIssue_destroyUninitializedChestCancel", chatConfig.getString("interaction_issue.destroyUninitializedChestCancel"));
         messageMap.put("interactionIssue_useOwnShop", chatConfig.getString("interaction_issue.useOwnShop"));
         messageMap.put("interactionIssue_useShopAlreadyInUse", chatConfig.getString("interaction_issue.useShopAlreadyInUse"));
         messageMap.put("interactionIssue_adminOpen", chatConfig.getString("interaction_issue.adminOpen"));

--- a/core/src/main/resources/chatConfig.yml
+++ b/core/src/main/resources/chatConfig.yml
@@ -193,6 +193,7 @@ interaction_issue:
    useShopAlreadyInUse: "&cThis shop is in the middle of a transaction."
    destroyChest: "&cYou must remove the sign from this shop to break it."
    destroyUninitializedChest: "&cThis chest cannot be destroyed while a shop is being created for it."
+   destroyUninitializedChestCancel: "&cA shop is being created for this chest. &7Break it again to cancel."
    useOwnShop: "&7You cannot use your own shop."
    adminOpen: "&7Admin shops are not able to be opened."
    worldBlacklist: "&cShops are not allowed to be created in this world."

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopDestroyTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopDestroyTest.java
@@ -355,18 +355,91 @@ public class ShopDestroyTest extends BaseMockBukkitTest {
         sendChatMessage(player, "sell");
         while (player.nextMessage() != null) {}
 
-        // Attempt to break the chest while creation is in progress
+        // The owner's first attempt warns them they can break again to cancel
         new PlayerSimulation(player).simulateBlockBreak(chestBlock);
-        assertEquals("§cThis chest cannot be destroyed while a shop is being created for it.", waitForNextMessage(player),
-                "Player should be warned chest cannot be destroyed during shop creation");
+        assertEquals("§cA shop is being created for this chest. §7Break it again to cancel.", waitForNextMessage(player),
+                "Owner should be warned chest cannot be destroyed and told they can break again to cancel");
         assertEquals(Material.CHEST, chestBlock.getType(), "Chest should not break during creation process");
     
-        // Attempt to break the chest while creation is in progress
+        // A different player attempting to break the chest always gets the original warning
         PlayerMock other = server.addPlayer();
         new PlayerSimulation(other).simulateBlockBreak(chestBlock);
         assertEquals("§cThis chest cannot be destroyed while a shop is being created for it.", waitForNextMessage(other),
                 "Player should be warned chest cannot be destroyed during shop creation");
         assertEquals(Material.CHEST, chestBlock.getType(), "Chest should not break during creation process");
+    }
+
+    @Test
+    void ownerSecondBreak_cancels_creation_and_breaks_chest() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        Block chestBlock = startSellChestCreation(server, world, player, new Location(world, 42, 65, 10));
+
+        // First attempt: warn the owner and arm the cancel; chest stays intact
+        new PlayerSimulation(player).simulateBlockBreak(chestBlock);
+        assertEquals("§cA shop is being created for this chest. §7Break it again to cancel.", waitForNextMessage(player),
+                "Owner should be told they can break again to cancel");
+        assertEquals(Material.CHEST, chestBlock.getType(), "Chest should not break on the first attempt");
+        assertNotNull(getPlugin().getMiscListener().getShopCreationProcess(player),
+                "Creation process should still be active after the first break");
+
+        // Second attempt by the owner: cancel the creation and break the chest in the same hit
+        new PlayerSimulation(player).simulateBlockBreak(chestBlock);
+        assertEquals("§cCancelled shop creation.", waitForNextMessage(player),
+                "Owner should be told the shop creation was cancelled");
+        assertEquals(Material.AIR, chestBlock.getType(), "Chest should break on the second attempt");
+        assertNull(getPlugin().getMiscListener().getShopCreationProcess(player),
+                "Creation process should be removed after cancel");
+        assertNull(getPlugin().getShopHandler().getShopByChest(chestBlock),
+                "No shop should be registered for the cancelled chest");
+    }
+
+    @Test
+    void nonOwner_cannot_cancel_creation_by_breaking() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        Block chestBlock = startSellChestCreation(server, world, player, new Location(world, 44, 65, 10));
+
+        PlayerMock other = server.addPlayer();
+
+        // A non-owner breaking repeatedly never arms or cancels the owner's creation
+        for (int i = 0; i < 2; i++) {
+            new PlayerSimulation(other).simulateBlockBreak(chestBlock);
+            assertEquals("§cThis chest cannot be destroyed while a shop is being created for it.", waitForNextMessage(other),
+                    "Non-owner should always get the original warning");
+            assertEquals(Material.CHEST, chestBlock.getType(), "Chest should never break for a non-owner during creation");
+        }
+        assertNotNull(getPlugin().getMiscListener().getShopCreationProcess(player),
+                "Owner's creation process should remain active");
+    }
+
+    private Block startSellChestCreation(ServerMock server, World world, PlayerMock player, Location chestLoc) {
+        player.setOp(true);
+
+        Block chestBlock = world.getBlockAt(chestLoc);
+        chestBlock.setType(Material.CHEST);
+        world.getBlockAt(chestLoc.clone().add(0, 0, -1)).setType(Material.AIR);
+
+        // Start creation by sneaking and left-clicking the chest with an item in hand, then pick a shop type
+        stubCalculateBlockFaceForSign(BlockFace.NORTH);
+        player.setSneaking(true);
+        ItemStack item = new ItemStack(Material.DIRT);
+        player.getInventory().setItemInMainHand(item);
+        PlayerInteractEvent startCreate = new PlayerInteractEvent(
+                player,
+                Action.LEFT_CLICK_BLOCK,
+                item,
+                chestBlock,
+                BlockFace.NORTH,
+                EquipmentSlot.HAND
+        );
+        server.getPluginManager().callEvent(startCreate);
+        server.getScheduler().performTicks(2);
+        sendChatMessage(player, "sell");
+        while (player.nextMessage() != null) {}
+        return chestBlock;
     }
 }
 

--- a/core/src/test/java/com/snowgears/shop/integration/features/ShopDestroyTest.java
+++ b/core/src/test/java/com/snowgears/shop/integration/features/ShopDestroyTest.java
@@ -3,6 +3,7 @@ package com.snowgears.shop.integration.features;
 import com.snowgears.shop.shop.AbstractShop;
 import com.snowgears.shop.testsupport.BaseMockBukkitTest;
 import com.snowgears.shop.event.PlayerDestroyShopEvent;
+import com.snowgears.shop.util.ShopCreationProcess;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -413,6 +414,78 @@ public class ShopDestroyTest extends BaseMockBukkitTest {
         }
         assertNotNull(getPlugin().getMiscListener().getShopCreationProcess(player),
                 "Owner's creation process should remain active");
+    }
+
+    @Test
+    void coincidentStartBreak_doesNotWarnOrArm() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+        setConfig("allowCreateMethodChest", true);
+
+        Location chestLoc = new Location(world, 46, 65, 10);
+        Block chestBlock = world.getBlockAt(chestLoc);
+        chestBlock.setType(Material.CHEST);
+        world.getBlockAt(chestLoc.clone().add(0, 0, -1)).setType(Material.AIR);
+        stubCalculateBlockFaceForSign(BlockFace.NORTH);
+
+        // In creative a single click both starts creation (interact) and instantly breaks the block in the
+        // same tick. Simulate that by firing the break before any tick clears the just-interacted flag.
+        player.setSneaking(true);
+        ItemStack item = new ItemStack(Material.DIRT);
+        player.getInventory().setItemInMainHand(item);
+        server.getPluginManager().callEvent(new PlayerInteractEvent(
+                player, Action.LEFT_CLICK_BLOCK, item, chestBlock, BlockFace.NORTH, EquipmentSlot.HAND));
+        while (player.nextMessage() != null) {} // drain creation prompts without ticking
+
+        new PlayerSimulation(player).simulateBlockBreak(chestBlock);
+
+        assertNull(player.nextMessage(), "Coincident start break should not warn about cancelling");
+        assertEquals(Material.CHEST, chestBlock.getType(), "Chest must not break on the creation-start click");
+        ShopCreationProcess process = getPlugin().getMiscListener().getShopCreationProcess(player);
+        assertNotNull(process, "Creation process should still be active after the start click");
+        assertFalse(process.isDestroyArmed(), "Coincident start break must not arm the cancel");
+    }
+
+    @Test
+    void coincidentBarterSelectionBreak_doesNotCancelCreation() {
+        ServerMock server = getServer();
+        World world = server.addSimpleWorld("world");
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+        setConfig("allowCreateMethodChest", true);
+
+        Location chestLoc = new Location(world, 48, 65, 10);
+        Block chestBlock = world.getBlockAt(chestLoc);
+        chestBlock.setType(Material.CHEST);
+        world.getBlockAt(chestLoc.clone().add(0, 0, -1)).setType(Material.AIR);
+        stubCalculateBlockFaceForSign(BlockFace.NORTH);
+
+        // Start a barter creation and advance to the barter-item selection step
+        player.setSneaking(true);
+        ItemStack sellItem = new ItemStack(Material.DIRT);
+        player.getInventory().setItemInMainHand(sellItem);
+        server.getPluginManager().callEvent(new PlayerInteractEvent(
+                player, Action.LEFT_CLICK_BLOCK, sellItem, chestBlock, BlockFace.NORTH, EquipmentSlot.HAND));
+        server.getScheduler().performTicks(2);
+        sendChatMessage(player, "barter");
+        sendChatMessage(player, "1");
+        while (player.nextMessage() != null) {}
+
+        // The barter-item selection click: interact selects the barter item, and in creative the same click
+        // instantly breaks the block in the same tick. The coincident break must not cancel the creation.
+        ItemStack barterItem = new ItemStack(Material.DIAMOND);
+        player.getInventory().setItemInMainHand(barterItem);
+        server.getPluginManager().callEvent(new PlayerInteractEvent(
+                player, Action.LEFT_CLICK_BLOCK, barterItem, chestBlock, BlockFace.NORTH, EquipmentSlot.HAND));
+        new PlayerSimulation(player).simulateBlockBreak(chestBlock);
+
+        ShopCreationProcess process = getPlugin().getMiscListener().getShopCreationProcess(player);
+        assertNotNull(process, "Barter creation must not be cancelled by the selection click's coincident break");
+        assertNotNull(process.getBarterItemStack(), "Barter item should have been selected");
+        assertFalse(process.isDestroyArmed(), "Barter selection must not arm the cancel");
+        assertEquals(Material.CHEST, chestBlock.getType(), "Chest must not break during barter selection");
     }
 
     private Block startSellChestCreation(ServerMock server, World world, PlayerMock player, Location chestLoc) {

--- a/runDev.sh
+++ b/runDev.sh
@@ -15,8 +15,8 @@ export MAVEN_OPTS="-Xms8g -Xmx16g"
 mvn -Drevision="$NEW_VERSION" clean package -T 8C #-o
 
 # Copy latest plugin in
-rm ../paper-test-1.21.8/plugins/Shop-*.jar 
-cp target/Shop-*.jar ../paper-test-1.21.8/plugins
+rm ../paper-test-26.1.2/plugins/Shop-*.jar 
+cp target/Shop-*.jar ../paper-test-26.1.2/plugins
 
-cd ../paper-test-1.21.8/
+cd ../paper-test-26.1.2/
 java -Xms4G -Xmx8G -jar paper*.jar --nogui

--- a/wiki/player-instructions.md
+++ b/wiki/player-instructions.md
@@ -19,6 +19,8 @@ More details: **[Trust Players](https://github.com/snowgears/shop/wiki/Trust-Pla
 3. Enter the amount of the item you want to buy/sell
 4. Enter the price you want to buy/sell the item for
 
+> **Started a shop by accident?** While a chest-based creation is in progress the chest is protected from being broken. If you actually wanted to remove the chest (for example while tearing down a storage room), just **break the chest again** after the warning to cancel the creation; the chest will break on that second hit.
+
 **`config.yml` Defaults:**
 
 ```yaml


### PR DESCRIPTION
Allow canceling creation of a new shop by breaking the chest twice in a row by an owner. This allows easier destruction of chest walls when the player might be pressing shift. A small nit, but might be nice for people nonetheless.